### PR TITLE
add 'docker' runtime to doc function-file.md

### DIFF
--- a/docs/function-file.md
+++ b/docs/function-file.md
@@ -37,7 +37,7 @@ position. You may use it to override the calculated route. If you plan to use
 appended to the image as a tag.
 
 `runtime` represents programming language runtime, for example,
-'go', 'python3', 'java', etc.  The runtime 'docker' will use the existing Dockerfile.
+'go', 'python', 'java', etc.  The runtime 'docker' will use the existing Dockerfile if one exists.
 
 `build` (optional) is an array of local shell calls which are used to help
 building the function.


### PR DESCRIPTION
This adds the 'docker' runtime to doc function-file.md where 'runtime' is defined.