### PR TITLE
Building of Java project with no dependencies

### DIFF
--- a/cli/langs/java.go
+++ b/cli/langs/java.go
@@ -80,7 +80,7 @@ func (lh *JavaLangHelper) DockerfileBuildCmds() []string {
 		fmt.Sprintf("ENV MAVEN_OPTS %s", mavenOpts()),
 		"ADD pom.xml /function/pom.xml",
 		"RUN [\"mvn\", \"package\", \"dependency:copy-dependencies\", \"-DincludeScope=runtime\", " +
-			"\"-DskipTests=true\", \"-Dmdep.prependGroupId=true\", \"-DoutputDirectory=target\"]",
+			"\"-DskipTests=true\", \"-Dmdep.prependGroupId=true\", \"-DoutputDirectory=target\", \"--fail-never\"]",
 		"ADD src /function/src",
 		"RUN [\"mvn\", \"package\"]",
 	}


### PR DESCRIPTION
Currently there is no way to perform a Docker `COPY` where the source
directory has no files, i.e. no way to ignore the error. So this change
puts all the dependencies into the `/function/target` directory whereas
they were in the `/function/target/dependency` directory before. This has
the benefit of knowing that the COPY command will always succeed even if
there are no dependencies as atleast the function jar itself will be in
`/function/target` directory.

Also a small addition of adding `--fail-never` to the maven step that pulls
all the dependencies. This is important as if the pom.xml has a compilation step, 
for example, generate some source for me from my proto files in my 
`src/main/resource` directory, this would fail as we have not copied the 
source directory in yet.

Fixes [jfaas/111](https://gitlab-odx.oracle.com/odx/jfaas/issues/111)