### PR TITLE
omitempty these fields since they can be null

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -2,7 +2,7 @@ package models
 
 type App struct {
 	Name   string `json:"name" db:"name"`
-	Config Config `json:"config" db:"config"`
+	Config Config `json:"config,omitempty" db:"config"`
 }
 
 func (a *App) Validate() error {

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -25,12 +25,12 @@ type Route struct {
 	Path        string  `json:"path" db:"path"`
 	Image       string  `json:"image" db:"image"`
 	Memory      uint64  `json:"memory" db:"memory"`
-	Headers     Headers `json:"headers" db:"headers"`
+	Headers     Headers `json:"headers,omitempty" db:"headers"`
 	Type        string  `json:"type" db:"type"`
 	Format      string  `json:"format" db:"format"`
 	Timeout     int32   `json:"timeout" db:"timeout"`
 	IdleTimeout int32   `json:"idle_timeout" db:"idle_timeout"`
-	Config      Config  `json:"config" db:"config"`
+	Config      Config  `json:"config,omitempty" db:"config"`
 }
 
 // SetDefaults sets zeroed field to defaults.


### PR DESCRIPTION
they show up in the api and should at least be `{}` but I think omitting them is fine/better.