### PR TITLE
Call metrics

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -414,8 +414,9 @@ func cherryPick(ds *docker.Stats) drivers.Stat {
 			"net_rx": uint64(rx),
 			"net_tx": uint64(tx),
 			// mem
-			"mem_limit": ds.MemoryStats.Limit,
-			"mem_usage": ds.MemoryStats.Usage,
+			"mem_limit":     ds.MemoryStats.Limit,
+			"mem_usage":     ds.MemoryStats.Usage,
+			"mem_max_usage": ds.MemoryStats.MaxUsage,
 			// i/o
 			"disk_read":  blkRead,
 			"disk_write": blkWrite,

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -369,7 +369,6 @@ func (drv *DockerDriver) collectStats(ctx context.Context, stopSignal <-chan str
 			if !stats.Timestamp.IsZero() {
 				task.WriteStat(ctx, stats)
 			}
-
 		}
 	}
 }

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/fnproject/fn/api/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/jmoiron/sqlx"
 	"github.com/opentracing/opentracing-go"
 )
@@ -83,6 +84,18 @@ func (m *metricds) InsertCall(ctx context.Context, call *models.Call) error {
 	return m.ds.InsertCall(ctx, call)
 }
 
+func (m *metricds) UpdateCallStatus(ctx context.Context, appName, callID, status string, completedAt strfmt.DateTime) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ds_update_call_status")
+	defer span.Finish()
+	return m.ds.UpdateCallStatus(ctx, appName, callID, status, completedAt)
+}
+
+func (m *metricds) UpdateCallMetrics(ctx context.Context, appName, callID string, CPUUsage, MemoryUsage uint64) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ds_update_call_metrics")
+	defer span.Finish()
+	return m.ds.UpdateCallMetrics(ctx, appName, callID, CPUUsage, MemoryUsage)
+}
+
 func (m *metricds) GetCall(ctx context.Context, appName, callID string) (*models.Call, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ds_get_call")
 	defer span.Finish()
@@ -115,9 +128,3 @@ func (m *metricds) DeleteLog(ctx context.Context, appName, callID string) error 
 
 // instant & no context ;)
 func (m *metricds) GetDatabase() *sqlx.DB { return m.ds.GetDatabase() }
-
-func (m *metricds) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ds_insert_call_stats")
-	defer span.Finish()
-	return m.ds.InsertCallStat(ctx, callStat)
-}

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -115,3 +115,9 @@ func (m *metricds) DeleteLog(ctx context.Context, appName, callID string) error 
 
 // instant & no context ;)
 func (m *metricds) GetDatabase() *sqlx.DB { return m.ds.GetDatabase() }
+
+func (m *metricds) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ds_insert_call_stats")
+	defer span.Finish()
+	return m.ds.InsertCallStat(ctx, callStat)
+}

--- a/api/datastore/internal/datastoreutil/validator.go
+++ b/api/datastore/internal/datastoreutil/validator.go
@@ -138,7 +138,3 @@ func (v *validator) DeleteLog(ctx context.Context, appName, callID string) error
 func (v *validator) GetDatabase() *sqlx.DB {
 	return v.Datastore.GetDatabase()
 }
-
-func (v *validator) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
-	return v.Datastore.InsertCallStat(ctx, callStat)
-}

--- a/api/datastore/internal/datastoreutil/validator.go
+++ b/api/datastore/internal/datastoreutil/validator.go
@@ -138,3 +138,7 @@ func (v *validator) DeleteLog(ctx context.Context, appName, callID string) error
 func (v *validator) GetDatabase() *sqlx.DB {
 	return v.Datastore.GetDatabase()
 }
+
+func (v *validator) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
+	return v.Datastore.InsertCallStat(ctx, callStat)
+}

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fnproject/fn/api/datastore/internal/datastoreutil"
 	"github.com/fnproject/fn/api/logs"
 	"github.com/fnproject/fn/api/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -180,6 +181,28 @@ func (m *mock) Get(ctx context.Context, key []byte) ([]byte, error) {
 func (m *mock) InsertCall(ctx context.Context, call *models.Call) error {
 	m.Calls = append(m.Calls, call)
 	return nil
+}
+
+func (m *mock) UpdateCallStatus(ctx context.Context, appName, callID, status string, completedAt strfmt.DateTime) error {
+	for i, oldCall := range m.Calls {
+		if oldCall.ID == callID && oldCall.AppName == appName {
+			m.Calls[i].Status = status
+			m.Calls[i].CompletedAt = completedAt
+			return nil
+		}
+	}
+	return models.ErrCallNotFound
+}
+
+func (m *mock) UpdateCallMetrics(ctx context.Context, appName, callID string, CPUUsage, MemoryUsage uint64) error {
+	for i, oldCall := range m.Calls {
+		if oldCall.ID == callID && oldCall.AppName == appName {
+			m.Calls[i].CPUUsage = CPUUsage
+			m.Calls[i].MemoryUsage = MemoryUsage
+			return nil
+		}
+	}
+	return models.ErrCallNotFound
 }
 
 func (m *mock) GetCall(ctx context.Context, appName, callID string) (*models.Call, error) {

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fnproject/fn/api/datastore/sql/migrations"
 	"github.com/fnproject/fn/api/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -65,6 +66,8 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	id varchar(256) NOT NULL,
 	app_name varchar(256) NOT NULL,
 	path varchar(256) NOT NULL,
+	memory_usage int NOT NULL,
+	cpu_usage int NOT NULL,
 	PRIMARY KEY (id)
 );`,
 
@@ -73,18 +76,11 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	app_name varchar(256) NOT NULL,
 	log text NOT NULL
 );`,
-
-	`CREATE TABLE IF NOT EXISTS call_stats (
-	id varchar(256) NOT NULL PRIMARY KEY,
-	app_name varchar(256) NOT NULL,
-	memory_usage int NOT NULL,
-	cpu_usage int NOT NULL,
-);`,
 }
 
 const (
 	routeSelector = `SELECT app_name, path, image, format, memory, type, timeout, idle_timeout, headers, config, created_at FROM routes`
-	callSelector  = `SELECT id, created_at, started_at, completed_at, status, app_name, path FROM calls`
+	callSelector  = `SELECT id, created_at, started_at, completed_at, status, app_name, path, cpu_usage, memory_usage FROM calls`
 )
 
 type sqlStore struct {
@@ -592,7 +588,9 @@ func (ds *sqlStore) InsertCall(ctx context.Context, call *models.Call) error {
 		completed_at,
 		status,
 		app_name,
-		path
+		path,
+		memory_usage,
+		cpu_usage
 	)
 	VALUES (
 		:id,
@@ -601,11 +599,63 @@ func (ds *sqlStore) InsertCall(ctx context.Context, call *models.Call) error {
 		:completed_at,
 		:status,
 		:app_name,
-		:path
+		:path,
+		:memory_usage,
+		:cpu_usage
 	);`)
-
 	_, err := ds.db.NamedExecContext(ctx, query, call)
 	return err
+}
+
+func (ds *sqlStore) updateCall(ctx context.Context, appName, callID, callQuery string, args ...interface{}) error {
+	var call models.Call
+	err := ds.Tx(func(tx *sqlx.Tx) error {
+		query := tx.Rebind(fmt.Sprintf("%s WHERE id=? AND app_name=?", callSelector))
+		row := tx.QueryRowxContext(ctx, query, callID, appName)
+
+		err := row.StructScan(&call)
+		if err == sql.ErrNoRows {
+			return models.ErrCallNotFound
+		} else if err != nil {
+			return err
+		}
+
+		args = append(args, callID)
+		res, err := tx.ExecContext(ctx, tx.Rebind(callQuery), args...)
+		if err != nil {
+			return err
+		}
+
+		if n, err := res.RowsAffected(); err != nil {
+			return err
+		} else if n == 0 {
+			// inside of the transaction, we are querying for the row, so we know that it exists
+			return nil
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ds *sqlStore) UpdateCallStatus(ctx context.Context, appName, callID, status string, completedAt strfmt.DateTime) error {
+	query := `UPDATE calls SET
+			status = ?,
+			completed_at = ?
+		WHERE id=?;`
+	return ds.updateCall(ctx, appName, callID, query, status, completedAt)
+}
+
+func (ds *sqlStore) UpdateCallMetrics(ctx context.Context, appName, callID string, CPUUsage, MemoryUsage uint64) error {
+	query := `UPDATE calls SET
+			cpu_usage = ?,
+			memory_usage = ?
+		WHERE id=?;`
+	return ds.updateCall(ctx, appName, callID, query, CPUUsage, MemoryUsage)
 }
 
 func (ds *sqlStore) GetCall(ctx context.Context, appName, callID string) (*models.Call, error) {
@@ -790,22 +840,4 @@ func buildFilterCallQuery(filter *models.CallFilter) (string, []interface{}) {
 // GetDatabase returns the underlying sqlx database implementation
 func (ds *sqlStore) GetDatabase() *sqlx.DB {
 	return ds.db
-}
-
-func (ds *sqlStore) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
-	query := ds.db.Rebind(`INSERT INTO call_stats (
-		id,
-		app_name,
-		memory_usage,
-		cpu_usage,
-	)
-	VALUES (
-		:id,
-		:app_name,
-		:memory_usage,
-		:cpu_usage,
-	);`)
-
-	_, err := ds.db.NamedExecContext(ctx, query, callStat)
-	return err
 }

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -73,6 +73,13 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	app_name varchar(256) NOT NULL,
 	log text NOT NULL
 );`,
+
+	`CREATE TABLE IF NOT EXISTS call_stats (
+	id varchar(256) NOT NULL PRIMARY KEY,
+	app_name varchar(256) NOT NULL,
+	memory_usage int NOT NULL,
+	cpu_usage int NOT NULL,
+);`,
 }
 
 const (
@@ -783,4 +790,22 @@ func buildFilterCallQuery(filter *models.CallFilter) (string, []interface{}) {
 // GetDatabase returns the underlying sqlx database implementation
 func (ds *sqlStore) GetDatabase() *sqlx.DB {
 	return ds.db
+}
+
+func (ds *sqlStore) InsertCallStat(ctx context.Context, callStat models.CallStat) error {
+	query := ds.db.Rebind(`INSERT INTO call_stats (
+		id,
+		app_name,
+		memory_usage,
+		cpu_usage,
+	)
+	VALUES (
+		:id,
+		:app_name,
+		:memory_usage,
+		:cpu_usage,
+	);`)
+
+	_, err := ds.db.NamedExecContext(ctx, query, callStat)
+	return err
 }

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -30,6 +30,13 @@ type CallLog struct {
 	AppName string `json:"app_name" db:"app_name"`
 }
 
+type CallStat struct {
+	CallID      string `json:"call_id" db:"id"`
+	MemoryUsage uint64 `json:"memory_usage" db:"memory_usage"`
+	CPUUsage    uint64 `json:"cpu_usage" db:"cpu_usage"`
+	AppName     string `json:"app_name" db:"app_name"`
+}
+
 // Call is a representation of a specific invocation of a route.
 type Call struct {
 	// Unique identifier representing a specific call.

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -30,13 +30,6 @@ type CallLog struct {
 	AppName string `json:"app_name" db:"app_name"`
 }
 
-type CallStat struct {
-	CallID      string `json:"call_id" db:"id"`
-	MemoryUsage uint64 `json:"memory_usage" db:"memory_usage"`
-	CPUUsage    uint64 `json:"cpu_usage" db:"cpu_usage"`
-	AppName     string `json:"app_name" db:"app_name"`
-}
-
 // Call is a representation of a specific invocation of a route.
 type Call struct {
 	// Unique identifier representing a specific call.
@@ -135,7 +128,9 @@ type Call struct {
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at"`
 
 	// Time when call started execution. Always in UTC.
-	StartedAt strfmt.DateTime `json:"started_at,omitempty" db:"started_at"`
+	StartedAt   strfmt.DateTime `json:"started_at,omitempty" db:"started_at"`
+	MemoryUsage uint64          `json:"memory_usage" db:"memory_usage"`
+	CPUUsage    uint64          `json:"cpu_usage" db:"cpu_usage"`
 }
 
 type CallFilter struct {

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -69,4 +69,7 @@ type Datastore interface {
 
 	// GetDatabase returns the underlying sqlx database implementation
 	GetDatabase() *sqlx.DB
+
+	// InsertCallStat
+	InsertCallStat(ctx context.Context, stat CallStat) error
 }

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -57,6 +58,12 @@ type Datastore interface {
 	// exists.
 	InsertCall(ctx context.Context, call *Call) error
 
+	// UpdateCallMetrics updates call
+	UpdateCallMetrics(ctx context.Context, appName, callID string, CPUUsage, MemoryUsage uint64) error
+
+	// UpdateCallMetrics updates call
+	UpdateCallStatus(ctx context.Context, appName, callID, status string, completedAt strfmt.DateTime) error
+
 	// GetCall returns a call at a certain id and app name.
 	GetCall(ctx context.Context, appName, callID string) (*Call, error)
 
@@ -69,7 +76,4 @@ type Datastore interface {
 
 	// GetDatabase returns the underlying sqlx database implementation
 	GetDatabase() *sqlx.DB
-
-	// InsertCallStat
-	InsertCallStat(ctx context.Context, stat CallStat) error
 }


### PR DESCRIPTION
Adding RAM/CPU metrics to call object

This PR splits call object creation at the backend in three steps:
1. Fn creates call object with `running` status when agent calls `call.Start`
2. Fn updates call object when status and completed_at available when agent calls `call.End`
3. Docker driver writes updates call object with CPU and RAM usage.

The idea of this PR to provide basic call metrics in addition to those presented such as status, created|started|completed_at timestamps.

Workaround for #522:
Write call metrics once then unset call ID to prevent metrics being overridden.

Known issue: #524 short-lived calls would not get their portion of stats due to races between docker stats and call context completion.

Closes: #19 