### PR TITLE
fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-vendor/
-_vendor*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,18 @@ FROM golang:alpine AS build-env
 RUN apk --no-cache add build-base git bzr mercurial gcc
 ENV D=/go/src/github.com/fnproject/fn
 # If dep ever gets decent enough to use, try `dep ensure --vendor-only` from here: https://medium.com/travis-on-docker/triple-stage-docker-builds-with-go-and-angular-1b7d2006cb88
-RUN go get -u github.com/Masterminds/glide
-ADD glide.* $D/
-RUN cd $D && glide install -v
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+# IF WE DO GLIDE INSTALL THEN THE DEPS DON'T MATCH WHAT WE HAVE IN GIT!!!!!!!
+#RUN go get -u github.com/Masterminds/glide
+#ADD glide.* $D/
+#RUN cd $D && glide install -v
+
 ADD . $D
 RUN cd $D && go build -o fn-alpine && cp fn-alpine /tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker-dep:
 	docker run --rm -it -v ${CURDIR}:/go/src/github.com/fnproject/fn -w /go/src/github.com/fnproject/fn treeder/glide install -v
 
 docker-build:
-	docker build --build-arg HTTP_PROXY -t fnproject/functions:latest .
+	docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/functions:latest .
 
 docker-run: docker-build
 	docker run --rm --privileged -it -e NO_PROXY -e HTTP_PROXY -e LOG_LEVEL=debug -e "DB_URL=sqlite3:///app/data/fn.db" -v ${CURDIR}/data:/app/data -p 8080:8080 funcy/functions


### PR DESCRIPTION
this is trivially incorrect since glide doesn't actually provide reproducible
builds. the idea is to build with the deps that we have checked into git, so
that we actually know what code is executing so that we might debug it...

all for multi stage build instead of what we had, but adding the glide step is
wrong. i added a loud warning so as to discourage this behavior in the future.

this is really urgent imo.