### PR TITLE
Per route api extensions

### DIFF
--- a/api/server/extension_points.go
+++ b/api/server/extension_points.go
@@ -88,7 +88,6 @@ func (s *Server) apiRouteHandlerWrapperFunc(apiHandler ApiRouteHandler) gin.Hand
 			c.Abort()
 			return
 		}
-		println("apiRouteHandlerWrapperFunc")
 		// get the route TODO
 		routePath := "/" + c.Param(api.CRoute)
 		route, err := s.Datastore.GetRoute(c.Request.Context(), appName, routePath)

--- a/api/server/extension_points.go
+++ b/api/server/extension_points.go
@@ -75,9 +75,10 @@ func (f ApiRouteHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, a
 
 func (s *Server) apiRouteHandlerWrapperFunc(apiHandler ApiRouteHandler) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		context := c.Request.Context()
 		// get the app
 		appName := c.Param(api.CApp)
-		app, err := s.Datastore.GetApp(c.Request.Context(), appName)
+		app, err := s.Datastore.GetApp(context, appName)
 		if err != nil {
 			handleErrorResponse(c, err)
 			c.Abort()
@@ -90,7 +91,7 @@ func (s *Server) apiRouteHandlerWrapperFunc(apiHandler ApiRouteHandler) gin.Hand
 		}
 		// get the route TODO
 		routePath := "/" + c.Param(api.CRoute)
-		route, err := s.Datastore.GetRoute(c.Request.Context(), appName, routePath)
+		route, err := s.Datastore.GetRoute(context, appName, routePath)
 		if err != nil {
 			handleErrorResponse(c, err)
 			c.Abort()

--- a/api/server/routes_get.go
+++ b/api/server/routes_get.go
@@ -12,8 +12,7 @@ func (s *Server) handleRouteGet(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	appName := c.MustGet(api.AppName).(string)
-	routePath := path.Clean(c.MustGet(api.Path).(string))
-
+	routePath := path.Clean("/" + c.MustGet(api.Path).(string))
 	route, err := s.Datastore.GetRoute(ctx, appName, routePath)
 	if err != nil {
 		handleErrorResponse(c, err)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -345,7 +345,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 
 			apps.GET("/routes", s.handleRouteList)
 			apps.POST("/routes", s.handleRoutesPostPutPatch)
-			apps.GET("/routes/*route", s.handleRouteGet)
+			apps.GET("/routes/:route", s.handleRouteGet) //
 			apps.PATCH("/routes/*route", s.handleRoutesPostPutPatch)
 			apps.PUT("/routes/*route", s.handleRoutesPostPutPatch)
 			apps.DELETE("/routes/*route", s.handleRouteDelete)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -345,7 +345,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 
 			apps.GET("/routes", s.handleRouteList)
 			apps.POST("/routes", s.handleRoutesPostPutPatch)
-			apps.GET("/routes/:route", s.handleRouteGet) //
+			apps.GET("/routes/:route", s.handleRouteGet)
 			apps.PATCH("/routes/*route", s.handleRoutesPostPutPatch)
 			apps.PUT("/routes/*route", s.handleRoutesPostPutPatch)
 			apps.DELETE("/routes/*route", s.handleRouteDelete)

--- a/examples/extensions/README.md
+++ b/examples/extensions/README.md
@@ -19,4 +19,6 @@ curl http://localhost:8080/v1/custom1
 curl http://localhost:8080/v1/custom2
 curl http://localhost:8080/v1/apps/myapp/custom3
 curl http://localhost:8080/v1/apps/myapp/custom4
+curl http://localhost:8080/v1/apps/myapp/routes/myroute/custom5
+curl http://localhost:8080/v1/apps/myapp/routes/myroute/custom5
 ```

--- a/examples/extensions/README.md
+++ b/examples/extensions/README.md
@@ -9,12 +9,9 @@ go build
 ./extensions
 ```
 
-Then test with:
+First create an app `myapp` and a function `myroute`. Then test with:
 
 ```sh
-# First, create an app
-fn apps create myapp
-# And test
 curl http://localhost:8080/v1/custom1
 curl http://localhost:8080/v1/custom2
 curl http://localhost:8080/v1/apps/myapp/custom3

--- a/examples/extensions/main.go
+++ b/examples/extensions/main.go
@@ -29,6 +29,14 @@ func main() {
 		fmt.Println("Custom4Handler called")
 		fmt.Fprintf(w, "Hello app %v func, %q", app.Name, html.EscapeString(r.URL.Path))
 	})
+	// the following will be at /v1/apps/:app_name/routes/:route_name/custom5
+	// and                      /v1/apps/:app_name/routes/:route_name/custom6
+	funcServer.AddRouteEndpoint("GET", "/custom5", &Custom5Handler{})
+	funcServer.AddRouteEndpointFunc("GET", "/custom6", func(w http.ResponseWriter, r *http.Request, app *models.App, route *models.Route) {
+		// fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+		fmt.Println("Custom6Handler called")
+		fmt.Fprintf(w, "Hello app %v, route %v, request %q", app.Name, route.Path, html.EscapeString(r.URL.Path))
+	})
 	funcServer.Start(ctx)
 }
 
@@ -46,4 +54,12 @@ type Custom3Handler struct {
 func (h *Custom3Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, app *models.App) {
 	fmt.Println("Custom3Handler called")
 	fmt.Fprintf(w, "Hello app %v, %q", app.Name, html.EscapeString(r.URL.Path))
+}
+
+type Custom5Handler struct {
+}
+
+func (h *Custom5Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, app *models.App, route *models.Route) {
+	fmt.Println("Custom5Handler called")
+	fmt.Fprintf(w, "Hello! app %v, route %v, request %q", app.Name, route.Path, html.EscapeString(r.URL.Path))
 }


### PR DESCRIPTION
This update extends the API extension mechanism to allow per-route API extensions. These use URLs of the following form:
```
http://localhost:8080/v1/apps/myapp/routes/myroute/custom5
```
The implementation is straightforward except for one thing. This was a runtime conflict between the extension handler and the existing handler in `api/server/server.go` for `/routes/*route`, since the latter uses a wildcard:
```
apps.GET("/routes/*route", s.handleRouteGet)
```
To avoid this I have changed the configuration of the existing handler to use `/routes/:route`, as follows:
```
apps.GET("/routes/:route", s.handleRouteGet)
```
However this means that the matched paths do not include a leading `/` character (which caused "route not found" errors) so I have changed `api/server/routes_get.go` to explicitly prepend the `/`. (Is there a cleaner way to do this?)

I've updated the example extension and the readme.
