### PR TITLE
Split queries to make them work on Postgres and MySQL

### DIFF
--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -223,11 +223,13 @@ func (ds *sqlStore) UpdateApp(ctx context.Context, newapp *models.App) (*models.
 func (ds *sqlStore) RemoveApp(ctx context.Context, appName string) error {
 	return ds.Tx(func(tx *sqlx.Tx) error {
 		res, err := tx.ExecContext(ctx, tx.Rebind(`DELETE FROM apps WHERE name=?`), appName)
+		if err != nil {
+			return err
+		}
 		n, err := res.RowsAffected()
 		if err != nil {
 			return err
 		}
-
 		if n == 0 {
 			return models.ErrAppsNotFound
 		}

--- a/test/fn-api-tests/apps_api.go
+++ b/test/fn-api-tests/apps_api.go
@@ -14,6 +14,9 @@ import (
 func CheckAppResponseError(t *testing.T, e error) {
 	if e != nil {
 		switch err := e.(type) {
+		case *apps.DeleteAppsAppNotFound:
+			t.Errorf("Unexpected error occurred: %v Original Location: %s", err.Payload.Error.Message, MyCaller())
+			t.FailNow()
 		case *apps.DeleteAppsAppDefault:
 			t.Errorf("Unexpected error occurred: %v. Status code: %v Orig Location: %s", err.Payload.Error.Message, err.Code(), MyCaller())
 			t.FailNow()

--- a/test/fn-api-tests/apps_test.go
+++ b/test/fn-api-tests/apps_test.go
@@ -11,6 +11,20 @@ import (
 
 func TestApps(t *testing.T) {
 
+	t.Run("delete-app-not-found-test", func(t *testing.T) {
+		t.Parallel()
+		s := SetupDefaultSuite()
+		cfg := &apps.DeleteAppsAppParams{
+			App:     "missing-app",
+			Context: s.Context,
+		}
+		cfg.WithTimeout(time.Second * 60)
+		_, err := s.Client.Apps.DeleteAppsApp(cfg)
+		if err == nil {
+			t.Errorf("Error during app delete: we should get HTTP 404, but got: %s", err.Error())
+		}
+	})
+
 	t.Run("app-not-found-test", func(t *testing.T) {
 		t.Parallel()
 		s := SetupDefaultSuite()


### PR DESCRIPTION
 Only SQLite supports multiple deletes in one transaction/statement,
 but other are not.