### PR TITLE
stop forcing GET bodies through ?payload

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -38,7 +38,6 @@ import (
 // TODO all Datastore methods need to take unit of tenancy (app or route) at least (e.g. not just call id)
 // TODO limit the request body length when making calls
 // TODO discuss concrete policy for hot launch or timeout / timeout vs time left
-// TODO can we get rid of 'GET url?payload' weirdness?
 // TODO call env need to be map[string][]string to match headers behavior...
 // TODO it may be nice to have an interchange type for Dispatch that can have
 // all the info we need to build e.g. http req, grpc req, json, etc.  so that

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -26,12 +25,6 @@ func (s *Server) handleRequest(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-
-	if c.Request.Method == "GET" {
-		// TODO we _could_ check the normal body, this is still weird
-		// TODO do we need to flush the original body if we do this? (hint: yes)
-		c.Request.Body = ioutil.NopCloser(strings.NewReader(c.Request.URL.Query().Get("payload")))
-	}
 
 	r, routeExists := c.Get(api.Path)
 	if !routeExists {


### PR DESCRIPTION
it's unclear why we had this behavior in the first place, but alas, no more.

closes #264