### PR TITLE
fn: move memory/token code into resource

### DIFF
--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -15,7 +15,7 @@ func (a *agent) asyncDequeue() {
 		select {
 		case <-a.shutdown:
 			return
-		case <-a.asyncRAM():
+		case <-a.resources.WaitAsyncResource():
 			// TODO we _could_ return a token here to reserve the ram so that there's
 			// not a race between here and Submit but we're single threaded
 			// dequeueing and retries handled gracefully inside of Submit if we run

--- a/api/agent/drivers/docker/registry.go
+++ b/api/agent/drivers/docker/registry.go
@@ -126,7 +126,7 @@ func (d *retryWrap) RoundTrip(req *http.Request) (*http.Response, error) {
 	// and then retry it (it will get authed and the challenge then accepted).
 	// why the docker distribution transport doesn't do this for you is
 	// a real testament to what sadists those docker people are.
-	if resp.StatusCode == http.StatusUnauthorized {
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
 		pingPath := req.URL.Path
 		if v2Root := strings.Index(req.URL.Path, "/v2/"); v2Root != -1 {
 			pingPath = pingPath[:v2Root+4]

--- a/api/agent/resource.go
+++ b/api/agent/resource.go
@@ -2,16 +2,123 @@ package agent
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 )
+
+// A simple resource (memory, cpu, disk, etc.) tracker for scheduling.
+// TODO: improve memory implementation
+// TODO: add cpu, disk, network IO for future
+type ResourceTracker interface {
+	WaitAsyncResource() chan struct{}
+	GetResourceToken(ctx context.Context, call *call) <-chan ResourceToken
+}
+
+type resourceTracker struct {
+	// cond protects access to ramUsed
+	cond *sync.Cond
+	// ramTotal is the total accessible memory by this process
+	ramTotal uint64
+	// ramUsed is ram reserved for running containers. idle hot containers
+	// count against ramUsed.
+	ramUsed uint64
+}
+
+func NewResourceTracker() ResourceTracker {
+
+	obj := &resourceTracker{
+		cond:     sync.NewCond(new(sync.Mutex)),
+		ramTotal: getAvailableMemory(),
+	}
+
+	return obj
+}
+
+type ResourceToken interface {
+	// Close must be called by any thread that receives a token.
+	io.Closer
+}
+
+type resourceToken struct {
+	decrement func()
+}
+
+func (t *resourceToken) Close() error {
+	t.decrement()
+	return nil
+}
+
+// the received token should be passed directly to launch (unconditionally), launch
+// will close this token (i.e. the receiver should not call Close)
+func (a *resourceTracker) GetResourceToken(ctx context.Context, call *call) <-chan ResourceToken {
+
+	memory := call.Memory * 1024 * 1024
+
+	c := a.cond
+	ch := make(chan ResourceToken)
+
+	go func() {
+		c.L.Lock()
+		for (a.ramUsed + memory) > a.ramTotal {
+			select {
+			case <-ctx.Done():
+				c.L.Unlock()
+				return
+			default:
+			}
+
+			c.Wait()
+		}
+
+		a.ramUsed += memory
+		c.L.Unlock()
+
+		t := &resourceToken{decrement: func() {
+			c.L.Lock()
+			a.ramUsed -= memory
+			c.L.Unlock()
+			c.Broadcast()
+		}}
+
+		select {
+		case ch <- t:
+		case <-ctx.Done():
+			// if we can't send b/c nobody is waiting anymore, need to decrement here
+			t.Close()
+		}
+	}()
+
+	return ch
+}
+
+// GetAsyncResource will send a signal on the returned channel when at least half of
+// the available RAM on this machine is free.
+func (a *resourceTracker) WaitAsyncResource() chan struct{} {
+	ch := make(chan struct{})
+
+	c := a.cond
+	go func() {
+		c.L.Lock()
+		for (a.ramTotal/2)-a.ramUsed < 0 {
+			c.Wait()
+		}
+		c.L.Unlock()
+		ch <- struct{}{}
+		// TODO this could leak forever (only in shutdown, blech)
+	}()
+
+	return ch
+}
 
 func getAvailableMemory() uint64 {
 	const tooBig = 322122547200 // #300GB or 0, biggest aws instance is 244GB


### PR DESCRIPTION
*) bugfix: fix nil ptr access in docker registry RoundTrip
*) move async and ram token related code into resource.go