### PR TITLE
link broken, changed to iron-io/logspout-statsd

### DIFF
--- a/docs/operating/metrics.md
+++ b/docs/operating/metrics.md
@@ -14,5 +14,5 @@ TODO hook up zipkin to poop out to logs/statsd/something else too
 
 ## Statsd
 
-The [Logspout Statsd Adapter](https://github.com/treeder/logspout-statsd) adapter can parse the log metrics and forward
+The [Logspout Statsd Adapter](https://github.com/iron-io/logspout-statsd) adapter can parse the log metrics and forward
 them to any statsd server.


### PR DESCRIPTION
searched in github and could only find iron-io with same project name.