### PR TITLE
Call setTracer() before Agent creation

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -77,6 +77,9 @@ func NewFromEnv(ctx context.Context, opts ...ServerOption) *Server {
 
 // New creates a new Functions server with the passed in datastore, message queue and API URL
 func New(ctx context.Context, ds models.Datastore, mq models.MessageQueue, logDB models.LogStore, opts ...ServerOption) *Server {
+
+	setTracer()
+	
 	s := &Server{
 		Agent:     agent.New(cache.Wrap(ds), mq), // only add datastore caching to agent
 		Router:    gin.New(),
@@ -86,7 +89,6 @@ func New(ctx context.Context, ds models.Datastore, mq models.MessageQueue, logDB
 	}
 
 	setMachineId()
-	s.setTracer()
 	s.Router.Use(loggerWrap, traceWrap, panicWrap)
 	s.bindHandlers(ctx)
 
@@ -119,7 +121,7 @@ func traceWrap(c *gin.Context) {
 	c.Next()
 }
 
-func (s *Server) setTracer() {
+func setTracer() {
 	var (
 		debugMode          = false
 		serviceName        = "fn-server"

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -79,7 +79,7 @@ func NewFromEnv(ctx context.Context, opts ...ServerOption) *Server {
 func New(ctx context.Context, ds models.Datastore, mq models.MessageQueue, logDB models.LogStore, opts ...ServerOption) *Server {
 
 	setTracer()
-	
+
 	s := &Server{
 		Agent:     agent.New(cache.Wrap(ds), mq), // only add datastore caching to agent
 		Router:    gin.New(),


### PR DESCRIPTION
This PR fixes an intermittent race condition which sometimes caused the following  panic at startup:
```
panic: interface conversion: opentracing.SpanContext is opentracing.noopSpanContext, not zipkintracer.SpanContext
goroutine 74 [running]:
github.com/fnproject/fn/vendor/github.com/openzipkin/zipkin-go-opentracing.(*tracerImpl).startSpanWithOptions()
	/go/src/github.com/fnproject/fn/vendor/github.com/openzipkin/zipkin-go-opentracing/tracer.go:309  
github.com/fnproject/fn/vendor/github.com/openzipkin/zipkin-go-opentracing.(*tracerImpl).StartSpan()
	/go/src/github.com/fnproject/fn/vendor/github.com/openzipkin/zipkin-go-opentracing/tracer.go:268  
github.com/fnproject/fn/api/server.FnTracer.StartSpan()
	/go/src/github.com/fnproject/fn/api/server/fntracer.go:23  
github.com/fnproject/fn/api/server.(*FnTracer).StartSpan()
	<autogenerated>:1  
github.com/fnproject/fn/vendor/github.com/opentracing/opentracing-go.startSpanFromContextWithTracer()
	/go/src/github.com/fnproject/fn/vendor/github.com/opentracing/opentracing-go/gocontext.go:52  
github.com/fnproject/fn/vendor/github.com/opentracing/opentracing-go.StartSpanFromContext()
	/go/src/github.com/fnproject/fn/vendor/github.com/opentracing/opentracing-go/gocontext.go:44  
github.com/fnproject/fn/api/agent/drivers/docker.(*dockerWrap).CreateContainer()
	/go/src/github.com/fnproject/fn/api/agent/drivers/docker/docker_client.go:213 
github.com/fnproject/fn/api/agent/drivers/docker.(*DockerDriver).Prepare
	/go/src/github.com/fnproject/fn/api/agent/drivers/docker/docker.go:136  
github.com/fnproject/fn/api/agent.(*agent).prepCold()
	/go/src/github.com/fnproject/fn/api/agent/agent.go:560  
github.com/fnproject/fn/api/agent.(*agent).launch.func1()
	/go/src/github.com/fnproject/fn/api/agent/agent.go:529 
created by github.com/fnproject/fn/api/agent.(*agent).launch
	/go/src/github.com/fnproject/fn/api/agent/agent.go:528  
```

This appears to be caused by an attempt to set a Span created using the default Tracer to be configured as the parent of a Span created using the Zipkin Tracer. It seems likely that this was because the parent span was created before the Zipkin Tracer was configured.

To fix this, this PR changes the `New` function in `api/server/server.go` to set the global tracer before creating the agent and server. 