### PR TITLE
Extend stats to report Failed calls

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -173,6 +173,7 @@ func (a *agent) Submit(callI Call) error {
 	default:
 	}
 
+	// increment queued count
 	a.stats.Enqueue(callI.Model().Path)
 
 	call := callI.(*call)
@@ -202,13 +203,20 @@ func (a *agent) Submit(callI Call) error {
 		return err
 	}
 
-	a.stats.Start(callI.Model().Path)
+	// decrement queued count, increment running count
+	a.stats.DequeueAndStart(callI.Model().Path)
 
 	err = slot.exec(ctx, call)
 	// pass this error (nil or otherwise) to end directly, to store status, etc
 	// End may rewrite the error or elect to return it
 
-	a.stats.Complete(callI.Model().Path)
+	if err == nil {
+		// decrement running count, increment completed count
+		a.stats.Complete(callI.Model().Path)
+	} else {
+		// decrement running count, increment failed count
+		a.stats.Failed(callI.Model().Path)
+	}
 
 	// TODO: we need to allocate more time to store the call + logs in case the call timed out,
 	// but this could put us over the timeout if the call did not reply yet (need better policy).


### PR DESCRIPTION
This change extends the /stats API call to return a new metric "Failed", which is the number of calls which failed. The metric "Complete" has been corrected to exclude these failed calls. 

Note that "failed" means the function returned a non-zero return code or timed out. Functions which failed internally and were retried successfully are not counted.

This is what the stats output now looks like:
```
$ curl http://localhost:8080/stats
{"Queue":0,"Running":0,"Complete":534,"Failed":66,"FunctionStatsMap":{"/hello1":{"Queue":0,"Running":0,"Complete":271,"Failed":29},"/hello2":{"Queue":0,"Running":0,"Complete":173,"Failed":27},"/hello3":{"Queue":0,"Running":0,"Complete":90,"Failed":10}}}
```