### PR TITLE
Add appname to basic metrics

### DIFF
--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -53,28 +53,28 @@ var (
 			Name: "fn_api_queued",
 			Help: "Queued requests by path",
 		},
-		[](string){"app","path"},
+		[](string){"app", "path"},
 	)
 	fnRunning = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fn_api_running",
 			Help: "Running requests by path",
 		},
-		[](string){"app","path"},
+		[](string){"app", "path"},
 	)
 	fnCompleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "fn_api_completed",
 			Help: "Completed requests by path",
 		},
-		[](string){"app","path"},
+		[](string){"app", "path"},
 	)
 	fnFailed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "fn_api_failed",
 			Help: "Failed requests by path",
 		},
-		[](string){"app","path"},
+		[](string){"app", "path"},
 	)
 )
 
@@ -109,12 +109,12 @@ func (s *stats) Enqueue(app string, path string) {
 }
 
 // Call when a function has been queued but cannot be started because of an error
-func (s *stats) Dequeue(path string) {
+func (s *stats) Dequeue(app string, path string) {
 	s.mu.Lock()
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(app,path).Dec()
+	fnQueued.WithLabelValues(app, path).Dec()
 
 	s.mu.Unlock()
 }
@@ -124,11 +124,11 @@ func (s *stats) DequeueAndStart(app string, path string) {
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(app,path).Dec()
+	fnQueued.WithLabelValues(app, path).Dec()
 
 	s.running++
 	s.getStatsForFunction(path).running++
-	fnRunning.WithLabelValues(app,path).Inc()
+	fnRunning.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }
@@ -138,11 +138,11 @@ func (s *stats) Complete(app string, path string) {
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	fnRunning.WithLabelValues(app,path).Dec()
+	fnRunning.WithLabelValues(app, path).Dec()
 
 	s.complete++
 	s.getStatsForFunction(path).complete++
-	fnCompleted.WithLabelValues(app,path).Inc()
+	fnCompleted.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }
@@ -152,11 +152,11 @@ func (s *stats) Failed(app string, path string) {
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	fnRunning.WithLabelValues(app,path).Dec()
+	fnRunning.WithLabelValues(app, path).Dec()
 
 	s.failed++
 	s.getStatsForFunction(path).failed++
-	fnFailed.WithLabelValues(app,path).Inc()
+	fnFailed.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }
@@ -166,11 +166,11 @@ func (s *stats) DequeueAndFail(app string, path string) {
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(app,path).Dec()
+	fnQueued.WithLabelValues(app, path).Dec()
 
 	s.failed++
 	s.getStatsForFunction(path).failed++
-	fnFailed.WithLabelValues(app,path).Inc()
+	fnFailed.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -103,7 +103,7 @@ func (s *stats) Enqueue(app string, path string) {
 
 	s.queue++
 	s.getStatsForFunction(path).queue++
-	fnQueued.WithLabelValues(path).Inc()
+	fnQueued.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -53,28 +53,28 @@ var (
 			Name: "fn_api_queued",
 			Help: "Queued requests by path",
 		},
-		[](string){"path"},
+		[](string){"app","path"},
 	)
 	fnRunning = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fn_api_running",
 			Help: "Running requests by path",
 		},
-		[](string){"path"},
+		[](string){"app","path"},
 	)
 	fnCompleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "fn_api_completed",
 			Help: "Completed requests by path",
 		},
-		[](string){"path"},
+		[](string){"app","path"},
 	)
 	fnFailed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "fn_api_failed",
 			Help: "Failed requests by path",
 		},
-		[](string){"path"},
+		[](string){"app","path"},
 	)
 )
 
@@ -98,7 +98,7 @@ func (s *stats) getStatsForFunction(path string) *functionStats {
 	return thisFunctionStats
 }
 
-func (s *stats) Enqueue(path string) {
+func (s *stats) Enqueue(app string, path string) {
 	s.mu.Lock()
 
 	s.queue++
@@ -114,63 +114,63 @@ func (s *stats) Dequeue(path string) {
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(path).Dec()
+	fnQueued.WithLabelValues(app,path).Dec()
 
 	s.mu.Unlock()
 }
 
-func (s *stats) DequeueAndStart(path string) {
+func (s *stats) DequeueAndStart(app string, path string) {
 	s.mu.Lock()
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(path).Dec()
+	fnQueued.WithLabelValues(app,path).Dec()
 
 	s.running++
 	s.getStatsForFunction(path).running++
-	fnRunning.WithLabelValues(path).Inc()
+	fnRunning.WithLabelValues(app,path).Inc()
 
 	s.mu.Unlock()
 }
 
-func (s *stats) Complete(path string) {
+func (s *stats) Complete(app string, path string) {
 	s.mu.Lock()
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	fnRunning.WithLabelValues(path).Dec()
+	fnRunning.WithLabelValues(app,path).Dec()
 
 	s.complete++
 	s.getStatsForFunction(path).complete++
-	fnCompleted.WithLabelValues(path).Inc()
+	fnCompleted.WithLabelValues(app,path).Inc()
 
 	s.mu.Unlock()
 }
 
-func (s *stats) Failed(path string) {
+func (s *stats) Failed(app string, path string) {
 	s.mu.Lock()
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	fnRunning.WithLabelValues(path).Dec()
+	fnRunning.WithLabelValues(app,path).Dec()
 
 	s.failed++
 	s.getStatsForFunction(path).failed++
-	fnFailed.WithLabelValues(path).Inc()
+	fnFailed.WithLabelValues(app,path).Inc()
 
 	s.mu.Unlock()
 }
 
-func (s *stats) DequeueAndFail(path string) {
+func (s *stats) DequeueAndFail(app string, path string) {
 	s.mu.Lock()
 
 	s.queue--
 	s.getStatsForFunction(path).queue--
-	fnQueued.WithLabelValues(path).Dec()
+	fnQueued.WithLabelValues(app,path).Dec()
 
 	s.failed++
 	s.getStatsForFunction(path).failed++
-	fnFailed.WithLabelValues(path).Inc()
+	fnFailed.WithLabelValues(app,path).Inc()
 
 	s.mu.Unlock()
 }

--- a/examples/grafana/fn_grafana_dashboard.json
+++ b/examples/grafana/fn_grafana_dashboard.json
@@ -54,7 +54,7 @@
   "hideControls": false,
   "id": null,
   "links": [],
-  "refresh": false,
+  "refresh": "30s",
   "rows": [
     {
       "collapse": false,
@@ -1076,5 +1076,5 @@
   },
   "timezone": "",
   "title": "Fn usage",
-  "version": 2
+  "version": 5
 }

--- a/examples/grafana/fn_grafana_dashboard.json
+++ b/examples/grafana/fn_grafana_dashboard.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.5.2"
+      "version": "4.6.2"
     },
     {
       "type": "panel",
@@ -36,7 +36,17 @@
     }
   ],
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
@@ -721,6 +731,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
+          "seriesOverrides": [],
           "spaceLength": 10,
           "span": 3,
           "stack": false,
@@ -731,7 +742,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{path}}",
+              "legendFormat": "{{app}} {{path}}",
               "refId": "A",
               "step": 1
             }
@@ -814,7 +825,7 @@
               "expr": "fn_api_running",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{path}}",
+              "legendFormat": "{{app}} {{path}}",
               "refId": "A",
               "step": 2
             }
@@ -896,7 +907,7 @@
               "expr": "fn_api_completed",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{path}}",
+              "legendFormat": "{{app}} {{path}}",
               "refId": "A",
               "step": 2
             }
@@ -978,7 +989,7 @@
               "expr": "fn_api_failed",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{path}}",
+              "legendFormat": "{{app}} {{path}}",
               "refId": "A",
               "step": 2
             }
@@ -1065,5 +1076,5 @@
   },
   "timezone": "",
   "title": "Fn usage",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This PR extends the existing Prometheus metrics `fn_api_queued`, `fn_api_running`, `fn_api_completed` and `fn_api_failed` to add a label containing the name of the application. This makes it consistent with other Prometheus metrics, and is needed to support new features in the `ext_metrics` repo. 