### PR TITLE
add error to call model

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -181,7 +181,6 @@ func transformTimeout(e error, isRetriable bool) error {
 }
 
 func (a *agent) Submit(callI Call) error {
-
 	a.wg.Add(1)
 	defer a.wg.Done()
 
@@ -217,7 +216,7 @@ func (a *agent) Submit(callI Call) error {
 	defer slot.Close() // notify our slot is free once we're done
 
 	// TODO Start is checking the timer now, we could do it here, too.
-	err = call.Start(ctx, a)
+	err = call.Start(ctx)
 	if err != nil {
 		a.stats.Dequeue(callI.Model().Path)
 		return transformTimeout(err, true)
@@ -241,7 +240,7 @@ func (a *agent) Submit(callI Call) error {
 	// TODO: we need to allocate more time to store the call + logs in case the call timed out,
 	// but this could put us over the timeout if the call did not reply yet (need better policy).
 	ctx = opentracing.ContextWithSpan(context.Background(), span)
-	err = call.End(ctx, err, a)
+	err = call.End(ctx, err)
 	return transformTimeout(err, false)
 }
 

--- a/api/datastore/internal/datastoretest/test.go
+++ b/api/datastore/internal/datastoretest/test.go
@@ -37,7 +37,8 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 
 	call := new(models.Call)
 	call.CreatedAt = strfmt.DateTime(time.Now())
-	call.Status = "success"
+	call.Status = "error"
+	call.Error = "ya dun goofed"
 	call.StartedAt = strfmt.DateTime(time.Now())
 	call.CompletedAt = strfmt.DateTime(time.Now())
 	call.AppName = testApp.Name
@@ -55,13 +56,37 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 	t.Run("call-get", func(t *testing.T) {
 		ds := dsf(t)
 		call.ID = id.New().String()
-		ds.InsertCall(ctx, call)
+		err := ds.InsertCall(ctx, call)
+		if err != nil {
+			t.Fatalf("Test GetCall: unexpected error `%v`", err)
+		}
 		newCall, err := ds.GetCall(ctx, call.AppName, call.ID)
 		if err != nil {
-			t.Fatalf("Test GetCall(ctx, call.ID): unexpected error `%v`", err)
+			t.Fatalf("Test GetCall: unexpected error `%v`", err)
 		}
 		if call.ID != newCall.ID {
-			t.Fatalf("Test GetCall(ctx, call.ID): unexpected error `%v`", err)
+			t.Fatalf("Test GetCall: id mismatch `%v` `%v`", call.ID, newCall.ID)
+		}
+		if call.Status != newCall.Status {
+			t.Fatalf("Test GetCall: status mismatch `%v` `%v`", call.Status, newCall.Status)
+		}
+		if call.Error != newCall.Error {
+			t.Fatalf("Test GetCall: error mismatch `%v` `%v`", call.Error, newCall.Error)
+		}
+		if time.Time(call.CreatedAt).Unix() != time.Time(newCall.CreatedAt).Unix() {
+			t.Fatalf("Test GetCall: created_at mismatch `%v` `%v`", call.CreatedAt, newCall.CreatedAt)
+		}
+		if time.Time(call.StartedAt).Unix() != time.Time(newCall.StartedAt).Unix() {
+			t.Fatalf("Test GetCall: started_at mismatch `%v` `%v`", call.StartedAt, newCall.StartedAt)
+		}
+		if time.Time(call.CompletedAt).Unix() != time.Time(newCall.CompletedAt).Unix() {
+			t.Fatalf("Test GetCall: completed_at mismatch `%v` `%v`", call.CompletedAt, newCall.CompletedAt)
+		}
+		if call.AppName != newCall.AppName {
+			t.Fatalf("Test GetCall: app_name mismatch `%v` `%v`", call.AppName, newCall.AppName)
+		}
+		if call.Path != newCall.Path {
+			t.Fatalf("Test GetCall: path mismatch `%v` `%v`", call.Path, newCall.Path)
 		}
 	})
 

--- a/api/datastore/sql/migrations/3_add_call_error.down.sql
+++ b/api/datastore/sql/migrations/3_add_call_error.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls DROP COLUMN error;

--- a/api/datastore/sql/migrations/3_add_call_error.up.sql
+++ b/api/datastore/sql/migrations/3_add_call_error.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls ADD error text;

--- a/api/datastore/sql/migrations/migrations.go
+++ b/api/datastore/sql/migrations/migrations.go
@@ -4,6 +4,8 @@
 // 1_add_route_created_at.up.sql
 // 2_add_call_stats.down.sql
 // 2_add_call_stats.up.sql
+// 3_add_call_error.down.sql
+// 3_add_call_error.up.sql
 // DO NOT EDIT!
 
 package migrations
@@ -86,7 +88,7 @@ func _1_add_route_created_atDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1_add_route_created_at.down.sql", size: 43, mode: os.FileMode(420), modTime: time.Unix(1510786558, 0)}
+	info := bindataFileInfo{name: "1_add_route_created_at.down.sql", size: 43, mode: os.FileMode(420), modTime: time.Unix(1511259011, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -106,7 +108,7 @@ func _1_add_route_created_atUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1_add_route_created_at.up.sql", size: 40, mode: os.FileMode(420), modTime: time.Unix(1510786558, 0)}
+	info := bindataFileInfo{name: "1_add_route_created_at.up.sql", size: 40, mode: os.FileMode(420), modTime: time.Unix(1511259011, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -126,7 +128,7 @@ func _2_add_call_statsDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "2_add_call_stats.down.sql", size: 37, mode: os.FileMode(420), modTime: time.Unix(1511225799, 0)}
+	info := bindataFileInfo{name: "2_add_call_stats.down.sql", size: 37, mode: os.FileMode(420), modTime: time.Unix(1511259011, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -146,7 +148,47 @@ func _2_add_call_statsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "2_add_call_stats.up.sql", size: 34, mode: os.FileMode(420), modTime: time.Unix(1511225651, 0)}
+	info := bindataFileInfo{name: "2_add_call_stats.up.sql", size: 34, mode: os.FileMode(420), modTime: time.Unix(1511259011, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __3_add_call_errorDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\xc9\x29\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x2d\x2a\xca\x2f\xb2\xe6\x02\x04\x00\x00\xff\xff\xc1\x14\x26\x51\x25\x00\x00\x00")
+
+func _3_add_call_errorDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__3_add_call_errorDownSql,
+		"3_add_call_error.down.sql",
+	)
+}
+
+func _3_add_call_errorDownSql() (*asset, error) {
+	bytes, err := _3_add_call_errorDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "3_add_call_error.down.sql", size: 37, mode: os.FileMode(420), modTime: time.Unix(1511265731, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __3_add_call_errorUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x4e\xcc\xc9\x29\x56\x70\x74\x71\x51\x48\x2d\x2a\xca\x2f\x52\x28\x49\xad\x28\xb1\xe6\x02\x04\x00\x00\xff\xff\xaf\xba\x27\xcd\x22\x00\x00\x00")
+
+func _3_add_call_errorUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__3_add_call_errorUpSql,
+		"3_add_call_error.up.sql",
+	)
+}
+
+func _3_add_call_errorUpSql() (*asset, error) {
+	bytes, err := _3_add_call_errorUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "3_add_call_error.up.sql", size: 34, mode: os.FileMode(420), modTime: time.Unix(1511265909, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -204,9 +246,11 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"1_add_route_created_at.down.sql": _1_add_route_created_atDownSql,
-	"1_add_route_created_at.up.sql":   _1_add_route_created_atUpSql,
-	"2_add_call_stats.down.sql":       _2_add_call_statsDownSql,
-	"2_add_call_stats.up.sql":         _2_add_call_statsUpSql,
+	"1_add_route_created_at.up.sql": _1_add_route_created_atUpSql,
+	"2_add_call_stats.down.sql": _2_add_call_statsDownSql,
+	"2_add_call_stats.up.sql": _2_add_call_statsUpSql,
+	"3_add_call_error.down.sql": _3_add_call_errorDownSql,
+	"3_add_call_error.up.sql": _3_add_call_errorUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -248,12 +292,13 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"1_add_route_created_at.down.sql": &bintree{_1_add_route_created_atDownSql, map[string]*bintree{}},
-	"1_add_route_created_at.up.sql":   &bintree{_1_add_route_created_atUpSql, map[string]*bintree{}},
-	"2_add_call_stats.down.sql":       &bintree{_2_add_call_statsDownSql, map[string]*bintree{}},
-	"2_add_call_stats.up.sql":         &bintree{_2_add_call_statsUpSql, map[string]*bintree{}},
+	"1_add_route_created_at.up.sql": &bintree{_1_add_route_created_atUpSql, map[string]*bintree{}},
+	"2_add_call_stats.down.sql": &bintree{_2_add_call_statsDownSql, map[string]*bintree{}},
+	"2_add_call_stats.up.sql": &bintree{_2_add_call_statsUpSql, map[string]*bintree{}},
+	"3_add_call_error.down.sql": &bintree{_3_add_call_errorDownSql, map[string]*bintree{}},
+	"3_add_call_error.up.sql": &bintree{_3_add_call_errorUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -302,3 +347,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/api/datastore/sql/migrations/migrations.go
+++ b/api/datastore/sql/migrations/migrations.go
@@ -246,11 +246,11 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"1_add_route_created_at.down.sql": _1_add_route_created_atDownSql,
-	"1_add_route_created_at.up.sql": _1_add_route_created_atUpSql,
-	"2_add_call_stats.down.sql": _2_add_call_statsDownSql,
-	"2_add_call_stats.up.sql": _2_add_call_statsUpSql,
-	"3_add_call_error.down.sql": _3_add_call_errorDownSql,
-	"3_add_call_error.up.sql": _3_add_call_errorUpSql,
+	"1_add_route_created_at.up.sql":   _1_add_route_created_atUpSql,
+	"2_add_call_stats.down.sql":       _2_add_call_statsDownSql,
+	"2_add_call_stats.up.sql":         _2_add_call_statsUpSql,
+	"3_add_call_error.down.sql":       _3_add_call_errorDownSql,
+	"3_add_call_error.up.sql":         _3_add_call_errorUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -292,13 +292,14 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"1_add_route_created_at.down.sql": &bintree{_1_add_route_created_atDownSql, map[string]*bintree{}},
-	"1_add_route_created_at.up.sql": &bintree{_1_add_route_created_atUpSql, map[string]*bintree{}},
-	"2_add_call_stats.down.sql": &bintree{_2_add_call_statsDownSql, map[string]*bintree{}},
-	"2_add_call_stats.up.sql": &bintree{_2_add_call_statsUpSql, map[string]*bintree{}},
-	"3_add_call_error.down.sql": &bintree{_3_add_call_errorDownSql, map[string]*bintree{}},
-	"3_add_call_error.up.sql": &bintree{_3_add_call_errorUpSql, map[string]*bintree{}},
+	"1_add_route_created_at.up.sql":   &bintree{_1_add_route_created_atUpSql, map[string]*bintree{}},
+	"2_add_call_stats.down.sql":       &bintree{_2_add_call_statsDownSql, map[string]*bintree{}},
+	"2_add_call_stats.up.sql":         &bintree{_2_add_call_statsUpSql, map[string]*bintree{}},
+	"3_add_call_error.down.sql":       &bintree{_3_add_call_errorDownSql, map[string]*bintree{}},
+	"3_add_call_error.up.sql":         &bintree{_3_add_call_errorUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -347,4 +348,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -66,6 +66,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	app_name varchar(256) NOT NULL,
 	path varchar(256) NOT NULL,
 	stats text,
+	error text,
 	PRIMARY KEY (id)
 );`,
 
@@ -78,7 +79,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 
 const (
 	routeSelector = `SELECT app_name, path, image, format, memory, type, timeout, idle_timeout, headers, config, created_at FROM routes`
-	callSelector  = `SELECT id, created_at, started_at, completed_at, status, app_name, path, stats FROM calls`
+	callSelector  = `SELECT id, created_at, started_at, completed_at, status, app_name, path, stats, error FROM calls`
 )
 
 type sqlStore struct {
@@ -587,7 +588,8 @@ func (ds *sqlStore) InsertCall(ctx context.Context, call *models.Call) error {
 		status,
 		app_name,
 		path,
-		stats
+		stats,
+		error
 	)
 	VALUES (
 		:id,
@@ -597,7 +599,8 @@ func (ds *sqlStore) InsertCall(ctx context.Context, call *models.Call) error {
 		:status,
 		:app_name,
 		:path,
-		:stats
+		:stats,
+		:error
 	);`)
 
 	_, err := ds.db.NamedExecContext(ctx, query, call)

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -133,6 +133,10 @@ type Call struct {
 
 	// Stats is a list of metrics from this call's execution, possibly empty.
 	Stats drivers.Stats `json:"stats,omitempty" db:"stats"`
+
+	// Error is the reason why the call failed, it is only non-empty if
+	// status is equal to "error".
+	Error string `json:"error,omitempty" db:"error"`
 }
 
 type CallFilter struct {

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -646,6 +646,10 @@ definitions:
         type: string
         description: Call execution status.
         readOnly: true
+      error:
+        type: string
+        description: Call execution error, if status is 'error'.
+        readOnly: true
       app_name:
         type: string
         description: App name that is assigned to a route that is being executed.

--- a/test.sh
+++ b/test.sh
@@ -28,7 +28,11 @@ docker rm -fv func-mysql-test || echo No prev mysql test db container
 docker run --name func-mysql-test -p 3306:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql
 docker rm -fv func-minio-test || echo No prev minio test container
 docker run -d -p 9000:9000 --name func-minio-test -e "MINIO_ACCESS_KEY=admin" -e "MINIO_SECRET_KEY=password" minio/minio server /data
-sleep 5
+
+# pull all images used in tests so that tests don't time out and fail spuriously
+docker pull fnproject/sleeper
+docker pull fnproject/error
+docker pull fnproject/hello
 
 MYSQL_HOST=`host func-mysql-test`
 MYSQL_PORT=3306


### PR DESCRIPTION
closes #331

previously, for async this error was being masked completely even if it was
something useful like the image not existing. for sync, the error was returned
in the http request but now it's also being stored. this error itself can
cover a lot of landscape, it could be an error in getting a slot, pulling an
image, running a container, among other things. anyway, no longer being
masked. we can likely improve it in certain cases we run into in the future,
but it's open ended at the moment and not being masked like some errors in
sync http request returns (503 non-models.APIError) for now.

* tucks in callTrigger stuff to keep api clean
* adds swagger
* adds migration
* adds tests for datastore and agent to ensure behavior