### PR TITLE
add traces to the lb

### DIFF
--- a/fnlb/main.go
+++ b/fnlb/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.StringVar(&conf.HealthcheckEndpoint, "hc-path", "/version", "endpoint to determine node health")
 	flag.IntVar(&conf.HealthcheckUnhealthy, "hc-unhealthy", 2, "threshold of failed checks to declare node unhealthy")
 	flag.IntVar(&conf.HealthcheckTimeout, "hc-timeout", 5, "timeout of healthcheck endpoint, in seconds")
-
+	flag.StringVar(&conf.ZipkinURL, "zipkin", "", "zipkin endpoint to send traces")
 	flag.Parse()
 
 	conf.MinAPIVersion = semver.New(*minAPIVersion)


### PR DESCRIPTION
also fixed the broken version checking stuff so this works again

these cross boundaries, which is pretty sweet. so now spans look like this if the lb gets involved (on lhs you can see 2 different services): 

<img width="1208" alt="screen shot 2017-08-02 at 1 50 32 pm" src="https://user-images.githubusercontent.com/2935111/28894476-d4522614-7789-11e7-8d85-b41e33e8e0ff.png">

want to shove these down into hot functions too, would be cool, but not related to lb patches.