### PR TITLE
add default to idle_timeout in hot fn docs

### DIFF
--- a/docs/hot-functions.md
+++ b/docs/hot-functions.md
@@ -107,5 +107,5 @@ requests:
 `format` (mandatory) either "default" or "http". If "http", then it is a hot
 container.
 
-`idle_timeout` (optional) - idle timeout (in seconds) before function termination.
+`idle_timeout` (optional) - idle timeout (in seconds) before function termination, default 30 seconds.
 


### PR DESCRIPTION
it's a bit funny that in hot / not functions idle_timeout appears but it's not such a big deal, either