### PR TITLE
[skip ci] Fix the name of Oracle Linux to the official product name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fn start
 
 This will start Fn in single server mode, using an embedded database and message queue. You can find all the
 configuration options [here](docs/operating/options.md). If you are on Windows, check [here](docs/operating/windows.md).
-If you are on a Linux system where the SELinux security policy is set to "Enforcing", such as OEL7.x, check
+If you are on a Linux system where the SELinux security policy is set to "Enforcing", such as Oracle Linux 7, check
 [here](docs/operating/selinux.md).
 
 ### Your First Function

--- a/docs/operating/selinux.md
+++ b/docs/operating/selinux.md
@@ -1,6 +1,6 @@
 # Running on SELinux systems
 
-Systems such as OEL 7.x where SELinux is enabled and the security policies are set to "Enforcing" will restrict Fn from
+Systems such as Oracle Linux 7 where SELinux is enabled and the security policies are set to "Enforcing" will restrict Fn from
 running containers and mounting volumes.
 
 For local development, you can relax SELinux constraints by running this command in a root shell:


### PR DESCRIPTION
Tiny little edit to remove the incorrect acronym "OEL" with the correct product name of Oracle Linux.

Resolves #583.

Signed-off-by: Avi Miller <avi.miller@oracle.com>