### PR TITLE
Do not let docker decide whether to kill container or not with allocated memory

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -110,8 +110,10 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 			AttachStdin: true,
 			StdinOnce:   true,
 		},
-		HostConfig: &docker.HostConfig{},
-		Context:    ctx,
+		HostConfig: &docker.HostConfig{
+			OOMKillDisable: true,
+		},
+		Context: ctx,
 	}
 
 	volumes := task.Volumes()


### PR DESCRIPTION
 We allocate memory for each container,
  so there's no particular case when container start growning unbounded.
 So, Docker allows/recommends (on your own risk)
  to disable OOM kill in case container has pre-defined RAM.

Closes: #332