### PR TITLE
Update README.md for Grafana example

### DIFF
--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -77,7 +77,7 @@ Open a terminal window and navigate to the directory containing this example.
 Start Grafana on port 3000:
 ```
 docker run --name=grafana -d -p 3000:3000 \
-  --link fnserver --link prometheus grafana/grafana
+  --link prometheus grafana/grafana
 ```
 
 Open a browser on Grafana at [http://localhost:3000](http://localhost:3000).
@@ -89,7 +89,7 @@ Create a datasource to obtain metrics from Promethesus:
 * Set **Name** to `PromDS` (or whatever name you choose)
 * Set **Type** to `Prometheus`
 * Set **URL** to `http://prometheus:9090` 
-* Set **Access** to `direct`
+* Set **Access** to `proxy`
 * Click **Add** and then **Save and test**
 
 Import the example dashboard that displays metrics from the Fn server:


### PR DESCRIPTION
This corrects an error in the instructions for the Grafana example. The instructions told the user to configure a Grafana data source to connect to Prometheus using `http://prometheus:9090`, where `prometheus` is an alias configured using `--link`. However the instructions specified that the data source should use `direct` mode. This doesn't work, since the connection is then created from the browser, which doesn't know what `prometheus:9090` is. The instructions need to be changed to specify `proxy` mode, in which case the connection is created from Grafana, which knows about the `prometheus` alias.

 