### PR TITLE
not ready for spans yet in hot land

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -596,6 +596,7 @@ func (a *agent) runHot(slots chan<- slot, call *call, tok Token) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{"id": container.id, "app": call.AppName, "route": call.Path, "image": call.Image, "memory": call.Memory, "format": call.Format, "idle_timeout": call.IdleTimeout})
+	ctx = common.WithLogger(ctx, logger)
 
 	cookie, err := a.driver.Prepare(ctx, container)
 	if err != nil {

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/fnproject/fn/api/models"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -459,7 +458,8 @@ func (drv *DockerDriver) wait(ctx context.Context, container string) (status str
 	case 0:
 		return drivers.StatusSuccess, nil
 	case 137: // OOM
-		opentracing.SpanFromContext(ctx).LogFields(log.String("docker", "oom"))
+		// TODO put in stats opentracing.SpanFromContext(ctx).LogFields(log.String("docker", "oom"))
+		common.Logger(ctx).Error("docker oom")
 		return drivers.StatusKilled, models.NewAPIError(http.StatusBadGateway, errors.New("container out of memory"))
 	}
 }


### PR DESCRIPTION
was from trying to strip out the `env` stuff, turns out opentracing doesn't have sane default fallbacks (makes sense) so this would panic when ooming

good find @hibooboo2 