### PR TITLE
fn: introducing 503 responses for out of capacity case

### DIFF
--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -50,7 +50,7 @@ func (a *agent) asyncDequeue() {
 			// are at least once semantics, which is really preferable to at most
 			// once, so let's do it for now
 
-			err, _ = a.Submit(call)
+			err = a.Submit(call)
 			if err != nil {
 				// NOTE: these could be errors / timeouts from the call that we're
 				// logging here (i.e. not our fault), but it's likely better to log

--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -50,7 +50,7 @@ func (a *agent) asyncDequeue() {
 			// are at least once semantics, which is really preferable to at most
 			// once, so let's do it for now
 
-			err = a.Submit(call)
+			err, _ = a.Submit(call)
 			if err != nil {
 				// NOTE: these could be errors / timeouts from the call that we're
 				// logging here (i.e. not our fault), but it's likely better to log

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -158,7 +158,7 @@ var (
 	}
 	ErrRoutesInvalidMemory = err{
 		code:  http.StatusBadRequest,
-		error: fmt.Errorf("memory value is invalid. 0 < memory < %d", MaxMemory),
+		error: fmt.Errorf("memory value is invalid. 0 < memory < %d", RouteMaxMemory),
 	}
 	ErrCallNotFound = err{
 		code:  http.StatusNotFound,

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -20,6 +20,10 @@ var (
 		code:  http.StatusGatewayTimeout,
 		error: errors.New("Timed out"),
 	}
+	ErrCallTimeoutServerBusy = err{
+		code:  http.StatusServiceUnavailable,
+		error: errors.New("Timed out - server too busy"),
+	}
 	ErrAppsMissingName = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Missing app name"),

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -17,8 +17,9 @@ const (
 	MaxSyncTimeout  = 120  // 2 minutes
 	MaxAsyncTimeout = 3600 // 1 hour
 	MaxIdleTimeout  = MaxAsyncTimeout
-	MaxMemory       = 1024 * 1024 * 100 // 100TB TODO should probably be a var of machine max?
 )
+
+var RouteMaxMemory = uint64(8 * 1024) // 8GB TODO should probably be a var of machine max?
 
 type Routes []*Route
 
@@ -112,7 +113,7 @@ func (r *Route) Validate() error {
 		return ErrRoutesInvalidIdleTimeout
 	}
 
-	if r.Memory < 1 || r.Memory > MaxMemory {
+	if r.Memory < 1 || r.Memory > RouteMaxMemory {
 		return ErrRoutesInvalidMemory
 	}
 

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -17,7 +17,7 @@ const (
 	MaxSyncTimeout  = 120  // 2 minutes
 	MaxAsyncTimeout = 3600 // 1 hour
 	MaxIdleTimeout  = MaxAsyncTimeout
-	MaxMemory       = 1024 * 8 // 8GB TODO should probably be a var of machine max?
+	MaxMemory       = 1024 * 1024 * 100 // 100TB TODO should probably be a var of machine max?
 )
 
 type Routes []*Route

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -32,6 +32,11 @@ func HandleErrorResponse(ctx context.Context, w http.ResponseWriter, err error) 
 		if e.Code() >= 500 {
 			log.WithFields(logrus.Fields{"code": e.Code()}).WithError(e).Error("api error")
 		}
+		if err == models.ErrCallTimeoutServerBusy {
+			// TODO: Determine a better delay value here (perhaps ask Agent). For now 15 secs with
+			// the hopes that fnlb will land this on a better server immediately.
+			w.Header().Set("Retry-After", "15")
+		}
 		statuscode = e.Code()
 	} else {
 		log.WithError(err).WithFields(logrus.Fields{"stack": string(debug.Stack())}).Error("internal server error")

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"path"
 	"strings"
@@ -86,20 +85,14 @@ func (s *Server) serve(c *gin.Context, appName, path string) {
 		return
 	}
 
-	err, execState := s.Agent.Submit(call)
+	err = s.Agent.Submit(call)
 	if err != nil {
 		// NOTE if they cancel the request then it will stop the call (kind of cool),
 		// we could filter that error out here too as right now it yells a little
-		if err == context.DeadlineExceeded {
+		if err == models.ErrCallTimeoutServerBusy || err == models.ErrCallTimeout {
 			// TODO maneuver
 			// add this, since it means that start may not have been called [and it's relevant]
 			c.Writer.Header().Add("XXX-FXLB-WAIT", time.Now().Sub(time.Time(model.CreatedAt)).String())
-
-			if execState == agent.SubmitStateWaitSlot {
-				err = models.ErrCallTimeoutServerBusy // 503 w/ retriable header
-			} else {
-				err = models.ErrCallTimeout // 504 w/ friendly note
-			}
 		}
 		// NOTE: if the task wrote the headers already then this will fail to write
 		// a 5xx (and log about it to us) -- that's fine (nice, even!)

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -234,7 +234,8 @@ func TestFailedEnqueue(t *testing.T) {
 func TestRouteRunnerTimeout(t *testing.T) {
 	buf := setLogBuffer()
 
-	hugeMem := uint64(models.MaxMemory - 1)
+	models.RouteMaxMemory = uint64(1024 * 1024 * 1024) // 1024 TB
+	hugeMem := uint64(models.RouteMaxMemory - 1)
 
 	ds := datastore.NewMockInit(
 		[]*models.App{


### PR DESCRIPTION
*) Adding 503 with Retry-After header case if request failed
during waiting for slots.
*) Increased MaxMemory for routes to 100TB.
*) TODO: return 503 without Retry-After if the request can
never be met by this fn server.

closes #509