### PR TITLE
Update swagger

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -435,7 +435,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /apps/{app}/calls/:
+  /apps/{app}/calls:
     get:
       summary: Get app-bound calls.
       description: Get app-bound calls can filter to route-bound calls.


### PR DESCRIPTION
 removing backslash that causes HTTP 301 Redirect

[GIN-debug] redirecting request 301: /v1/apps/testapp/calls/ --> /v1/apps/testapp/calls