### PR TITLE
Fixed tagging issue

### DIFF
--- a/fnlb/release.sh
+++ b/fnlb/release.sh
@@ -28,11 +28,12 @@ echo "Version: $version"
 
 make docker-build
 
+gtag=$service-$version
 git add -u
 git commit -m "$service: $version release [skip ci]"
-git tag -f -a "fnlb-$version" -m "version fnlb-$version"
+git tag -f -a "$gtag" -m "version $gtag"
 git push
-git push origin $version
+git push origin $gtag
 
 # Finally tag and push docker images
 docker tag $user/$service:$tag $user/$service:$version


### PR DESCRIPTION
Was getting this in CI:

```
+ git add -u
+ git commit -m 'fnlb: 0.0.36 release [skip ci]'
[master e66658fe] fnlb: 0.0.36 release [skip ci]
 1 file changed, 1 insertion(+), 1 deletion(-)
+ git tag -f -a fnlb-0.0.36 -m 'version fnlb-0.0.36'
+ git push
Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.

Counting objects: 4, done.
Delta compression using up to 2 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 363 bytes | 0 bytes/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:fnproject/fn.git
   f9d9c248..e66658fe  master -> master
+ git push origin 0.0.36
error: src refspec 0.0.36 does not match any.
error: failed to push some refs to 'git@github.com:fnproject/fn.git'
Exited with code 1
```