### PR TITLE
Slot mgr fixes

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -188,7 +187,7 @@ func (a *agent) Submit(callI Call) error {
 
 	select {
 	case <-a.shutdown:
-		return errors.New("agent shut down")
+		return models.ErrCallTimeoutServerBusy
 	default:
 	}
 
@@ -376,7 +375,7 @@ func (a *agent) waitHot(ctx context.Context, call *call) (Slot, error) {
 		case <-time.After(time.Duration(200) * time.Millisecond):
 			// ping dequeuer again
 		case <-a.shutdown: // server shutdown
-			return nil, errors.New("agent shut down")
+			return nil, models.ErrCallTimeoutServerBusy
 		}
 	}
 }

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -370,6 +370,7 @@ func (a *agent) waitHot(ctx context.Context, call *call) (Slot, error) {
 		// send a notification to launcHot()
 		select {
 		case call.slots.signaller <- true:
+		default:
 		}
 
 		select {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -266,7 +266,6 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 
 	isHot := protocol.IsStreamable(protocol.Protocol(call.Format))
 	if isHot {
-
 		start := time.Now()
 
 		// For hot requests, we use a long lived slot queue, which we use to manage hot containers
@@ -278,7 +277,6 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 
 		s, err := a.waitHot(ctx, call)
 		call.slots.exitStateWithLatency(SlotQueueWaiter, uint64(time.Now().Sub(start).Seconds()*1000))
-
 		return s, err
 	}
 
@@ -363,10 +361,7 @@ func (a *agent) waitHot(ctx context.Context, call *call) (Slot, error) {
 		}
 
 		select {
-		case s, ok := <-ch:
-			if !ok {
-				return nil, errors.New("slot shut down while waiting for hot slot")
-			}
+		case s := <-ch:
 			if s.acquireSlot() {
 				if s.slot.Error() != nil {
 					s.slot.Close()
@@ -374,7 +369,6 @@ func (a *agent) waitHot(ctx context.Context, call *call) (Slot, error) {
 				}
 				return s.slot, nil
 			}
-
 			// we failed to take ownership of the token (eg. container idle timeout) => try again
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -267,7 +267,7 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 	isHot := protocol.IsStreamable(protocol.Protocol(call.Format))
 	if isHot {
 
-		// For hot requests, we use a long lived (60 minutes) slot queue, which we use to manage hot containers
+		// For hot requests, we use a long lived slot queue, which we use to manage hot containers
 		var isNew bool
 		call.slots, isNew = a.slotMgr.getHotSlotQueue(call)
 		if isNew {

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -239,6 +239,18 @@ func (a *slotQueue) queueSlot(slot Slot) *slotToken {
 	return nil
 }
 
+// isIdle() returns true is there's no activity for this slot queue. This
+// means no one is waiting, running or starting.
+func (a *slotQueue) isIdle() bool {
+	var partySize uint64
+
+	a.statsLock.Lock()
+	partySize = a.stats.states[SlotQueueWaiter] + a.stats.states[SlotQueueStarter] + a.stats.states[SlotQueueRunner]
+	a.statsLock.Unlock()
+
+	return partySize == 0
+}
+
 func (a *slotQueue) getStats() slotQueueStats {
 	var out slotQueueStats
 	a.statsLock.Lock()

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -192,8 +192,6 @@ func (a *slotQueue) startDequeuer(ctx context.Context) (chan *slotToken, context
 				}
 			}
 		}
-
-		close(output)
 	}()
 
 	return output, myCancel

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -151,11 +151,6 @@ func (a *slotQueue) destroySlotQueue() {
 	}
 
 }
-func (a *slotQueue) pingDequeuer() {
-	select {
-	case a.signaller <- true:
-	}
-}
 
 func (a *slotQueue) startDequeuer(ctx context.Context) (chan *slotToken, context.CancelFunc) {
 
@@ -344,7 +339,7 @@ func (a *slotQueue) exitStateWithLatency(metricIdx SlotQueueMetricType, latency 
 
 // getSlot must ensure that if it receives a slot, it will be returned, otherwise
 // a container will be locked up forever waiting for slot to free.
-func (a *slotQueueMgr) getHotSlotQueue(call *call, myFunc func(chan bool, *slotQueue)) *slotQueue {
+func (a *slotQueueMgr) getHotSlotQueue(call *call) (*slotQueue, bool) {
 
 	isNew := false
 	key := getSlotQueueKey(call)
@@ -363,10 +358,7 @@ func (a *slotQueueMgr) getHotSlotQueue(call *call, myFunc func(chan bool, *slotQ
 		a.hMu.Unlock()
 	}
 
-	if isNew {
-		go myFunc(slots.signaller, slots)
-	}
-	return slots
+	return slots, isNew
 }
 
 // currently unused. But at some point, we need to age/delete old

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -48,12 +48,12 @@ func TestSlotQueueBasic1(t *testing.T) {
 	obj := NewSlotQueue(slotName)
 
 	outChan, cancel := obj.startDequeuer(context.Background())
-
 	select {
 	case z := <-outChan:
 		t.Fatalf("Should not get anything from queue: %#v", z)
 	case <-time.After(time.Duration(500) * time.Millisecond):
 	}
+	cancel()
 
 	// create slots
 	for id := uint64(0); id < maxId; id += 1 {
@@ -91,6 +91,8 @@ func TestSlotQueueBasic1(t *testing.T) {
 	if obj.ejectSlot(tokens[5]) {
 		t.Fatalf("Shouldn't be able to eject slotToken: %#v", tokens[5])
 	}
+
+	outChan, cancel = obj.startDequeuer(context.Background())
 
 	// now we should get 8
 	select {

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type testSlot struct {
+	id       uint64
+	err      error
+	isClosed bool
+}
+
+func (a *testSlot) exec(ctx context.Context, call *call) error {
+	return nil
+}
+
+func (a *testSlot) Close() error {
+	if a.isClosed {
+		return fmt.Errorf("id=%d already closed %v", a.id, a)
+	}
+	a.isClosed = true
+	return nil
+}
+
+func (a *testSlot) Error() error {
+	return a.err
+}
+
+func NewTestSlot(id uint64) Slot {
+	mySlot := &testSlot{
+		id: id,
+	}
+	return mySlot
+}
+
+func TestSlotQueueBasic1(t *testing.T) {
+
+	maxId := uint64(10)
+	slotName := "test1"
+
+	slots := make([]Slot, 0, maxId)
+	tokens := make([]*slotToken, 0, maxId)
+
+	obj := NewSlotQueue(slotName)
+
+	outChan := obj.getDequeueChan()
+
+	select {
+	case z := <-outChan:
+		t.Fatalf("Should not get anything from queue: %v", z)
+	default:
+	}
+
+	// create slots
+	for id := uint64(0); id < maxId; id += 1 {
+		slots = append(slots, NewTestSlot(id))
+	}
+
+	// queue a few slots here
+	for id := uint64(0); id < maxId; id += 1 {
+		tok := obj.queueSlot(slots[id])
+
+		innerTok := tok.slot.(*testSlot)
+
+		// check for slot id match
+		if innerTok != slots[id] {
+			t.Fatalf("queued testSlot does not match with slotToken.slot %v vs %v", innerTok, slots[id])
+		}
+
+		tokens = append(tokens, tok)
+	}
+
+	// Now according to LIFO semantics, we should get 9,8,7,5,4,3,2,1,0 if we dequeued right now.
+	// but let's eject 9
+	if !obj.ejectSlot(tokens[9]) {
+		t.Fatalf("Cannot eject slotToken: %v", tokens[9])
+	}
+	// let eject 0
+	if !obj.ejectSlot(tokens[0]) {
+		t.Fatalf("Cannot eject slotToken: %v", tokens[0])
+	}
+	// let eject 5
+	if !obj.ejectSlot(tokens[5]) {
+		t.Fatalf("Cannot eject slotToken: %v", tokens[5])
+	}
+	// try ejecting 5 again, it should fail
+	if obj.ejectSlot(tokens[5]) {
+		t.Fatalf("Shouldn't be able to eject slotToken: %v", tokens[5])
+	}
+
+	// now we should get 8
+	select {
+	case z := <-outChan:
+		if z.id != 8 {
+			t.Fatalf("Bad slotToken received: %v", z)
+		}
+
+		if !z.acquireSlot() {
+			t.Fatalf("Cannot acquire slotToken received: %v", z)
+		}
+
+	case <-time.After(time.Duration(1) * time.Second):
+		t.Fatal("timeout in waiting slotToken")
+	}
+
+	// now we should get 7
+	select {
+	case z := <-outChan:
+		if z.id != 7 {
+			t.Fatalf("Bad slotToken received: %v", z)
+		}
+
+		// eject it before we can consume
+		if !obj.ejectSlot(tokens[7]) {
+			t.Fatalf("Cannot eject slotToken: %v", tokens[2])
+		}
+
+		// we shouldn't be able to consume an ejected slotToken
+		if z.acquireSlot() {
+			t.Fatalf("We should not be able to acquire slotToken received: %v", z)
+		}
+
+	case <-time.After(time.Duration(1) * time.Second):
+		t.Fatal("timeout in waiting slotToken")
+	}
+
+	// now we've got: 4,3,2,1
+	// let's destroy this queue
+	obj.destroySlotQueue()
+
+	// we should get nothing
+	select {
+	case z, ok := <-outChan:
+		if ok {
+			t.Fatalf("Should not get anything from queue: %v", z)
+		}
+	default:
+	}
+
+	// attempt to queue again should fail
+	tok := obj.queueSlot(slots[0])
+	if tok != nil {
+		t.Fatalf("Attempt to queue into closed slotQueue should fail")
+	}
+
+	// all of our slots should be busy (acquired now)
+	for _, v := range tokens {
+		if v.isBusy == uint32(0) {
+			t.Fatalf("Slot not busy after ejects and destroyed queue %v", v)
+		}
+	}
+
+	stats1 := obj.getStats()
+	isNeeded, stats2 := obj.isNewContainerNeeded()
+
+	if stats1 != stats2 {
+		t.Fatalf("Faulty stats %v != %v", stats1, stats2)
+	}
+
+	if isNeeded {
+		t.Fatalf("Shouldn't need a container for destroy slotQueue")
+	}
+}

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -46,11 +46,11 @@ func TestSlotQueueBasic1(t *testing.T) {
 
 	obj := NewSlotQueue(slotName)
 
-	outChan := obj.getDequeueChan()
+	outChan, cancel := obj.startDequeuer(context.Background())
 
 	select {
 	case z := <-outChan:
-		t.Fatalf("Should not get anything from queue: %v", z)
+		t.Fatalf("Should not get anything from queue: %#v", z)
 	default:
 	}
 
@@ -67,7 +67,7 @@ func TestSlotQueueBasic1(t *testing.T) {
 
 		// check for slot id match
 		if innerTok != slots[id] {
-			t.Fatalf("queued testSlot does not match with slotToken.slot %v vs %v", innerTok, slots[id])
+			t.Fatalf("queued testSlot does not match with slotToken.slot %#v vs %#v", innerTok, slots[id])
 		}
 
 		tokens = append(tokens, tok)
@@ -76,30 +76,30 @@ func TestSlotQueueBasic1(t *testing.T) {
 	// Now according to LIFO semantics, we should get 9,8,7,5,4,3,2,1,0 if we dequeued right now.
 	// but let's eject 9
 	if !obj.ejectSlot(tokens[9]) {
-		t.Fatalf("Cannot eject slotToken: %v", tokens[9])
+		t.Fatalf("Cannot eject slotToken: %#v", tokens[9])
 	}
 	// let eject 0
 	if !obj.ejectSlot(tokens[0]) {
-		t.Fatalf("Cannot eject slotToken: %v", tokens[0])
+		t.Fatalf("Cannot eject slotToken: %#v", tokens[0])
 	}
 	// let eject 5
 	if !obj.ejectSlot(tokens[5]) {
-		t.Fatalf("Cannot eject slotToken: %v", tokens[5])
+		t.Fatalf("Cannot eject slotToken: %#v", tokens[5])
 	}
 	// try ejecting 5 again, it should fail
 	if obj.ejectSlot(tokens[5]) {
-		t.Fatalf("Shouldn't be able to eject slotToken: %v", tokens[5])
+		t.Fatalf("Shouldn't be able to eject slotToken: %#v", tokens[5])
 	}
 
 	// now we should get 8
 	select {
 	case z := <-outChan:
 		if z.id != 8 {
-			t.Fatalf("Bad slotToken received: %v", z)
+			t.Fatalf("Bad slotToken received: %#v", z)
 		}
 
 		if !z.acquireSlot() {
-			t.Fatalf("Cannot acquire slotToken received: %v", z)
+			t.Fatalf("Cannot acquire slotToken received: %#v", z)
 		}
 
 	case <-time.After(time.Duration(1) * time.Second):
@@ -110,17 +110,17 @@ func TestSlotQueueBasic1(t *testing.T) {
 	select {
 	case z := <-outChan:
 		if z.id != 7 {
-			t.Fatalf("Bad slotToken received: %v", z)
+			t.Fatalf("Bad slotToken received: %#v", z)
 		}
 
 		// eject it before we can consume
 		if !obj.ejectSlot(tokens[7]) {
-			t.Fatalf("Cannot eject slotToken: %v", tokens[2])
+			t.Fatalf("Cannot eject slotToken: %#v", tokens[2])
 		}
 
 		// we shouldn't be able to consume an ejected slotToken
 		if z.acquireSlot() {
-			t.Fatalf("We should not be able to acquire slotToken received: %v", z)
+			t.Fatalf("We should not be able to acquire slotToken received: %#v", z)
 		}
 
 	case <-time.After(time.Duration(1) * time.Second):
@@ -131,11 +131,13 @@ func TestSlotQueueBasic1(t *testing.T) {
 	// let's destroy this queue
 	obj.destroySlotQueue()
 
+	cancel()
+
 	// we should get nothing
 	select {
 	case z, ok := <-outChan:
 		if ok {
-			t.Fatalf("Should not get anything from queue: %v", z)
+			t.Fatalf("Should not get anything from queue: %#v", z)
 		}
 	default:
 	}
@@ -149,7 +151,7 @@ func TestSlotQueueBasic1(t *testing.T) {
 	// all of our slots should be busy (acquired now)
 	for _, v := range tokens {
 		if v.isBusy == uint32(0) {
-			t.Fatalf("Slot not busy after ejects and destroyed queue %v", v)
+			t.Fatalf("Slot not busy after ejects and destroyed queue %#v", v)
 		}
 	}
 
@@ -157,7 +159,7 @@ func TestSlotQueueBasic1(t *testing.T) {
 	isNeeded, stats2 := obj.isNewContainerNeeded()
 
 	if stats1 != stats2 {
-		t.Fatalf("Faulty stats %v != %v", stats1, stats2)
+		t.Fatalf("Faulty stats %#v != %#v", stats1, stats2)
 	}
 
 	if isNeeded {


### PR DESCRIPTION
*) new inactivity time out for hot queue, we previously kept hot queues in memory forever.
*) each hot queue now has a hot launcher to monitor and launch hot containers
*) consumers now create a consumer channel with startDequeuer() that can be cancelled via context
*) consumers now ping (signal) hot launcher every 200 msecs until they get a slot
*) tests for slot queue & mgr