### PR TITLE
bubble up some docker errors to user

### DIFF
--- a/api/agent/drivers/docker/docker_client.go
+++ b/api/agent/drivers/docker/docker_client.go
@@ -5,8 +5,6 @@ package docker
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -130,25 +128,7 @@ func isDocker50x(err error) bool {
 	return ok && derr.Status >= 500
 }
 
-func containerConfigError(err error) error {
-	derr, ok := err.(*docker.Error)
-	if ok && derr.Status == 400 {
-		// derr.Message is a JSON response from docker, which has a "message" field we want to extract if possible.
-		var v struct {
-			Msg string `json:"message"`
-		}
-
-		err := json.Unmarshal([]byte(derr.Message), &v)
-		if err != nil {
-			// If message was not valid JSON, the raw body is still better than nothing.
-			return fmt.Errorf("%s", derr.Message)
-		}
-		return fmt.Errorf("%s", v.Msg)
-	}
-
-	return nil
-}
-
+// implement common.Temporary()
 type temporary struct {
 	error
 }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -4,7 +4,6 @@ package drivers
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 	"time"
@@ -53,19 +52,17 @@ type Driver interface {
 
 // RunResult indicates only the final state of the task.
 type RunResult interface {
-	// Error is an actionable/checkable error from the container.
-	error
+	// Error is an actionable/checkable error from the container, nil if
+	// Status() returns "success", otherwise non-nil
+	Error() error
 
 	// Status should return the current status of the task.
 	// Only valid options are {"error", "success", "timeout", "killed", "cancelled"}.
 	Status() string
 }
 
-// The ContainerTask interface guides task execution across a wide variety of
+// The ContainerTask interface guides container execution across a wide variety of
 // container oriented runtimes.
-// This interface is unstable.
-//
-// FIXME: This interface is large, and it is currently a little Docker specific.
 type ContainerTask interface {
 	// Command returns the command to run within the container.
 	Command() string
@@ -115,21 +112,6 @@ type Stat struct {
 	Timestamp time.Time
 	Metrics   map[string]uint64
 }
-
-// Set of acceptable errors coming from container engines to TaskRunner
-var (
-	// ErrOutOfMemory for OOM in container engine
-	ErrOutOfMemory = userError(errors.New("out of memory error"))
-)
-
-// TODO agent.UserError should be elsewhere
-func userError(err error) error { return &ue{err} }
-
-type ue struct {
-	error
-}
-
-func (u *ue) UserVisible() bool { return true }
 
 // TODO: ensure some type is applied to these statuses.
 const (

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -32,18 +32,18 @@ func (c *cookie) Run(ctx context.Context) (drivers.WaitResult, error) {
 		return nil, fmt.Errorf("Mocker error! Bad.")
 	}
 	return &runResult{
-		error:  nil,
+		err:    nil,
 		status: "success",
 		start:  time.Now(),
 	}, nil
 }
 
 type runResult struct {
-	error
+	err    error
 	status string
 	start  time.Time
 }
 
 func (r *runResult) Wait(context.Context) (drivers.RunResult, error) { return r, nil }
 func (r *runResult) Status() string                                  { return r.status }
-func (r *runResult) StartTime() time.Time                            { return r.start }
+func (r *runResult) Error() error                                    { return r.err }

--- a/api/common/errors.go
+++ b/api/common/errors.go
@@ -6,26 +6,6 @@ import (
 	"syscall"
 )
 
-// Errors that can be directly exposed to call creators/users.
-type UserVisibleError interface {
-	UserVisible() bool
-}
-
-func IsUserVisibleError(err error) bool {
-	ue, ok := err.(UserVisibleError)
-	return ok && ue.UserVisible()
-}
-
-type userVisibleError struct {
-	error
-}
-
-func (u *userVisibleError) UserVisible() bool { return true }
-
-func UserError(err error) error {
-	return &userVisibleError{err}
-}
-
 type Temporary interface {
 	Temporary() bool
 }

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -168,6 +168,8 @@ type err struct {
 
 func (e err) Code() int { return e.code }
 
+func NewAPIError(code int, e error) APIError { return err{code, e} }
+
 // uniform error output
 type Error struct {
 	Error *ErrorBody `json:"error,omitempty"`

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -33,6 +32,8 @@ func testRouterAsync(ds models.Datastore, mq models.MessageQueue, rnr agent.Agen
 }
 
 func TestRouteRunnerAsyncExecution(t *testing.T) {
+	buf := setLogBuffer()
+
 	ds := datastore.NewMockInit(
 		[]*models.App{
 			{Name: "myapp", Config: map[string]string{"app": "true"}},
@@ -71,20 +72,21 @@ func TestRouteRunnerAsyncExecution(t *testing.T) {
 	} {
 		body := bytes.NewBuffer([]byte(test.body))
 
-		fmt.Println("About to start router")
+		t.Log("About to start router")
 		rnr, cancel := testRunner(t, ds)
 		router := testRouterAsync(ds, mq, rnr)
 
-		fmt.Println("makeing requests")
+		t.Log("making requests")
 		req, rec := newRouterRequest(t, "POST", test.path, body)
 		for name, value := range test.headers {
 			req.Header.Set(name, value[0])
 		}
-		fmt.Println("About to start router2")
+		t.Log("About to start router2")
 		router.ServeHTTP(rec, req)
-		fmt.Println("after servehttp")
+		t.Log("after servehttp")
 
 		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
 			t.Errorf("Test %d: Expected status code to be %d but was %d",
 				i, test.expectedCode, rec.Code)
 		}

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -131,6 +131,8 @@ func TestRouteRunnerExecution(t *testing.T) {
 			{Path: "/", AppName: "myapp", Image: "fnproject/hello", Headers: map[string][]string{"X-Function": {"Test"}}},
 			{Path: "/myroute", AppName: "myapp", Image: "fnproject/hello", Headers: map[string][]string{"X-Function": {"Test"}}},
 			{Path: "/myerror", AppName: "myapp", Image: "fnproject/error", Headers: map[string][]string{"X-Function": {"Test"}}},
+			{Path: "/mydne", AppName: "myapp", Image: "fnproject/imagethatdoesnotexist"},
+			{Path: "/mydnehot", AppName: "myapp", Image: "fnproject/imagethatdoesnotexist", Format: "http"},
 		}, nil,
 	)
 
@@ -149,12 +151,14 @@ func TestRouteRunnerExecution(t *testing.T) {
 	}{
 		{"/r/myapp/", ``, "GET", http.StatusOK, map[string][]string{"X-Function": {"Test"}}},
 		{"/r/myapp/myroute", ``, "GET", http.StatusOK, map[string][]string{"X-Function": {"Test"}}},
-		{"/r/myapp/myerror", ``, "GET", http.StatusInternalServerError, map[string][]string{"X-Function": {"Test"}}},
+		{"/r/myapp/myerror", ``, "GET", http.StatusBadGateway, map[string][]string{"X-Function": {"Test"}}},
+		{"/r/myapp/mydne", ``, "GET", http.StatusNotFound, nil},
+		{"/r/myapp/mydnehot", ``, "GET", http.StatusNotFound, nil},
 
 		// Added same tests again to check if time is reduced by the auth cache
 		{"/r/myapp/", ``, "GET", http.StatusOK, map[string][]string{"X-Function": {"Test"}}},
 		{"/r/myapp/myroute", ``, "GET", http.StatusOK, map[string][]string{"X-Function": {"Test"}}},
-		{"/r/myapp/myerror", ``, "GET", http.StatusInternalServerError, map[string][]string{"X-Function": {"Test"}}},
+		{"/r/myapp/myerror", ``, "GET", http.StatusBadGateway, map[string][]string{"X-Function": {"Test"}}},
 	} {
 		body := strings.NewReader(test.body)
 		_, rec := routerRequest(t, srv.Router, test.method, test.path, body)

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -118,7 +118,7 @@ func TestFullStack(t *testing.T) {
 		{"get myroute2", "GET", "/v1/apps/myapp/routes/myroute2", ``, http.StatusOK, 0},
 		{"get all routes", "GET", "/v1/apps/myapp/routes", ``, http.StatusOK, 0},
 		{"execute myroute", "POST", "/r/myapp/myroute", `{ "name": "Teste" }`, http.StatusOK, 1},
-		{"execute myroute2", "POST", "/r/myapp/myroute2", `{ "name": "Teste" }`, http.StatusInternalServerError, 2},
+		{"execute myroute2", "POST", "/r/myapp/myroute2", `{ "name": "Teste" }`, http.StatusBadGateway, 2},
 		{"get myroute2", "GET", "/v1/apps/myapp/routes/myroute2", ``, http.StatusOK, 2},
 		{"delete myroute", "DELETE", "/v1/apps/myapp/routes/myroute", ``, http.StatusOK, 1},
 		{"delete myroute2", "DELETE", "/v1/apps/myapp/routes/myroute2", ``, http.StatusOK, 0},


### PR DESCRIPTION
currently:

* container ran out of memory (code 137)
* container exited with other code != 0
* unable to pull image (auth/404)

there may be others but this is a good start (the most common). notably, for
both hot and cold these should bubble up (if deterministic, which hub isn't
always), and these are useful for users to use in debugging why things aren't
working.

added tests to make sure that these behaviors are working.

also changed the behavior such that when the container exits we return a 502
instead of a 503, just to be able to distinguish the fact that fn is working
as expected but the container is acting funky (400 is weird here, so idk).

removed references to old IsUserVisible crap and slightly changed the
interface for RunResult for plumbing reasons (to get the error type,
specifically).

fixed an issue where if ~/.docker/config.json exists sometimes pulling images
wouldn't work deterministically (should be more inline w/ expectations now)

closes #275