### PR TITLE
WIP: Add --pull to build cmd

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -124,6 +124,7 @@ func dockerbuild(verbwriter io.Writer, path string, ff *funcfile, noCache bool) 
 			args = append(args, "--no-cache")
 		}
 		args = append(args,
+			"--pull",
 			"--build-arg", "HTTP_PROXY",
 			"--build-arg", "HTTPS_PROXY",
 			".")


### PR DESCRIPTION
Currently in the fn CLI, the build and run Docker images reference `latest`. In jfaas, we're now embedding the runtime into the run image (a bit like the lambda support's bootstrap.js). In order for jfaas to release independently, it would be good if Docker checked if a particular image has an update at build-time. The Docker build command supports a `--pull` flag which will check for newer version of images. 

The reason this is WIP is this issue: https://github.com/docker/for-mac/issues/1751. There's currently a bug which is fixed in 17.06.1 which causes `--pull` to fail when used in conjunction with multi-stage build.

This change assumes we're going to release the fn cli with images referencing `:latest`...