### PR TITLE
fn: fnlb: enhancements and new grouper tests

### DIFF
--- a/fnlb/lb/allgrouper_test.go
+++ b/fnlb/lb/allgrouper_test.go
@@ -1,0 +1,480 @@
+package lb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type mockDB struct {
+	isAddError    bool
+	isDeleteError bool
+	isListError   bool
+	nodeList      map[string]bool
+}
+
+func (mock *mockDB) Add(node string) error {
+	if mock.isAddError {
+		return errors.New("simulated add error")
+	}
+	mock.nodeList[node] = true
+	return nil
+}
+func (mock *mockDB) Delete(node string) error {
+	if mock.isDeleteError {
+		return errors.New("simulated delete error")
+	}
+	delete(mock.nodeList, node)
+	return nil
+}
+func (mock *mockDB) List() ([]string, error) {
+	if mock.isListError {
+		return nil, errors.New("simulated list error")
+	}
+	list := make([]string, 0, len(mock.nodeList))
+	for key, _ := range mock.nodeList {
+		list = append(list, key)
+	}
+	return list, nil
+}
+
+func initializeRunner() (Grouper, error) {
+	db := &mockDB{
+		nodeList: make(map[string]bool),
+	}
+
+	conf := Config{
+		HealthcheckInterval:  1,
+		HealthcheckEndpoint:  "/version",
+		HealthcheckUnhealthy: 1,
+		HealthcheckHealthy:   1,
+		HealthcheckTimeout:   1,
+		MinAPIVersion:        semver.New("0.0.104"),
+		Transport:            &http.Transport{},
+	}
+
+	return NewAllGrouper(conf, db)
+}
+
+type testServer struct {
+	addr     string
+	version  string
+	healthy  bool
+	inPool   bool
+	listener *net.Listener
+	server   *http.Server
+}
+
+func (s *testServer) getHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "/version" == r.URL.Path {
+			if s.healthy {
+				sendValue(w, fnVersion{Version: s.version})
+			} else {
+				sendError(w, http.StatusServiceUnavailable, "service unhealthy")
+			}
+		} else {
+			sendError(w, http.StatusNotFound, "unknown uri")
+		}
+	})
+}
+
+// return a list of supposed to be healthy (good version and in pool) nodes
+func getCurrentHealthySet(list []*testServer) []string {
+
+	out := make([]string, 0)
+
+	for _, val := range list {
+		if val.healthy && val.inPool {
+			out = append(out, val.addr)
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+// shutdown a server
+func teardownServer(t *testing.T, server *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(100)*time.Millisecond)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		t.Logf("shutdown error: %s", err.Error())
+	}
+}
+
+// spin up backend servers
+func initializeAPIServer(t *testing.T, grouper Grouper) (*http.Server, string, error) {
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+	handler := NullHandler()
+	handler = grouper.Wrap(handler) // add/del/list endpoints
+	server := &http.Server{Handler: handler}
+
+	go func(srv *http.Server, addr string) {
+		err := server.Serve(listener)
+		if err != nil {
+			t.Logf("server exited %s with %s", addr, err.Error())
+		}
+	}(server, addr)
+
+	return server, addr, nil
+}
+
+// spin up backend servers
+func initializeTestServers(t *testing.T, numOfServers uint64) ([]*testServer, error) {
+
+	list := make([]*testServer, 0)
+
+	for i := uint64(0); i < numOfServers; i++ {
+
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			return list, err
+		}
+
+		server := &testServer{
+			addr:     listener.Addr().String(),
+			version:  "0.0.104",
+			healthy:  true,
+			inPool:   false,
+			listener: &listener,
+		}
+
+		server.server = &http.Server{Handler: server.getHandler()}
+
+		go func(srv *testServer) {
+			err := srv.server.Serve(listener)
+			if err != nil {
+				t.Logf("server exited %s with %s", srv.addr, err.Error())
+			}
+		}(server)
+
+		list = append(list, server)
+	}
+
+	return list, nil
+}
+
+// tear down backend servers
+func shutdownTestServers(t *testing.T, servers []*testServer) {
+	for _, srv := range servers {
+		teardownServer(t, srv.server)
+	}
+}
+
+func testCompare(t *testing.T, grouper Grouper, servers []*testServer, ctx string) {
+
+	// compare current supposed to be healthy VS healthy list from allGrouper
+	current := getCurrentHealthySet(servers)
+	t.Logf("%s Expecting healthy servers %v", ctx, current)
+
+	round, err := grouper.List("ignore")
+	if err != nil {
+		if len(current) != 0 {
+			t.Errorf("%s Not expected error %s", ctx, err.Error())
+		}
+	} else {
+		t.Logf("%s Detected healthy servers  %v", ctx, round)
+
+		if len(current) != len(round) {
+			t.Errorf("%s Got %d servers, expected: %d", ctx, len(round), len(current))
+		}
+		for idx, srv := range round {
+			if srv != current[idx] {
+				t.Errorf("%s Mismatch idx: %d %s != %s", ctx, idx, srv, current[idx])
+			}
+		}
+	}
+}
+
+// using mgmt API modify (add/remove) a node
+func mgmtModServer(t *testing.T, addr string, operation string, node string) error {
+	client := &http.Client{}
+	url := "http://" + addr + "/1/lb/nodes"
+
+	str := fmt.Sprintf("{\"Node\":\"%s\"}", node)
+	body := []byte(str)
+	req, err := http.NewRequest(operation, url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	t.Logf("%s node=%s response=%s status=%d", operation, node, respBody, resp.StatusCode)
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("%s node=%s status=%d %s", operation, node, resp.StatusCode, respBody)
+	}
+
+	return nil
+}
+
+// using mgmt api list servers and compare with test server list
+func mgmtListServers(t *testing.T, addr string, servers []*testServer) error {
+	client := &http.Client{}
+	url := "http://" + addr + "/1/lb/nodes"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("list status=%d", resp.StatusCode)
+	}
+
+	var listResp struct {
+		Nodes map[string]string `json:"nodes"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&listResp)
+	if err != nil {
+		return err
+	}
+
+	cmpList := make(map[string]string, len(servers))
+	for _, val := range servers {
+		if val.inPool {
+			if val.healthy {
+				cmpList[val.addr] = "online"
+			} else {
+				cmpList[val.addr] = "offline"
+			}
+		}
+	}
+
+	t.Logf("list response=%v expected=%v", listResp.Nodes, cmpList)
+
+	for key, val1 := range cmpList {
+		val2, ok := listResp.Nodes[key]
+		if !ok {
+			t.Errorf("failed list comparison node=`%s` is not in received", key)
+			return nil
+
+		}
+
+		if val1 != val2 {
+			t.Errorf("failed list comparison node=`%s` expected=`%s` received=`%s`", key, val1, val2)
+			return nil
+		}
+
+		delete(cmpList, key)
+		delete(listResp.Nodes, key)
+	}
+
+	if len(cmpList) != 0 || len(listResp.Nodes) != 0 {
+		t.Errorf("failed list comparison (remaining unmatches) expected=`%v` received=`%v`", cmpList, listResp.Nodes)
+	}
+
+	return nil
+}
+
+// Basic tests via DB add/remove functions
+func TestRouteRunnerExecution(t *testing.T) {
+
+	a, err := initializeRunner()
+	if err != nil {
+		t.Errorf("Not expected error `%s`", err.Error())
+	}
+
+	var concrete *allGrouper
+	concrete = a.(*allGrouper)
+
+	// initialize and add some servers (all healthy)
+	serverCount := 10
+	servers, err := initializeTestServers(t, uint64(serverCount))
+	if err != nil {
+		t.Errorf("Not expected error `%s`", err.Error())
+	} else {
+		defer shutdownTestServers(t, servers)
+
+		if serverCount != len(servers) {
+			t.Errorf("Got %d servers, expected: %d", len(servers), serverCount)
+		}
+
+		srvList := make([]string, 0, len(servers))
+		for _, srv := range servers {
+			srvList = append(srvList, srv.addr)
+		}
+		t.Logf("Spawned servers %s", srvList)
+
+		testCompare(t, a, servers, "round0")
+
+		for _, srv := range servers {
+			// add these servers to allGrouper
+			err := concrete.add(srv.addr)
+			if err != nil {
+				t.Errorf("Not expected error `%s` when adding `%s`", err.Error(), srv.addr)
+			}
+			srv.inPool = true
+		}
+	}
+
+	t.Logf("Starting round1 all servers healthy")
+
+	// let health checker converge
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round1")
+
+	t.Logf("Starting round2 one server unhealthy")
+
+	// now set one server unhealthy
+	servers[2].healthy = false
+	t.Logf("Setting server %s to unhealthy", servers[2].addr)
+
+	// let health checker converge
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round2")
+
+	t.Logf("Starting round3 remove one server from grouper")
+
+	t.Logf("Removing server %s from grouper", servers[3].addr)
+	err = concrete.remove(servers[3].addr)
+	if err != nil {
+		t.Errorf("Not expected error `%s` when removing `%s`", err.Error(), servers[3].addr)
+	}
+	servers[3].inPool = false
+
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round3")
+
+	t.Logf("Starting round4 add server back to grouper")
+
+	t.Logf("Adding server %s to grouper", servers[3].addr)
+	err = concrete.add(servers[3].addr)
+	if err != nil {
+		t.Errorf("Not expected error `%s` when adding `%s`", err.Error(), servers[3].addr)
+	}
+	servers[3].inPool = true
+
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round4")
+
+	t.Logf("Starting round5 set unhealthy server back to healthy")
+	servers[2].healthy = true
+	t.Logf("Setting server %s to healthy", servers[2].addr)
+
+	// let health checker converge
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round5")
+
+	t.Logf("Starting round6 no change")
+	// fetch list again
+	testCompare(t, a, servers, "round6")
+}
+
+// Basic tests via mgmt API
+func TestRouteRunnerMgmtAPI(t *testing.T) {
+
+	a, err := initializeRunner()
+	if err != nil {
+		t.Errorf("Not expected error `%s`", err.Error())
+	}
+
+	mgmtSrv, mgmtAddr, err := initializeAPIServer(t, a)
+	if err != nil {
+		t.Errorf("cannot start mgmt api server `%s`", err.Error())
+	}
+	defer teardownServer(t, mgmtSrv)
+
+	// initialize and add some servers (all healthy)
+	serverCount := 5
+	servers, err := initializeTestServers(t, uint64(serverCount))
+	if err != nil {
+		t.Errorf("Not expected error `%s`", err.Error())
+	} else {
+		defer shutdownTestServers(t, servers)
+
+		if serverCount != len(servers) {
+			t.Errorf("Got %d servers, expected: %d", len(servers), serverCount)
+		}
+
+		srvList := make([]string, 0, len(servers))
+		for _, srv := range servers {
+			srvList = append(srvList, srv.addr)
+		}
+		t.Logf("Spawned servers %s", srvList)
+
+		testCompare(t, a, servers, "round0")
+
+		for _, srv := range servers {
+			err := mgmtModServer(t, mgmtAddr, "PUT", srv.addr)
+			if err != nil {
+				t.Errorf("Not expected error `%s` when adding `%s`", err.Error(), srv.addr)
+			}
+			srv.inPool = true
+		}
+	}
+
+	t.Logf("Starting round1 all servers healthy")
+
+	// let health checker converge
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round1")
+
+	err = mgmtListServers(t, mgmtAddr, servers)
+	if err != nil {
+		t.Errorf("Not expected error `%s` when listing", err.Error())
+	}
+
+	t.Logf("Starting round2 remove one server from grouper")
+
+	// let's set server at 2 as unhealthy as well
+	servers[2].healthy = false
+
+	t.Logf("Removing server %s from grouper", servers[3].addr)
+	err = mgmtModServer(t, mgmtAddr, "DELETE", servers[3].addr)
+	if err != nil {
+		t.Errorf("Not expected error `%s` when removing `%s`", err.Error(), servers[3].addr)
+	}
+	servers[3].inPool = false
+
+	time.Sleep(time.Duration(2) * time.Second)
+	testCompare(t, a, servers, "round2")
+
+	err = mgmtListServers(t, mgmtAddr, servers)
+	if err != nil {
+		t.Errorf("Not expected error `%s` when listing", err.Error())
+	}
+}
+
+// TODO: test old version case
+// TODO: test DB unhealthy case
+// TODO: test healthy/unhealthy thresholds
+// TODO: test health check timeout case

--- a/fnlb/lb/db.go
+++ b/fnlb/lb/db.go
@@ -1,0 +1,153 @@
+package lb
+
+import (
+	"database/sql"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/mattn/go-sqlite3"
+	"github.com/sirupsen/logrus"
+)
+
+func NewDB(conf Config) (DBStore, error) {
+	db, err := db(conf.DBurl)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, err
+}
+
+// TODO put this somewhere better
+type DBStore interface {
+	Add(string) error
+	Delete(string) error
+	List() ([]string, error)
+}
+
+// implements DBStore
+type sqlStore struct {
+	db *sqlx.DB
+
+	// TODO we should prepare all of the statements, rebind them
+	// and store them all here.
+}
+
+// New will open the db specified by url, create any tables necessary
+// and return a models.Datastore safe for concurrent usage.
+func db(uri string) (DBStore, error) {
+	url, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	driver := url.Scheme
+	// driver must be one of these for sqlx to work, double check:
+	switch driver {
+	case "postgres", "pgx", "mysql", "sqlite3", "oci8", "ora", "goracle":
+	default:
+		return nil, errors.New("invalid db driver, refer to the code")
+	}
+
+	if driver == "sqlite3" {
+		// make all the dirs so we can make the file..
+		dir := filepath.Dir(url.Path)
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	uri = url.String()
+	if driver != "postgres" {
+		// postgres seems to need this as a prefix in lib/pq, everyone else wants it stripped of scheme
+		uri = strings.TrimPrefix(url.String(), url.Scheme+"://")
+	}
+
+	sqldb, err := sql.Open(driver, uri)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{"url": uri}).WithError(err).Error("couldn't open db")
+		return nil, err
+	}
+
+	db := sqlx.NewDb(sqldb, driver)
+	// force a connection and test that it worked
+	err = db.Ping()
+	if err != nil {
+		logrus.WithFields(logrus.Fields{"url": uri}).WithError(err).Error("couldn't ping db")
+		return nil, err
+	}
+
+	maxIdleConns := 30 // c.MaxIdleConnections
+	db.SetMaxIdleConns(maxIdleConns)
+	logrus.WithFields(logrus.Fields{"max_idle_connections": maxIdleConns, "datastore": driver}).Info("datastore dialed")
+
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS lb_nodes (
+        address text NOT NULL PRIMARY KEY
+    );`)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sqlStore{db: db}, nil
+}
+
+func (s *sqlStore) Add(node string) error {
+	query := s.db.Rebind("INSERT INTO lb_nodes (address) VALUES (?);")
+	_, err := s.db.Exec(query, node)
+	if err != nil {
+		// if it already exists, just filter that error out
+		switch err := err.(type) {
+		case *mysql.MySQLError:
+			if err.Number == 1062 {
+				return nil
+			}
+		case *pq.Error:
+			if err.Code == "23505" {
+				return nil
+			}
+		case sqlite3.Error:
+			if err.ExtendedCode == sqlite3.ErrConstraintUnique || err.ExtendedCode == sqlite3.ErrConstraintPrimaryKey {
+				return nil
+			}
+		}
+	}
+	return err
+}
+
+func (s *sqlStore) Delete(node string) error {
+	query := s.db.Rebind(`DELETE FROM lb_nodes WHERE address=?`)
+	_, err := s.db.Exec(query, node)
+	// TODO we can filter if it didn't exist, too...
+	return err
+}
+
+func (s *sqlStore) List() ([]string, error) {
+	query := s.db.Rebind(`SELECT DISTINCT address FROM lb_nodes`)
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []string
+	for rows.Next() {
+		var node string
+		err := rows.Scan(&node)
+		if err == nil {
+			nodes = append(nodes, node)
+		}
+	}
+
+	err = rows.Err()
+	if err == sql.ErrNoRows {
+		err = nil // don't care...
+	}
+
+	return nodes, err
+}

--- a/fnlb/lb/proxy.go
+++ b/fnlb/lb/proxy.go
@@ -32,11 +32,14 @@ import (
 type Config struct {
 	DBurl                string          `json:"db_url"`
 	Listen               string          `json:"port"`
+	MgmtListen           string          `json:"mgmt_port"`
+	ShutdownTimeout      int             `json:"shutdown_timeout"`
 	ZipkinURL            string          `json:"zipkin_url"`
 	Nodes                []string        `json:"nodes"`
 	HealthcheckInterval  int             `json:"healthcheck_interval"`
 	HealthcheckEndpoint  string          `json:"healthcheck_endpoint"`
 	HealthcheckUnhealthy int             `json:"healthcheck_unhealthy"`
+	HealthcheckHealthy   int             `json:"healthcheck_healthy"`
 	HealthcheckTimeout   int             `json:"healthcheck_timeout"`
 	MinAPIVersion        *semver.Version `json:"min_api_version"`
 

--- a/fnlb/lb/util.go
+++ b/fnlb/lb/util.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	ErrNoNodes = errors.New("no nodes available")
+	ErrNoNodes        = errors.New("no nodes available")
+	ErrUnknownCommand = errors.New("unknown command")
 )
 
 func sendValue(w http.ResponseWriter, v interface{}) {
@@ -44,4 +45,10 @@ func sendError(w http.ResponseWriter, code int, msg string) {
 	if err != nil {
 		logrus.WithError(err).Error("error writing response response")
 	}
+}
+
+func NullHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendError(w, http.StatusNotFound, ErrUnknownCommand.Error())
+	})
 }

--- a/fnlb/main.go
+++ b/fnlb/main.go
@@ -27,9 +27,12 @@ func main() {
 	var conf lb.Config
 	flag.StringVar(&conf.DBurl, "db", "sqlite3://:memory:", "backend to store nodes, default to in memory")
 	flag.StringVar(&conf.Listen, "listen", ":8081", "port to run on")
+	flag.StringVar(&conf.MgmtListen, "mgmt-listen", ":8081", "management port to run on")
+	flag.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", 0, "graceful shutdown timeout")
 	flag.IntVar(&conf.HealthcheckInterval, "hc-interval", 3, "how often to check f(x) nodes, in seconds")
 	flag.StringVar(&conf.HealthcheckEndpoint, "hc-path", "/version", "endpoint to determine node health")
 	flag.IntVar(&conf.HealthcheckUnhealthy, "hc-unhealthy", 2, "threshold of failed checks to declare node unhealthy")
+	flag.IntVar(&conf.HealthcheckHealthy, "hc-healthy", 1, "threshold of success checks to declare node healthy")
 	flag.IntVar(&conf.HealthcheckTimeout, "hc-timeout", 5, "timeout of healthcheck endpoint, in seconds")
 	flag.StringVar(&conf.ZipkinURL, "zipkin", "", "zipkin endpoint to send traces")
 	flag.Parse()
@@ -54,7 +57,12 @@ func main() {
 		},
 	}
 
-	g, err := lb.NewAllGrouper(conf)
+	db, err := lb.NewDB(conf)
+	if err != nil {
+		logrus.WithError(err).Fatal("error setting up database")
+	}
+
+	g, err := lb.NewAllGrouper(conf, db)
 	if err != nil {
 		logrus.WithError(err).Fatal("error setting up grouper")
 	}
@@ -64,27 +72,57 @@ func main() {
 		return r.URL.Path, nil
 	}
 
-	h := lb.NewProxy(k, g, r, conf)
-	h = g.Wrap(h) // add/del/list endpoints
-	h = r.Wrap(h) // stats / dash endpoint
+	servers := make([]*http.Server, 0, 1)
+	handler := lb.NewProxy(k, g, r, conf)
 
-	err = serve(conf.Listen, h)
-	if err != nil {
-		logrus.WithError(err).Fatal("server error")
+	// a separate mgmt listener is requested? then let's create a LB traffic only server
+	if conf.Listen != conf.MgmtListen {
+		servers = append(servers, &http.Server{Addr: conf.Listen, Handler: handler})
+		handler = lb.NullHandler()
 	}
+
+	// add mgmt endpoints to the handler
+	handler = g.Wrap(handler) // add/del/list endpoints
+	handler = r.Wrap(handler) // stats / dash endpoint
+
+	servers = append(servers, &http.Server{Addr: conf.MgmtListen, Handler: handler})
+	serve(servers, &conf)
 }
 
-func serve(addr string, handler http.Handler) error {
-	server := &http.Server{Addr: addr, Handler: handler}
+func serve(servers []*http.Server, conf *lb.Config) {
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGQUIT, syscall.SIGINT)
-	go func() {
-		for sig := range ch {
-			logrus.WithFields(logrus.Fields{"signal": sig}).Info("received signal")
-			server.Shutdown(context.Background()) // safe shutdown
-			return
+
+	for i := 0; i < len(servers); i++ {
+		go func(idx int) {
+			err := servers[idx].ListenAndServe()
+			if err != nil && err != http.ErrServerClosed {
+				logrus.WithFields(logrus.Fields{"server_id": idx}).WithError(err).Fatal("server error")
+			} else {
+				logrus.WithFields(logrus.Fields{"server_id": idx}).Info("server stopped")
+			}
+		}(i)
+	}
+
+	sig := <-ch
+	logrus.WithFields(logrus.Fields{"signal": sig}).Info("received signal")
+
+	for i := 0; i < len(servers); i++ {
+
+		ctx := context.Background()
+
+		if conf.ShutdownTimeout > 0 {
+			tmpCtx, cancel := context.WithTimeout(context.Background(), time.Duration(conf.ShutdownTimeout)*time.Second)
+			ctx = tmpCtx
+			defer cancel()
 		}
-	}()
-	return server.ListenAndServe()
+
+		err := servers[i].Shutdown(ctx) // safe shutdown
+		if err != nil {
+			logrus.WithFields(logrus.Fields{"server_id": i}).WithError(err).Fatal("server shutdown error")
+		} else {
+			logrus.WithFields(logrus.Fields{"server_id": i}).Info("server shutdown")
+		}
+	}
 }


### PR DESCRIPTION
*) added healthy threshold (default: 1)
*) grouper now logs when servers switch between healthy/unhealthy state
*) moved DB code out of grouper
*) run health check immediately at start (don't wait until hcInterval)
*) optional shutdown timeout (default: 0) & mgmt port (default: 8081)
*) hot path List() in grouper now uses atomic ptr Load
*) consistent router: moved closure to a new function
*) bugfix: grouper is now using configured hcEndpoint for version checks
*) bugfix: version parsing from fn servers should not panic fnlb
*) bugfix: when servers removed from DB, stayed in healthy list
*) bugfix: if DB is down, health checker should not stop monitoring
*) basic new tests for grouper (add/rm/unhealthy/healthy) server