### PR TITLE
Set FN_FORMAT correctly in `fn run`

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -108,7 +108,7 @@ func runff(ff *funcfile, stdin io.Reader, stdout, stderr io.Writer, method strin
 	runEnv = append(runEnv, kvEq("REQUEST_URL", LocalTestURL))
 	runEnv = append(runEnv, kvEq("APP_NAME", "myapp"))
 	runEnv = append(runEnv, kvEq("ROUTE", "/hello")) // TODO: should we change this to PATH ?
-	runEnv = append(runEnv, kvEq("FORMAT", format))
+	runEnv = append(runEnv, kvEq("FN_FORMAT", format))
 
 	// add user defined envs
 	runEnv = append(runEnv, envVars...)


### PR DESCRIPTION
Looks like was changed from `FORMAT` to `FN_FORMAT` in [9ccd48e](https://github.com/fnproject/fn/commit/9ccd48eb18fe40ba5e47aef6d210ee15c38e40e2) for server side functions.

Also, I can't seem to find this anywhere, but is there an explicit contract that states that `FN_FORMAT` will always be set even if it is `default`? Or is the expectation that `default` should be assumed if `FN_FORMAT` is not set?