### PR TITLE
Fixing call getter

### DIFF
--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -489,6 +489,9 @@ func (ds *sqlStore) GetCall(ctx context.Context, appName, callID string) (*model
 	var call models.Call
 	err := row.StructScan(&call)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, models.ErrCallNotFound
+		}
 		return nil, err
 	}
 	return &call, nil


### PR DESCRIPTION
Before this fix server was throwing HTTP 500:
```
fn logs get emokognitio 01BVBJBCP108S0200000000000
ERROR: unknown error (status 500): {resp:0xc420412000}
```