### PR TITLE
hybrid server side api

### DIFF
--- a/api/agent/drivers/docker/docker_client.go
+++ b/api/agent/drivers/docker/docker_client.go
@@ -113,7 +113,7 @@ func (d *dockerWrap) retry(ctx context.Context, f func() error) error {
 		err := filter(ctx, f())
 		if common.IsTemporary(err) || isDocker50x(err) {
 			logger.WithError(err).Warn("docker temporary error, retrying")
-			b.Sleep()
+			b.Sleep(ctx)
 			span.LogFields(log.String("task", "tmperror.docker"))
 			continue
 		}

--- a/api/common/backoff.go
+++ b/api/common/backoff.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"sync"
@@ -21,12 +22,8 @@ func (b *Backoff) Sleep(ctx context.Context) {
 		interval = 25 * time.Millisecond
 	)
 
-	if rng == nil {
-		rng = defaultRNG
-	}
-	if clock == nil {
-		clock = defaultClock
-	}
+	rng := defaultRNG
+	clock := defaultClock
 
 	// 25-50ms, 50-100ms, 100-200ms, 200-400ms, 400-800ms, 800-1600ms, 1600-3200ms, 3200-6400ms
 	d := time.Duration(math.Pow(2, float64(*b))) * interval

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -1,0 +1,64 @@
+package server
+
+func (s *Server) handleRunnerEnqueue(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var call models.Call
+	err := c.BindJSON(&call)
+	if err != nil {
+		handleErrorResponse(c, models.ErrInvalidJSON)
+		return
+	}
+
+	// XXX (reed): validate the call struct
+
+	call.State = "queued"
+
+	_, err := s.MQ.Push(ctx, &call)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	// at this point, the message is on the queue and could be picked up by a
+	// runner and enter into 'running' state before we can insert it in the db as
+	// 'queued' state. we can ignore any error inserting into db here and Start
+	// will ensure the call exists in the db in 'running' state there.
+	db.InsertCall(ctx, call)
+}
+
+func (s *Server) handleRunnerDequeue(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	var b common.Backoff
+	for {
+		msg, err := s.MQ.Reserve(ctx)
+		if err != nil {
+			handleErrorResponse(c, err)
+			return
+		}
+		if msg != nil {
+			c.JSON([]struct {
+				AppName string `json:"app_name"`
+				Path    string `json:"path"`
+			}{{AppName: msg.AppName, Path: msg.Path}})
+			return
+		}
+
+		b.Sleep(ctx)
+
+		switch {
+		case <-ctx.Done():
+			c.JSON([]struct{}{})
+			return
+		default:
+		}
+	}
+}
+
+func (s *Server) handleRunnerStart(c *gin.Context) {
+}
+
+func (s *Server) handleRunnerStart(c *gin.Context) {
+}

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -24,13 +24,18 @@ func (s *Server) handleRunnerEnqueue(c *gin.Context) {
 	// runner and enter into 'running' state before we can insert it in the db as
 	// 'queued' state. we can ignore any error inserting into db here and Start
 	// will ensure the call exists in the db in 'running' state there.
-	db.InsertCall(ctx, call)
+	s.Datastore.InsertCall(ctx, call)
+
+	c.JSON(struct {
+		M string `json:"msg"`
+	}{M: "enqueued call"})
 }
 
 func (s *Server) handleRunnerDequeue(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
 
+	// long poll until ctx expires / we find a message
 	var b common.Backoff
 	for {
 		msg, err := s.MQ.Reserve(ctx)
@@ -58,7 +63,90 @@ func (s *Server) handleRunnerDequeue(c *gin.Context) {
 }
 
 func (s *Server) handleRunnerStart(c *gin.Context) {
+	var body struct {
+		AppName string `json:"app_name"`
+		CallID  string `json:"call_id"`
+	}
+
+	err := c.BindJSON(&body)
+	if err != nil {
+		handleErrorResponse(c, models.ErrInvalidJSON)
+		return
+	}
+
+	// TODO hook up update. we really just want it to set status to running iff
+	// status=queued, but this must be in a txn in Update with behavior:
+	// queued->running
+	// running->error (returning error)
+	// error->error (returning error)
+	// success->success (returning error)
+	// timeout->timeout (returning error)
+	//
+	// there is nuance for running->error as in theory it could be the correct machine retrying
+	// and we risk not running a task [ever]. needs further thought, but marking as error will
+	// cover our tracks since if the db is down we can't run anything anyway (treat as such).
+	var call models.Call
+	call.AppName = body.AppName
+	call.Id = body.CallID
+	call.Status = "running"
+	//err := s.Datastore.UpdateCall(c.Request.Context(), &call)
+	//if err != nil {
+	//if err == InvalidStatusChange {
+	//// TODO we could either let UpdateCall handle setting to error or do it
+	//// here explicitly
+
+	//if err := s.MQ.DeleteMsg(&call); err != nil { // TODO change this to take some string(s), not a whole call
+	//logrus.WithFields(logrus.Fields{"id": call.Id}).WithError(err).Error("error deleting mq message")
+	//// just log this one, return error from update call
+	//}
+	//}
+	//handleErrorResponse(c, err)
+	//return
+	//}
+
+	c.JSON(struct {
+		M string `json:"msg"`
+	}{M: "slingshot: engage"})
 }
 
-func (s *Server) handleRunnerStart(c *gin.Context) {
+func (s *Server) handleRunnerFinish(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var body struct {
+		Call models.Call `json:"call"`
+		Log  string      `json:"log"` // TODO use multipart so that we don't have to serialize/deserialize this? measure..
+	}
+	err := c.BindJSON(&body)
+	if err != nil {
+		handleErrorResponse(c, models.ErrInvalidJSON)
+		return
+	}
+
+	// TODO validate?
+	call := body.Call
+
+	// TODO this needs UpdateCall functionality to work for async and should only work if:
+	// running->error|timeout|success
+	// TODO all async will fail here :( all sync will work fine :) -- *feeling conflicted*
+	if err := s.Datastore.InsertCall(ctx, &call); err != nil {
+		common.Logger(ctx).WithError(err).Error("error inserting call into datastore")
+		// note: Not returning err here since the job could have already finished successfully.
+	}
+
+	if err := s.LogDB.InsertLog(ctx, call.AppName, call.ID, body.Log); err != nil {
+		common.Logger(ctx).WithError(err).Error("error uploading log")
+		// note: Not returning err here since the job could have already finished successfully.
+	}
+
+	// TODO we don't know whether a call is async or sync. we likely need an additional
+	// arg in params for a message id and can detect based on this. for now, delete messages
+	// for sync and async even though sync doesn't have any (ignore error)
+	if err := s.MQ.DeleteMsg(&call); err != nil { // TODO change this to take some string(s), not a whole call
+		common.Logger(ctx).WithError(err).Error("error deleting mq msg")
+		// note: Not returning err here since the job could have already finished successfully.
+	}
+
+	c.JSON(struct {
+		M string `json:"msg"`
+	}{M: "good night, sweet prince"})
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -291,6 +291,15 @@ func (s *Server) bindHandlers(ctx context.Context) {
 			apps.GET("/calls/:call", s.handleCallGet)
 			apps.GET("/calls/:call/log", s.handleCallLogGet)
 		}
+
+		{
+			runner := v1.Group("/runner")
+			runner.PUT("/async", s.handleRunnerEnqueue)
+			runner.GET("/async", s.handleRunnerDequeue)
+
+			runner.POST("/start", s.handleRunnerStart)
+			runner.POST("/finish", s.handleRunnerFinish)
+		}
 	}
 
 	{

--- a/docs/developers/hybrid.md
+++ b/docs/developers/hybrid.md
@@ -45,10 +45,13 @@ reply with a 500 error to the client as if this call never existed
 
 ##### /v1/runner/dequeue
 
-the runner queries for a call to run. the request contains an identifier for
+the runner long polls for a call to run. the request contains an identifier for
 this runner node to pull from the partition in kafka for this runner node`***`.
-the response contains an app name and a route name (the runner will cache apps
-and routes, otherwise looking this up at respective API call positions).
+the response contains a list of {app_name, route_name} (the runner will cache apps
+and routes, otherwise looking this up at respective API call positions),
+possibly an empty list. This call will timeout and return an empty list after
+30 seconds if no messages are found. For now, it should return the first
+message it finds immediately.
 
 * dequeue a message from the MQ if there is some capacity
 

--- a/docs/developers/hybrid.md
+++ b/docs/developers/hybrid.md
@@ -1,0 +1,119 @@
+# Hybrid API Proposal
+
+TODO fill in auth information herein (possibly do w/o first?)
+
+Hybrid API will consist of a few endpoints that encapsulate all functionality
+required for `fn` to run tasks using split API and 'runner' nodes. These
+endpoints exist under the `/runner/` endpoints. In addition to these
+endpoints, the runner has access to any `/v1/` endpoints it needs as well
+(namely, `GetApp` and `GetRoute`).
+
+API nodes are responsible for interacting with an MQ and DB [on behalf of the
+runner], as well as handling all requests under the `/v1/` routes.
+
+runner nodes are responsible for receiving requests under the `/r/` endpoints
+from the fnlb and sending requests to the `/runner/` endpoints to API nodes,
+its duties are:
+
+* enqueueing async calls
+* dequeueing async calls when there is spare capacity
+* executing calls (both sync and async)
+* management of message lifecycle
+* reporting call status & logs
+
+## Endpoints
+
+All functionality listed here will be implemented in the API nodes under the
+given endpoint. The runner is responsible for calling each of these endpoints
+with the given input.
+
+##### /runner/enqueue
+
+this is called when a runner receives a request for an async route.  the
+request contains an entire constructed `models.Call` object, as well as an
+identifier for this runner node to queue this call to a specific partition in
+kafka [mapping to the runner node]***. returns success/fail.
+
+* enqueue an async call to an MQ
+* insert a call to the DB with 'queued' state
+
+special cases:
+
+* if enqueue to MQ fails, the request fails and the runner will
+reply with a 500 error to the client as if this call never existed
+* if insert fails, we ignore this error, which will be handled in Start
+
+##### /runner/dequeue
+
+the runner queries for a call to run. the request contains an identifier for
+this runner node to pull from the partition in kafka for this runner node***.
+the response contains an app name and a route name (the runner will cache apps
+and routes, otherwise looking this up at respective API call positions).
+
+* dequeue a message from the MQ if there is some capacity
+
+##### /runner/start
+
+the runner calls this endpoint immediately before starting a task, only
+starting the task if this endpoint returns a success. the request contains the
+app name and route name. the response returns success/fail code.
+
+sync:
+
+* noop, the runner will not call this endpoint.
+
+async:
+
+* update call in db to status=running, conditionally. if the status is already
+  running, set the status to error as this means that the task has been
+  started successfully previously and we don't want to run it twice, and after
+  successfully setting the status to error, delete the mq message, and return
+  a failure status code. if the status is a final state (error | timeout |
+  success), delete the mq message and return a failure status code. if the
+  update to status=running succeeds, return a success status code.
+
+##### /runner/finish
+
+the runner calls this endpoint after a call has completed, either because of
+an error, a timeout, or because it ran successfully. it will always return a
+success code as the call is completed at this point, the runner may retry this
+endpoint if it fails (timeout, etc).
+
+sync:
+
+* insert the call model into the db (ignore error, retry)
+* insert the log into the log store (ignore error, retry)
+
+async:
+
+* insert the call model into the db (ignore error, retry)
+* insert the log into the log store (ignore error, retry)
+* delete the MQ message (ignore error, retry, failure is handled in start)
+
+## Additional notes & changes required
+
+* All runner requests and responses will contain a header `XXX-RUNNER-LOAD`
+  that API server nodes and FNLB nodes can use to determine how to distribute
+  load to that node. This will keep a relatively up to date view of each of
+  the runner nodes to the API and FNLB, assuming that each of those are small
+  sets of nodes. The API nodes can use this to determine whether to distribute
+  messages for async nodes to runner nodes as well as fnlb for routing async
+  or sync requests.
+* Each runner node will have a partition in Kafka that maps to messages that
+  it enqueues. This will allow us to use distribution information, based off
+  load, from the load balancer, since the load balancer will send requests to
+  queue async tasks optimistically to runner nodes. The runner then only
+  processes messages on its partition. This is likely fraught with some
+  danger, however, kafka messaging semantics have no idea of timeouts and we
+  make no real SLAs about time between enqueue and start, so its somewhat sexy
+  to think that runners don't have to think about maneuvering timeouts. This
+  likely needs further fleshing out, as noted in***.
+
+`***` current understanding of kafka consumer groups semantics is largely
+incomplete and this is making the assumption that if a runner fails, consumer
+groups will allow another runner node to cover for this one as well as its
+own. distribution should also be considered, and sending in partition ids is
+important so that FNLB will dictate the distribution of async functions across
+nodes as their load increases, this is also why `XXX-RUNNER-LOAD` is required,
+since async tasks aren't returning wait information up stack to the lb. this
+likely requires further thought, but is possibly correct as proposed (1% odds)

--- a/docs/developers/hybrid.md
+++ b/docs/developers/hybrid.md
@@ -4,15 +4,15 @@ TODO fill in auth information herein (possibly do w/o first?)
 
 Hybrid API will consist of a few endpoints that encapsulate all functionality
 required for `fn` to run tasks using split API and 'runner' nodes. These
-endpoints exist under the `/runner/` endpoints. In addition to these
+endpoints exist under the `/v1/runner/` endpoints. In addition to these
 endpoints, the runner has access to any `/v1/` endpoints it needs as well
 (namely, `GetApp` and `GetRoute`).
 
 API nodes are responsible for interacting with an MQ and DB [on behalf of the
 runner], as well as handling all requests under the `/v1/` routes.
 
-runner nodes are responsible for receiving requests under the `/r/` endpoints
-from the fnlb and sending requests to the `/runner/` endpoints to API nodes,
+Runner nodes are responsible for receiving requests under the `/r/` endpoints
+from the fnlb and sending requests to the `/v1/runner/` endpoints to API nodes,
 its duties are:
 
 * enqueueing async calls
@@ -27,12 +27,12 @@ All functionality listed here will be implemented in the API nodes under the
 given endpoint. The runner is responsible for calling each of these endpoints
 with the given input.
 
-##### /runner/enqueue
+##### /v1/runner/enqueue
 
 this is called when a runner receives a request for an async route.  the
 request contains an entire constructed `models.Call` object, as well as an
 identifier for this runner node to queue this call to a specific partition in
-kafka [mapping to the runner node]***. returns success/fail.
+kafka [mapping to the runner node]`***`. returns success/fail.
 
 * enqueue an async call to an MQ
 * insert a call to the DB with 'queued' state
@@ -43,16 +43,16 @@ special cases:
 reply with a 500 error to the client as if this call never existed
 * if insert fails, we ignore this error, which will be handled in Start
 
-##### /runner/dequeue
+##### /v1/runner/dequeue
 
 the runner queries for a call to run. the request contains an identifier for
-this runner node to pull from the partition in kafka for this runner node***.
+this runner node to pull from the partition in kafka for this runner node`***`.
 the response contains an app name and a route name (the runner will cache apps
 and routes, otherwise looking this up at respective API call positions).
 
 * dequeue a message from the MQ if there is some capacity
 
-##### /runner/start
+##### /v1/runner/start
 
 the runner calls this endpoint immediately before starting a task, only
 starting the task if this endpoint returns a success. the request contains the
@@ -72,7 +72,7 @@ async:
   success), delete the mq message and return a failure status code. if the
   update to status=running succeeds, return a success status code.
 
-##### /runner/finish
+##### /v1/runner/finish
 
 the runner calls this endpoint after a call has completed, either because of
 an error, a timeout, or because it ran successfully. it will always return a
@@ -107,7 +107,7 @@ async:
   danger, however, kafka messaging semantics have no idea of timeouts and we
   make no real SLAs about time between enqueue and start, so its somewhat sexy
   to think that runners don't have to think about maneuvering timeouts. This
-  likely needs further fleshing out, as noted in***.
+  likely needs further fleshing out, as noted in`***`.
 
 `***` current understanding of kafka consumer groups semantics is largely
 incomplete and this is making the assumption that if a runner fails, consumer

--- a/docs/developers/hybrid.md
+++ b/docs/developers/hybrid.md
@@ -27,7 +27,7 @@ All functionality listed here will be implemented in the API nodes under the
 given endpoint. The runner is responsible for calling each of these endpoints
 with the given input.
 
-##### /v1/runner/enqueue
+##### POST /v1/runner/async
 
 this is called when a runner receives a request for an async route.  the
 request contains an entire constructed `models.Call` object, as well as an
@@ -43,7 +43,7 @@ special cases:
 reply with a 500 error to the client as if this call never existed
 * if insert fails, we ignore this error, which will be handled in Start
 
-##### /v1/runner/dequeue
+##### GET /v1/runner/async
 
 the runner long polls for a call to run. the request contains an identifier for
 this runner node to pull from the partition in kafka for this runner node`***`.
@@ -59,7 +59,10 @@ message it finds immediately.
 
 the runner calls this endpoint immediately before starting a task, only
 starting the task if this endpoint returns a success. the request contains the
-app name and the call id. the response returns success/fail code.
+app name and the call id. the response returns success/fail code. this
+transition _could_ be done in the dequeue portion of the call lifecycle since
+it's only for async, however this exists because the time between dequeueing
+and being prepared to execute a task may be long (or even succeed).
 
 sync:
 
@@ -75,7 +78,7 @@ async:
   success), delete the mq message and return a failure status code. if the
   update to status=running succeeds, return a success status code.
 
-##### PUT /v1/runner/finish
+##### POST /v1/runner/finish
 
 the runner calls this endpoint after a call has completed, either because of
 an error, a timeout, or because it ran successfully. the request must contain

--- a/docs/developers/hybrid.md
+++ b/docs/developers/hybrid.md
@@ -55,11 +55,11 @@ message it finds immediately.
 
 * dequeue a message from the MQ if there is some capacity
 
-##### /v1/runner/start
+##### POST /v1/runner/start
 
 the runner calls this endpoint immediately before starting a task, only
 starting the task if this endpoint returns a success. the request contains the
-app name and route name. the response returns success/fail code.
+app name and the call id. the response returns success/fail code.
 
 sync:
 
@@ -75,12 +75,13 @@ async:
   success), delete the mq message and return a failure status code. if the
   update to status=running succeeds, return a success status code.
 
-##### /v1/runner/finish
+##### PUT /v1/runner/finish
 
 the runner calls this endpoint after a call has completed, either because of
-an error, a timeout, or because it ran successfully. it will always return a
-success code as the call is completed at this point, the runner may retry this
-endpoint if it fails (timeout, etc).
+an error, a timeout, or because it ran successfully. the request must contain
+an entire completed call object as well as its log (multipart?). it will
+always return a success code as the call is completed at this point, the
+runner may retry this endpoint if it fails (timeout, etc).
 
 sync:
 


### PR DESCRIPTION
this implements the beginnings of the server side API for API nodes. this is relatively in flux API, and as such, haven't wrote a doc with the endpoints or made a client library for it as of yet. it would be nice to start lining up trains so we can start mashing some of this stuff together, even if everything is in flux, so here goes. 

follows from discussion in #531. there are stubs for UpdateCall atm, we should discuss how we want this to work based on functionality highlighted here -- discuss elsewhere, probably. also, cannot really test this reliably until we can shut off the agent, which is in another patch.

anyway, choo choo