### PR TITLE
Set runtime to 'java' to have the pom.xml created

### DIFF
--- a/examples/tutorial/hello/java/README.md
+++ b/examples/tutorial/hello/java/README.md
@@ -5,7 +5,7 @@ This example will show you how to test and deploy Java code to Oracle Functions.
 
 ```sh
 # Initialize your function creating a func.yaml file
-fn init <DOCKERHUB_USERNAME>/hello-java
+fn init <DOCKERHUB_USERNAME>/hello-java --runtime java
 
 # Test your function. This will run inside a container exactly how it will on the server
 fn run


### PR DESCRIPTION
When the runtime is ['assumed' to java](https://github.com/fnproject/fn/blob/11b5c4ce673e1524731f064de6ec6300d5b2c49a/cli/init.go#L182-L188) (i.e. not explicitly set), the [pom.xml isn't created](https://github.com/fnproject/fn/blob/85ae711447b593b4c5be1247d2090b058fc64011/cli/langs/java.go#L38-L45) and hence [init fail](https://github.com/fnproject/fn/blob/85ae711447b593b4c5be1247d2090b058fc64011/cli/langs/java.go#L99-L101).