### PR TITLE
More metrics

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -195,19 +195,19 @@ func (a *agent) Submit(callI Call) error {
 
 	call := callI.(*call)
 	ctx := call.req.Context()
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit")
-	span.SetBaggageItem("fn_appname", callI.Model().AppName)
-	span.SetBaggageItem("fn_path", callI.Model().Path)
-	defer span.Finish()
+	
+	// start spans in the correct order so each span is given, and inherits, the correct baggage
+	span_global, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
+	defer span_global.Finish()
 	
 	span_app,_ := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
 	span_app.SetBaggageItem("fn_appname", callI.Model().AppName)
 	defer span_app.Finish()
 
-	span_global, _ := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
-	defer span_global.Finish()
-
+	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit")
+	span.SetBaggageItem("fn_path", callI.Model().Path)
+	defer span.Finish()
+	
 	// start the timer STAT! TODO add some wiggle room
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(call.Timeout)*time.Second)
 	call.req = call.req.WithContext(ctx)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -195,19 +195,19 @@ func (a *agent) Submit(callI Call) error {
 
 	call := callI.(*call)
 	ctx := call.req.Context()
-	
+
 	// start spans in the correct order so each span is given, and inherits, the correct baggage
 	span_global, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
 	defer span_global.Finish()
-	
-	span_app,_ := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
+
+	span_app, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
 	span_app.SetBaggageItem("fn_appname", callI.Model().AppName)
 	defer span_app.Finish()
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit")
 	span.SetBaggageItem("fn_path", callI.Model().Path)
 	defer span.Finish()
-	
+
 	// start the timer STAT! TODO add some wiggle room
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(call.Timeout)*time.Second)
 	call.req = call.req.WithContext(ctx)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -201,12 +201,12 @@ func (a *agent) Submit(callI Call) error {
 	span.SetBaggageItem("fn_path", callI.Model().Path)
 	defer span.Finish()
 	
-	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
-	span.SetBaggageItem("fn_appname", callI.Model().AppName)
-	defer span.Finish()
+	span_app,_ := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
+	span_app.SetBaggageItem("fn_appname", callI.Model().AppName)
+	defer span_app.Finish()
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
-	defer span.Finish()
+	span_global, _ := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
+	defer span_global.Finish()
 
 	// start the timer STAT! TODO add some wiggle room
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(call.Timeout)*time.Second)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -200,6 +200,13 @@ func (a *agent) Submit(callI Call) error {
 	span.SetBaggageItem("fn_appname", callI.Model().AppName)
 	span.SetBaggageItem("fn_path", callI.Model().Path)
 	defer span.Finish()
+	
+	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_app")
+	span.SetBaggageItem("fn_appname", callI.Model().AppName)
+	defer span.Finish()
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_submit_global")
+	defer span.Finish()
 
 	// start the timer STAT! TODO add some wiggle room
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(call.Timeout)*time.Second)


### PR DESCRIPTION
This PR modifies the tracing spans, and hence Prometheus metrics for the `agent_submit` operation, which essentially encompasses the execution of a cold or hot function. 

There are now three separate tracing spans (Prometheus metrics) with different baggage items (Prometheus labels) as follows:
* `agent_submit_route` - has the labels `fn_appname` and `fn_path` set
* `agent_submit_app` - has the label `fn_appname` set (but not `fn_path`)
* `agent_submit_global` - neither label set

These three separate metrics are required to support the queries needed by the new statistics API provided by the `ext-metrics` extension.