### PR TITLE
Update global stats charts to show breakdown by function

### DIFF
--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -6,36 +6,83 @@ import "sync"
 // * hot containers active
 // * memory used / available
 
+// global statistics
 type stats struct {
-	mu       sync.Mutex
+	mu sync.Mutex
+	// statistics for all functions combined
+	queue    uint64
+	running  uint64
+	complete uint64
+	// statistics for individual functions, keyed by function path
+	functionStatsMap map[string]*functionStats
+}
+
+// statistics for an individual function
+type functionStats struct {
 	queue    uint64
 	running  uint64
 	complete uint64
 }
 
 type Stats struct {
+	// statistics for all functions combined
+	Queue    uint64
+	Running  uint64
+	Complete uint64
+	// statistics for individual functions, keyed by function path
+	FunctionStatsMap map[string]*FunctionStats
+}
+
+// statistics for an individual function
+type FunctionStats struct {
 	Queue    uint64
 	Running  uint64
 	Complete uint64
 }
 
-func (s *stats) Enqueue() {
+func (s *stats) getStatsForFunction(path string) *functionStats {
+	if s.functionStatsMap == nil {
+		s.functionStatsMap = make(map[string]*functionStats)
+	}
+	thisFunctionStats, found := s.functionStatsMap[path]
+	if !found {
+		thisFunctionStats = &functionStats{}
+		s.functionStatsMap[path] = thisFunctionStats
+	}
+
+	return thisFunctionStats
+}
+
+func (s *stats) Enqueue(path string) {
 	s.mu.Lock()
 	s.queue++
+	s.getStatsForFunction(path).queue++
 	s.mu.Unlock()
 }
 
-func (s *stats) Start() {
+// Call when a function has been queued but cannot be started because of an error
+func (s *stats) Dequeue(path string) {
 	s.mu.Lock()
 	s.queue--
-	s.running++
+	s.getStatsForFunction(path).queue--
 	s.mu.Unlock()
 }
 
-func (s *stats) Complete() {
+func (s *stats) Start(path string) {
+	s.mu.Lock()
+	s.queue--
+	s.getStatsForFunction(path).queue--
+	s.running++
+	s.getStatsForFunction(path).running++
+	s.mu.Unlock()
+}
+
+func (s *stats) Complete(path string) {
 	s.mu.Lock()
 	s.running--
+	s.getStatsForFunction(path).running--
 	s.complete++
+	s.getStatsForFunction(path).complete++
 	s.mu.Unlock()
 }
 
@@ -45,6 +92,11 @@ func (s *stats) Stats() Stats {
 	stats.Running = s.running
 	stats.Complete = s.complete
 	stats.Queue = s.queue
+	stats.FunctionStatsMap = make(map[string]*FunctionStats)
+	for key, value := range s.functionStatsMap {
+		thisFunctionStats := &FunctionStats{Queue: value.queue, Running: value.running, Complete: value.complete}
+		stats.FunctionStatsMap[key] = thisFunctionStats
+	}
 	s.mu.Unlock()
 	return stats
 }


### PR DESCRIPTION
This is the change originally in https://github.com/fnproject/fn/pull/334. 

I've created this new PR from a direct cloned repo rather than from a fork: apparently this may be necessary to allow the CircleCI tests to run. Let's see what happens now.

Other changes:
Formatting fixed
Minor performance tweak as suggested.

Once this is approved I'm going to look at adding charts for each app. This will probably involve a change to the stats API to be closer to Denis's suggestion. I'll also add some tests for the final API chosen.