### PR TITLE
Environment variable should be API_CALL for Kubernetes too

### DIFF
--- a/docs/operating/kubernetes/README.md
+++ b/docs/operating/kubernetes/README.md
@@ -31,7 +31,7 @@ Note that `fn-service` is initially pending on allocating an external IP. The `k
 If you are using a Kubernetes setup that can expose a public load balancer, run:
 
 ```bash
-$ export FUNCTIONS=$(kubectl get -o json svc fn-service | jq -r '.status.loadBalancer.ingress[0].ip'):8080
+$ export API_URL=$(kubectl get -o json svc fn-service | jq -r '.status.loadBalancer.ingress[0].ip'):8080
 ```
 
 If you are using a Kubernetes setup like minikube, run
@@ -57,7 +57,6 @@ Hello Johnny!
 You can also use the [Fn CLI](https://github.com/fnproject/cli):
 
 ```bash
-$ export API_URL=http://192.168.99.100:30966
 $ fn apps list
 myapp
 $ fn routes list myapp


### PR DESCRIPTION
1. use API_CALL w/ Kubernetes w/ load-balancer *and* minikube
2. Since API_CALL is set (consistently in #1) no need to redefine it (incorrectly) here.