### PR TITLE
update bump script to be slightly less brittle, all perl syntax

### DIFF
--- a/cli/release.sh
+++ b/cli/release.sh
@@ -15,12 +15,12 @@ fi
 git pull
 
 version_file="version.go"
-if [ -z $(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file) ]; then
+if [ -z $(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file) ]; then
   echo "did not find semantic version in $version_file"
   exit 1
 fi
-perl -i -pe 's/\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
-version=$(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file)
+perl -i -pe 's/(?<= = ")\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
+version=$(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file)
 echo "Version: $version"
 
 #cd lambda

--- a/fnlb/release.sh
+++ b/fnlb/release.sh
@@ -18,12 +18,12 @@ fi
 git pull
 
 version_file="main.go"
-if [ -z $(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file) ]; then
+if [ -z $(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file) ]; then
   echo "did not find semantic version in $version_file"
   exit 1
 fi
-perl -i -pe 's/\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
-version=$(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file)
+perl -i -pe 's/(?<= = ")\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
+version=$(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file)
 echo "Version: $version"
 
 make docker-build

--- a/release.sh
+++ b/release.sh
@@ -18,12 +18,12 @@ fi
 git pull
 
 version_file="api/version/version.go"
-if [ -z $(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file) ]; then
+if [ -z $(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file) ]; then
   echo "did not find semantic version in $version_file"
   exit 1
 fi
-perl -i -pe 's/\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
-version=$(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file)
+perl -i -pe 's/(?<= = ")\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
+version=$(grep -m1 -Po '(?<= = ")\d+\.\d+\.\d+' $version_file)
 echo "Version: $version"
 
 make docker-build


### PR DESCRIPTION
https://github.com/fnproject/fn/commit/0322d2623e9494c75d1d8886a334016025e4d15d was happening. and we don't want that to happen. this fixes that. (yes, i realize we could probably put this in a script somewhere we could reference. no, i'd rather not get into that right now, just trying to quick fix this and get on with my life please)