### PR TITLE
Timestamps on apps / routes

### DIFF
--- a/api/agent/protocol/json_test.go
+++ b/api/agent/protocol/json_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/fnproject/fn/api/models"
@@ -113,7 +112,7 @@ func TestJSONProtocolwriteJSONInputRequestWithoutData(t *testing.T) {
 		t.Errorf("Request body assertion mismatch: expected: %s, got %s",
 			"<empty-string>", incomingReq.Body)
 	}
-	if ok := reflect.DeepEqual(req.Header, incomingReq.Protocol.Headers); !ok {
+	if !models.Headers(req.Header).Equals(models.Headers(incomingReq.Protocol.Headers)) {
 		t.Errorf("Request headers assertion mismatch: expected: %s, got %s",
 			req.Header, incomingReq.Protocol.Headers)
 	}

--- a/api/datastore/internal/datastoretest/test.go
+++ b/api/datastore/internal/datastoretest/test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log"
-	"reflect"
 	"testing"
 	"time"
 
@@ -289,7 +288,7 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 		if err != nil {
 			t.Fatalf("Test InsertApp: error when storing new app: %s", err)
 		}
-		if !reflect.DeepEqual(*inserted, *testApp) {
+		if !inserted.Equals(testApp) {
 			t.Fatalf("Test InsertApp: expected to insert:\n%v\nbut got:\n%v", testApp, inserted)
 		}
 
@@ -300,13 +299,12 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 
 		{
 			// Set a config var
-			updated, err := ds.UpdateApp(ctx,
-				&models.App{Name: testApp.Name, Config: map[string]string{"TEST": "1"}})
+			updated, err := ds.UpdateApp(ctx, &models.App{Name: testApp.Name, Config: map[string]string{"TEST": "1"}})
 			if err != nil {
 				t.Fatalf("Test UpdateApp: error when updating app: %v", err)
 			}
 			expected := &models.App{Name: testApp.Name, Config: map[string]string{"TEST": "1"}}
-			if !reflect.DeepEqual(*updated, *expected) {
+			if !updated.Equals(expected) {
 				t.Fatalf("Test UpdateApp: expected updated `%v` but got `%v`", expected, updated)
 			}
 
@@ -317,7 +315,7 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 				t.Fatalf("Test UpdateApp: error when updating app: %v", err)
 			}
 			expected = &models.App{Name: testApp.Name, Config: map[string]string{"TEST": "1", "OTHER": "TEST"}}
-			if !reflect.DeepEqual(*updated, *expected) {
+			if !updated.Equals(expected) {
 				t.Fatalf("Test UpdateApp: expected updated `%v` but got `%v`", expected, updated)
 			}
 
@@ -328,7 +326,7 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 				t.Fatalf("Test UpdateApp: error when updating app: %v", err)
 			}
 			expected = &models.App{Name: testApp.Name, Config: map[string]string{"OTHER": "TEST"}}
-			if !reflect.DeepEqual(*updated, *expected) {
+			if !updated.Equals(expected) {
 				t.Fatalf("Test UpdateApp: expected updated `%v` but got `%v`", expected, updated)
 			}
 		}
@@ -496,9 +494,8 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 			if err != nil {
 				t.Fatalf("Test GetRoute: unexpected error %v", err)
 			}
-			var expected models.Route = *testRoute
-			if !reflect.DeepEqual(*route, expected) {
-				t.Fatalf("Test InsertApp: expected to insert:\n%v\nbut got:\n%v", expected, *route)
+			if !route.Equals(testRoute) {
+				t.Fatalf("Test InsertApp: expected to insert:\n%v\nbut got:\n%v", testRoute, *route)
 			}
 		}
 
@@ -545,7 +542,7 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 					"Third":  []string{"test", "test2"},
 				},
 			}
-			if !reflect.DeepEqual(*updated, *expected) {
+			if !updated.Equals(expected) {
 				t.Fatalf("Test UpdateRoute: expected updated `%v` but got `%v`", expected, updated)
 			}
 
@@ -586,7 +583,7 @@ func Test(t *testing.T, dsf func(t *testing.T) models.Datastore) {
 					"Third": []string{"test", "test2"},
 				},
 			}
-			if !reflect.DeepEqual(*updated, *expected) {
+			if !updated.Equals(expected) {
 				t.Fatalf("Test UpdateRoute: expected updated:\n`%v`\nbut got:\n`%v`", expected, updated)
 			}
 		}

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -75,7 +75,7 @@ func (m *mock) UpdateApp(ctx context.Context, app *models.App) (*models.App, err
 	if err != nil {
 		return nil, err
 	}
-	a.UpdateConfig(app.Config)
+	a.UpdateConfig(app)
 
 	return a.Clone(), nil
 }

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -75,7 +75,7 @@ func (m *mock) UpdateApp(ctx context.Context, app *models.App) (*models.App, err
 	if err != nil {
 		return nil, err
 	}
-	a.UpdateConfig(app)
+	a.Update(app)
 
 	return a.Clone(), nil
 }

--- a/api/datastore/sql/migrations/4_add_route_updated_at.down.sql
+++ b/api/datastore/sql/migrations/4_add_route_updated_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE routes DROP COLUMN updated_at;

--- a/api/datastore/sql/migrations/4_add_route_updated_at.up.sql
+++ b/api/datastore/sql/migrations/4_add_route_updated_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE routes ADD updated_at varchar(256);

--- a/api/datastore/sql/migrations/5_add_app_created_at.down.sql
+++ b/api/datastore/sql/migrations/5_add_app_created_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps DROP COLUMN created_at;

--- a/api/datastore/sql/migrations/5_add_app_created_at.up.sql
+++ b/api/datastore/sql/migrations/5_add_app_created_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps ADD created_at varchar(256);

--- a/api/datastore/sql/migrations/6_add_app_updated_at.down.sql
+++ b/api/datastore/sql/migrations/6_add_app_updated_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps DROP COLUMN updated_at;

--- a/api/datastore/sql/migrations/6_add_app_updated_at.up.sql
+++ b/api/datastore/sql/migrations/6_add_app_updated_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps ADD updated_at varchar(256);

--- a/api/datastore/sql/migrations/migrations.go
+++ b/api/datastore/sql/migrations/migrations.go
@@ -6,6 +6,8 @@
 // 2_add_call_stats.up.sql
 // 3_add_call_error.down.sql
 // 3_add_call_error.up.sql
+// 4_add_route_updated_at.down.sql
+// 4_add_route_updated_at.up.sql
 // DO NOT EDIT!
 
 package migrations
@@ -108,7 +110,7 @@ func _1_add_route_created_atUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1_add_route_created_at.up.sql", size: 40, mode: os.FileMode(420), modTime: time.Unix(1511259011, 0)}
+	info := bindataFileInfo{name: "1_add_route_created_at.up.sql", size: 40, mode: os.FileMode(420), modTime: time.Unix(1511919777, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +170,7 @@ func _3_add_call_errorDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "3_add_call_error.down.sql", size: 37, mode: os.FileMode(420), modTime: time.Unix(1511265731, 0)}
+	info := bindataFileInfo{name: "3_add_call_error.down.sql", size: 37, mode: os.FileMode(420), modTime: time.Unix(1511301534, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -188,7 +190,47 @@ func _3_add_call_errorUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "3_add_call_error.up.sql", size: 34, mode: os.FileMode(420), modTime: time.Unix(1511265909, 0)}
+	info := bindataFileInfo{name: "3_add_call_error.up.sql", size: 34, mode: os.FileMode(420), modTime: time.Unix(1511301534, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __4_add_route_updated_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\xca\x2f\x2d\x49\x2d\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x2d\x48\x49\x2c\x49\x4d\x89\x4f\x2c\xb1\xe6\x02\x04\x00\x00\xff\xff\xa4\x67\xb0\xea\x2b\x00\x00\x00")
+
+func _4_add_route_updated_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__4_add_route_updated_atDownSql,
+		"4_add_route_updated_at.down.sql",
+	)
+}
+
+func _4_add_route_updated_atDownSql() (*asset, error) {
+	bytes, err := _4_add_route_updated_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "4_add_route_updated_at.down.sql", size: 43, mode: os.FileMode(420), modTime: time.Unix(1513728957, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __4_add_route_updated_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\xca\x2f\x2d\x49\x2d\x56\x70\x74\x71\x51\x28\x2d\x48\x49\x2c\x49\x4d\x89\x4f\x2c\x51\x28\x4b\x2c\x4a\xce\x48\x2c\xd2\x30\x32\x35\xd3\xb4\xe6\x02\x04\x00\x00\xff\xff\x54\xf7\xac\x11\x30\x00\x00\x00")
+
+func _4_add_route_updated_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__4_add_route_updated_atUpSql,
+		"4_add_route_updated_at.up.sql",
+	)
+}
+
+func _4_add_route_updated_atUpSql() (*asset, error) {
+	bytes, err := _4_add_route_updated_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "4_add_route_updated_at.up.sql", size: 48, mode: os.FileMode(420), modTime: time.Unix(1513730260, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -251,6 +293,8 @@ var _bindata = map[string]func() (*asset, error){
 	"2_add_call_stats.up.sql":         _2_add_call_statsUpSql,
 	"3_add_call_error.down.sql":       _3_add_call_errorDownSql,
 	"3_add_call_error.up.sql":         _3_add_call_errorUpSql,
+	"4_add_route_updated_at.down.sql": _4_add_route_updated_atDownSql,
+	"4_add_route_updated_at.up.sql":   _4_add_route_updated_atUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -300,6 +344,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"2_add_call_stats.up.sql":         &bintree{_2_add_call_statsUpSql, map[string]*bintree{}},
 	"3_add_call_error.down.sql":       &bintree{_3_add_call_errorDownSql, map[string]*bintree{}},
 	"3_add_call_error.up.sql":         &bintree{_3_add_call_errorUpSql, map[string]*bintree{}},
+	"4_add_route_updated_at.down.sql": &bintree{_4_add_route_updated_atDownSql, map[string]*bintree{}},
+	"4_add_route_updated_at.up.sql":   &bintree{_4_add_route_updated_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/api/datastore/sql/migrations/migrations.go
+++ b/api/datastore/sql/migrations/migrations.go
@@ -8,6 +8,8 @@
 // 3_add_call_error.up.sql
 // 4_add_route_updated_at.down.sql
 // 4_add_route_updated_at.up.sql
+// 5_add_app_created_at.down.sql
+// 5_add_app_created_at.up.sql
 // DO NOT EDIT!
 
 package migrations
@@ -230,7 +232,47 @@ func _4_add_route_updated_atUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "4_add_route_updated_at.up.sql", size: 48, mode: os.FileMode(420), modTime: time.Unix(1513730260, 0)}
+	info := bindataFileInfo{name: "4_add_route_updated_at.up.sql", size: 48, mode: os.FileMode(420), modTime: time.Unix(1513730369, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __5_add_app_created_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x2c\x28\x28\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x2e\x4a\x4d\x2c\x49\x4d\x89\x4f\x2c\xb1\xe6\x02\x04\x00\x00\xff\xff\xd2\xde\x5c\x98\x29\x00\x00\x00")
+
+func _5_add_app_created_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__5_add_app_created_atDownSql,
+		"5_add_app_created_at.down.sql",
+	)
+}
+
+func _5_add_app_created_atDownSql() (*asset, error) {
+	bytes, err := _5_add_app_created_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "5_add_app_created_at.down.sql", size: 41, mode: os.FileMode(420), modTime: time.Unix(1513730497, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __5_add_app_created_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x2c\x28\x28\x56\x70\x74\x71\x51\x48\x2e\x4a\x4d\x2c\x49\x4d\x89\x4f\x2c\x51\x28\x4b\x2c\x4a\xce\x48\x2c\xd2\x30\x32\x35\xd3\xb4\xe6\x02\x04\x00\x00\xff\xff\x76\x6c\x0f\x45\x2e\x00\x00\x00")
+
+func _5_add_app_created_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__5_add_app_created_atUpSql,
+		"5_add_app_created_at.up.sql",
+	)
+}
+
+func _5_add_app_created_atUpSql() (*asset, error) {
+	bytes, err := _5_add_app_created_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "5_add_app_created_at.up.sql", size: 46, mode: os.FileMode(420), modTime: time.Unix(1513730527, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -295,6 +337,8 @@ var _bindata = map[string]func() (*asset, error){
 	"3_add_call_error.up.sql":         _3_add_call_errorUpSql,
 	"4_add_route_updated_at.down.sql": _4_add_route_updated_atDownSql,
 	"4_add_route_updated_at.up.sql":   _4_add_route_updated_atUpSql,
+	"5_add_app_created_at.down.sql":   _5_add_app_created_atDownSql,
+	"5_add_app_created_at.up.sql":     _5_add_app_created_atUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -346,6 +390,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"3_add_call_error.up.sql":         &bintree{_3_add_call_errorUpSql, map[string]*bintree{}},
 	"4_add_route_updated_at.down.sql": &bintree{_4_add_route_updated_atDownSql, map[string]*bintree{}},
 	"4_add_route_updated_at.up.sql":   &bintree{_4_add_route_updated_atUpSql, map[string]*bintree{}},
+	"5_add_app_created_at.down.sql":   &bintree{_5_add_app_created_atDownSql, map[string]*bintree{}},
+	"5_add_app_created_at.up.sql":     &bintree{_5_add_app_created_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/api/datastore/sql/migrations/migrations.go
+++ b/api/datastore/sql/migrations/migrations.go
@@ -10,6 +10,8 @@
 // 4_add_route_updated_at.up.sql
 // 5_add_app_created_at.down.sql
 // 5_add_app_created_at.up.sql
+// 6_add_app_updated_at.down.sql
+// 6_add_app_updated_at.up.sql
 // DO NOT EDIT!
 
 package migrations
@@ -277,6 +279,46 @@ func _5_add_app_created_atUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __6_add_app_updated_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x2c\x28\x28\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x2d\x48\x49\x2c\x49\x4d\x89\x4f\x2c\xb1\xe6\x02\x04\x00\x00\xff\xff\x31\x44\xd7\xcc\x29\x00\x00\x00")
+
+func _6_add_app_updated_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__6_add_app_updated_atDownSql,
+		"6_add_app_updated_at.down.sql",
+	)
+}
+
+func _6_add_app_updated_atDownSql() (*asset, error) {
+	bytes, err := _6_add_app_updated_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "6_add_app_updated_at.down.sql", size: 41, mode: os.FileMode(420), modTime: time.Unix(1513733616, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __6_add_app_updated_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\x2c\x28\x28\x56\x70\x74\x71\x51\x28\x2d\x48\x49\x2c\x49\x4d\x89\x4f\x2c\x51\x28\x4b\x2c\x4a\xce\x48\x2c\xd2\x30\x32\x35\xd3\xb4\xe6\x02\x04\x00\x00\xff\xff\x65\x01\x8b\x34\x2e\x00\x00\x00")
+
+func _6_add_app_updated_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__6_add_app_updated_atUpSql,
+		"6_add_app_updated_at.up.sql",
+	)
+}
+
+func _6_add_app_updated_atUpSql() (*asset, error) {
+	bytes, err := _6_add_app_updated_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "6_add_app_updated_at.up.sql", size: 46, mode: os.FileMode(420), modTime: time.Unix(1513733621, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -339,6 +381,8 @@ var _bindata = map[string]func() (*asset, error){
 	"4_add_route_updated_at.up.sql":   _4_add_route_updated_atUpSql,
 	"5_add_app_created_at.down.sql":   _5_add_app_created_atDownSql,
 	"5_add_app_created_at.up.sql":     _5_add_app_created_atUpSql,
+	"6_add_app_updated_at.down.sql":   _6_add_app_updated_atDownSql,
+	"6_add_app_updated_at.up.sql":     _6_add_app_updated_atUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -392,6 +436,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"4_add_route_updated_at.up.sql":   &bintree{_4_add_route_updated_atUpSql, map[string]*bintree{}},
 	"5_add_app_created_at.down.sql":   &bintree{_5_add_app_created_atDownSql, map[string]*bintree{}},
 	"5_add_app_created_at.up.sql":     &bintree{_5_add_app_created_atUpSql, map[string]*bintree{}},
+	"6_add_app_updated_at.down.sql":   &bintree{_6_add_app_updated_atDownSql, map[string]*bintree{}},
+	"6_add_app_updated_at.up.sql":     &bintree{_6_add_app_updated_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -300,7 +300,7 @@ func (ds *sqlStore) InsertApp(ctx context.Context, app *models.App) (*models.App
 func (ds *sqlStore) UpdateApp(ctx context.Context, newapp *models.App) (*models.App, error) {
 	app := &models.App{Name: newapp.Name}
 	err := ds.Tx(func(tx *sqlx.Tx) error {
-		// NOTE: must query whole object since we're returning app, UpdateConfig logic
+		// NOTE: must query whole object since we're returning app, Update logic
 		// must only modify modifiable fields (as seen here). need to fix brittle..
 		query := tx.Rebind(`SELECT name, config, created_at, updated_at FROM apps WHERE name=?`)
 		row := tx.QueryRowxContext(ctx, query, app.Name)
@@ -312,7 +312,7 @@ func (ds *sqlStore) UpdateApp(ctx context.Context, newapp *models.App) (*models.
 			return err
 		}
 
-		app.UpdateConfig(newapp)
+		app.Update(newapp)
 
 		query = tx.Rebind(`UPDATE apps SET config=:config, updated_at=:updated_at WHERE name=:name`)
 		res, err := tx.NamedExecContext(ctx, query, app)

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -1,8 +1,25 @@
 package models
 
+import (
+	"time"
+
+	"github.com/go-openapi/strfmt"
+)
+
 type App struct {
-	Name   string `json:"name" db:"name"`
-	Config Config `json:"config,omitempty" db:"config"`
+	Name      string          `json:"name" db:"name"`
+	Config    Config          `json:"config,omitempty" db:"config"`
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at"`
+}
+
+func (a *App) SetDefaults() {
+	if time.Time(a.CreatedAt).IsZero() {
+		a.CreatedAt = strfmt.DateTime(time.Now())
+	}
+	if a.Config == nil {
+		// keeps the json from being nil
+		a.Config = map[string]string{}
+	}
 }
 
 func (a *App) Validate() error {
@@ -33,12 +50,12 @@ func (a *App) Clone() *App {
 }
 
 // UpdateConfig adds entries from patch to a.Config, and removes entries with empty values.
-func (a *App) UpdateConfig(patch Config) {
-	if patch != nil {
+func (a *App) UpdateConfig(src *App) {
+	if src.Config != nil {
 		if a.Config == nil {
 			a.Config = make(Config)
 		}
-		for k, v := range patch {
+		for k, v := range src.Config {
 			if v == "" {
 				delete(a.Config, k)
 			} else {

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -47,7 +47,7 @@ func (a *App) Clone() *App {
 
 	// now deep copy the map
 	if a.Config != nil {
-		clone.Config = make(Config)
+		clone.Config = make(Config, len(a.Config))
 		for k, v := range a.Config {
 			clone.Config[k] = v
 		}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -10,11 +10,15 @@ type App struct {
 	Name      string          `json:"name" db:"name"`
 	Config    Config          `json:"config,omitempty" db:"config"`
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at"`
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at"`
 }
 
 func (a *App) SetDefaults() {
 	if time.Time(a.CreatedAt).IsZero() {
 		a.CreatedAt = strfmt.DateTime(time.Now())
+	}
+	if time.Time(a.UpdatedAt).IsZero() {
+		a.UpdatedAt = strfmt.DateTime(time.Now())
 	}
 	if a.Config == nil {
 		// keeps the json from being nil
@@ -52,6 +56,7 @@ func (a *App) Clone() *App {
 // UpdateConfig adds entries from patch to a.Config, and removes entries with empty values.
 func (a *App) UpdateConfig(src *App) {
 	if src.Config != nil {
+		a.UpdatedAt = strfmt.DateTime(time.Now())
 		if a.Config == nil {
 			a.Config = make(Config)
 		}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -55,10 +55,25 @@ func (a *App) Clone() *App {
 	return clone
 }
 
-// UpdateConfig adds entries from patch to a.Config, and removes entries with empty values.
-func (a *App) UpdateConfig(src *App) {
+func (a1 *App) Equals(a2 *App) bool {
+	// start off equal, check equivalence of each field.
+	// the RHS of && won't eval if eq==false so config checking is lazy
+
+	eq := true
+	eq = eq && a1.Name == a2.Name
+	eq = eq && a1.Config.Equals(a2.Config)
+	// NOTE: datastore tests are not very fun to write with timestamp checks,
+	// and these are not values the user may set so we kind of don't care.
+	//eq = eq && time.Time(a1.CreatedAt).Equal(time.Time(a2.CreatedAt))
+	//eq = eq && time.Time(a1.UpdatedAt).Equal(time.Time(a2.UpdatedAt))
+	return eq
+}
+
+// Update adds entries from patch to a.Config, and removes entries with empty values.
+func (a *App) Update(src *App) {
+	original := a.Clone()
+
 	if src.Config != nil {
-		a.UpdatedAt = strfmt.DateTime(time.Now())
 		if a.Config == nil {
 			a.Config = make(Config)
 		}
@@ -69,6 +84,10 @@ func (a *App) UpdateConfig(src *App) {
 				a.Config[k] = v
 			}
 		}
+	}
+
+	if !a.Equals(original) {
+		a.UpdatedAt = strfmt.DateTime(time.Now())
 	}
 }
 

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -42,15 +42,17 @@ func (a *App) Validate() error {
 }
 
 func (a *App) Clone() *App {
-	var c App
-	c.Name = a.Name
+	clone := new(App)
+	*clone = *a // shallow copy
+
+	// now deep copy the map
 	if a.Config != nil {
-		c.Config = make(Config)
+		clone.Config = make(Config)
 		for k, v := range a.Config {
-			c.Config[k] = v
+			clone.Config[k] = v
 		}
 	}
-	return &c
+	return clone
 }
 
 // UpdateConfig adds entries from patch to a.Config, and removes entries with empty values.

--- a/api/models/config.go
+++ b/api/models/config.go
@@ -14,6 +14,19 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+func (c1 Config) Equals(c2 Config) bool {
+	if len(c1) != len(c2) {
+		return false
+	}
+	for k1, v1 := range r1.Config {
+		v2, _ := r2.Config[k1]
+		if v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
 // implements sql.Valuer, returning a string
 func (c Config) Value() (driver.Value, error) {
 	if len(c) < 1 {
@@ -55,6 +68,24 @@ func (c *Config) Scan(value interface{}) error {
 
 // Headers is an http.Header that implements additional methods.
 type Headers http.Header
+
+func (h1 Headers) Equals(h2 Headers) bool {
+	if len(h1) != len(h2) {
+		return false
+	}
+	for k1, v1s := range r1.Headers {
+		v2s, ok := r2.Headers[k1]
+		if !ok || len(v2s) != len(v1s) {
+			return false
+		}
+		for i, v1 := range v1s {
+			if v2s[i] != v1 {
+				return false
+			}
+		}
+	}
+	return true
+}
 
 // implements sql.Valuer, returning a string
 func (h Headers) Value() (driver.Value, error) {

--- a/api/models/config.go
+++ b/api/models/config.go
@@ -18,8 +18,8 @@ func (c1 Config) Equals(c2 Config) bool {
 	if len(c1) != len(c2) {
 		return false
 	}
-	for k1, v1 := range r1.Config {
-		v2, _ := r2.Config[k1]
+	for k1, v1 := range c1 {
+		v2, _ := c2[k1]
 		if v1 != v2 {
 			return false
 		}
@@ -73,9 +73,9 @@ func (h1 Headers) Equals(h2 Headers) bool {
 	if len(h1) != len(h2) {
 		return false
 	}
-	for k1, v1s := range r1.Headers {
-		v2s, ok := r2.Headers[k1]
-		if !ok || len(v2s) != len(v1s) {
+	for k1, v1s := range h1 {
+		v2s, _ := h2[k1]
+		if len(v2s) != len(v1s) {
 			return false
 		}
 		for i, v1 := range v1s {

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -152,38 +152,51 @@ func (r *Route) Clone() *Route {
 	return clone
 }
 
-func (r *Route) up() { r.UpdatedAt = strfmt.DateTime(time.Now()) }
+func (r1 *Route) Equals(r2 *Route) bool {
+	// start off equal, check equivalence of each field.
+	// the RHS of && won't eval if eq==false so config/headers checking is lazy
+
+	eq := true
+	eq = eq && r1.AppName == r2.AppName
+	eq = eq && r1.Path == r2.Path
+	eq = eq && r1.Image == r2.Image
+	eq = eq && r1.Memory == r2.Memory
+	eq = eq && r1.Headers.Equals(r2.Headers)
+	eq = eq && r1.Type == r2.Type
+	eq = eq && r1.Format == r2.Format
+	eq = eq && r1.Timeout == r2.Timeout
+	eq = eq && r1.IdleTimeout == r2.IdleTimeout
+	eq = eq && r1.Config.Equals(r2.Config)
+	eq = eq && r1.CreatedAt == r2.CreatedAt
+	eq = eq && r2.UpdatedAt == r2.UpdatedAt
+	return eq
+}
 
 // Update updates fields in r with non-zero field values from new, and sets
 // updated_at if any of the fields change. 0-length slice Header values, and
 // empty-string Config values trigger removal of map entry.
 func (r *Route) Update(new *Route) {
+	original := r.Clone()
+
 	if new.Image != "" {
-		r.up()
 		r.Image = new.Image
 	}
 	if new.Memory != 0 {
-		r.up()
 		r.Memory = new.Memory
 	}
 	if new.Type != "" {
-		r.up()
 		r.Type = new.Type
 	}
 	if new.Timeout != 0 {
-		r.up()
 		r.Timeout = new.Timeout
 	}
 	if new.IdleTimeout != 0 {
-		r.up()
 		r.IdleTimeout = new.IdleTimeout
 	}
 	if new.Format != "" {
-		r.up()
 		r.Format = new.Format
 	}
 	if new.Headers != nil {
-		r.up()
 		if r.Headers == nil {
 			r.Headers = Headers(make(http.Header))
 		}
@@ -196,7 +209,6 @@ func (r *Route) Update(new *Route) {
 		}
 	}
 	if new.Config != nil {
-		r.up()
 		if r.Config == nil {
 			r.Config = make(Config)
 		}
@@ -207,6 +219,10 @@ func (r *Route) Update(new *Route) {
 				r.Config[k] = v
 			}
 		}
+	}
+
+	if !r.Equals(original) {
+		r.UpdatedAt = strfmt.DateTime(time.Now())
 	}
 }
 

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -137,13 +137,13 @@ func (r *Route) Clone() *Route {
 
 	// now deep copy the maps
 	if r.Config != nil {
-		clone.Config = make(Config)
+		clone.Config = make(Config, len(r.Config))
 		for k, v := range r.Config {
 			clone.Config[k] = v
 		}
 	}
 	if r.Headers != nil {
-		clone.Headers = Headers(make(http.Header))
+		clone.Headers = Headers(make(http.Header), len(r.Headers))
 		for k, v := range r.Headers {
 			// TODO technically, we need to deep copy this slice...
 			clone.Headers[k] = v

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 )
@@ -57,6 +58,7 @@ func (r *Route) SetDefaults() {
 	}
 
 	if r.Config == nil {
+		// keeps the json from being nil
 		r.Config = map[string]string{}
 	}
 

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -132,11 +132,24 @@ func (r *Route) Validate() error {
 }
 
 func (r *Route) Clone() *Route {
-	var clone Route
-	clone.AppName = r.AppName
-	clone.Path = r.Path
-	clone.Update(r)
-	return &clone
+	clone := new(Route)
+	*clone = *r // shallow copy
+
+	// now deep copy the maps
+	if r.Config != nil {
+		clone.Config = make(Config)
+		for k, v := range r.Config {
+			clone.Config[k] = v
+		}
+	}
+	if r.Headers != nil {
+		clone.Headers = Headers(make(http.Header))
+		for k, v := range r.Headers {
+			// TODO technically, we need to deep copy this slice...
+			clone.Headers[k] = v
+		}
+	}
+	return clone
 }
 
 func (r *Route) up() { r.UpdatedAt = strfmt.DateTime(time.Now()) }

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -143,7 +143,7 @@ func (r *Route) Clone() *Route {
 		}
 	}
 	if r.Headers != nil {
-		clone.Headers = Headers(make(http.Header), len(r.Headers))
+		clone.Headers = make(Headers, len(r.Headers))
 		for k, v := range r.Headers {
 			// TODO technically, we need to deep copy this slice...
 			clone.Headers[k] = v

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -167,8 +167,10 @@ func (r1 *Route) Equals(r2 *Route) bool {
 	eq = eq && r1.Timeout == r2.Timeout
 	eq = eq && r1.IdleTimeout == r2.IdleTimeout
 	eq = eq && r1.Config.Equals(r2.Config)
-	eq = eq && r1.CreatedAt == r2.CreatedAt
-	eq = eq && r2.UpdatedAt == r2.UpdatedAt
+	// NOTE: datastore tests are not very fun to write with timestamp checks,
+	// and these are not values the user may set so we kind of don't care.
+	//eq = eq && time.Time(r1.CreatedAt).Equal(time.Time(r2.CreatedAt))
+	//eq = eq && time.Time(r2.UpdatedAt).Equal(time.Time(r2.UpdatedAt))
 	return eq
 }
 

--- a/api/server/apps_create.go
+++ b/api/server/apps_create.go
@@ -18,29 +18,31 @@ func (s *Server) handleAppCreate(c *gin.Context) {
 		return
 	}
 
-	if wapp.App == nil {
+	app := wapp.App
+	if app == nil {
 		handleErrorResponse(c, models.ErrAppsMissingNew)
 		return
 	}
 
-	if err = wapp.Validate(); err != nil {
+	app.SetDefaults()
+	if err = app.Validate(); err != nil {
 		handleErrorResponse(c, err)
 		return
 	}
 
-	err = s.FireBeforeAppCreate(ctx, wapp.App)
+	err = s.FireBeforeAppCreate(ctx, app)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return
 	}
 
-	app, err := s.datastore.InsertApp(ctx, wapp.App)
+	app, err := s.datastore.InsertApp(ctx, app)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return
 	}
 
-	err = s.FireAfterAppCreate(ctx, wapp.App)
+	err = s.FireAfterAppCreate(ctx, app)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_create.go
+++ b/api/server/apps_create.go
@@ -36,7 +36,7 @@ func (s *Server) handleAppCreate(c *gin.Context) {
 		return
 	}
 
-	app, err := s.datastore.InsertApp(ctx, app)
+	app, err = s.datastore.InsertApp(ctx, app)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_test.go
+++ b/api/server/apps_test.go
@@ -90,11 +90,11 @@ func TestAppCreate(t *testing.T) {
 			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
 			if time.Time(app.CreatedAt).Before(time.Now().Add(-1 * time.Hour)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected created_at to be set on app, it wasn't: %v", i, app.CreatedAt)
+				t.Errorf("Test %d: expected created_at to be set on app, it wasn't: %s", i, app.CreatedAt)
 			}
 			if !(time.Time(app.CreatedAt)).Equal(time.Time(app.UpdatedAt)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to be set and same as created at, it wasn't: %v %v", i, app.CreatedAt, app.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to be set and same as created at, it wasn't: %s %s", i, app.CreatedAt, app.UpdatedAt)
 			}
 		}
 
@@ -325,7 +325,7 @@ func TestAppUpdate(t *testing.T) {
 			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
 			if time.Time(app.UpdatedAt).Before(time.Now().Add(-1 * time.Hour)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to be set on app, it wasn't: %v", i, app.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to be set on app, it wasn't: %s", i, app.UpdatedAt)
 			}
 
 			// this isn't perfect, since a PATCH could succeed without updating any
@@ -334,7 +334,7 @@ func TestAppUpdate(t *testing.T) {
 			// this is a decent approximation that the timestamp gets changed
 			if (time.Time(app.UpdatedAt)).Equal(time.Time(app.CreatedAt)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to not be the same as created at, it wasn't: %v %v", i, app.CreatedAt, app.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to not be the same as created at, it wasn't: %s %s", i, app.CreatedAt, app.UpdatedAt)
 			}
 		}
 

--- a/api/server/routes_create_update.go
+++ b/api/server/routes_create_update.go
@@ -5,12 +5,10 @@ import (
 	"net/http"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/fnproject/fn/api"
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
-	"github.com/go-openapi/strfmt"
 )
 
 /* handleRouteCreateOrUpdate is used to handle POST PUT and PATCH for routes.

--- a/api/server/routes_create_update.go
+++ b/api/server/routes_create_update.go
@@ -51,7 +51,6 @@ func (s *Server) handleRoutesPostPutPatch(c *gin.Context) {
 }
 
 func (s *Server) submitRoute(ctx context.Context, wroute *models.RouteWrapper) error {
-	wroute.Route.CreatedAt = strfmt.DateTime(time.Now())
 	wroute.Route.SetDefaults()
 	err := wroute.Route.Validate()
 	if err != nil {

--- a/api/server/routes_test.go
+++ b/api/server/routes_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/logs"
@@ -49,6 +50,46 @@ func (test *routeTestCase) run(t *testing.T, i int, buf *bytes.Buffer) {
 				i, test.expectedError, resp.Error.Message)
 		}
 	}
+
+	if test.expectedCode == http.StatusOK {
+		var rwrap models.RouteWrapper
+		err := json.NewDecoder(rec.Body).Decode(&rwrap)
+		if err != nil {
+			t.Log(buf.String())
+			t.Errorf("Test %d: error decoding body for 'ok' json, it was a lie: %v", i, err)
+		}
+
+		route := rwrap.Route
+		if test.method == http.MethodPost {
+			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
+			if time.Time(route.CreatedAt).Before(time.Now().Add(-1 * time.Hour)) {
+				t.Log(buf.String())
+				t.Error("Test %d: expected created_at to be set on route, it wasn't: %v", i, route.CreatedAt)
+			}
+			if !(time.Time(route.CreatedAt)).Equal(time.Time(route.UpdatedAt)) {
+				t.Log(buf.String())
+				t.Error("Test %d: expected updated_at to be set and same as created at, it wasn't: %v %v", i, route.CreatedAt, route.UpdatedAt)
+			}
+		}
+
+		if test.method == http.MethodPatch {
+			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
+			if time.Time(route.UpdatedAt).Before(time.Now().Add(-1 * time.Hour)) {
+				t.Log(buf.String())
+				t.Error("Test %d: expected updated_at to be set on route, it wasn't: %v", i, route.UpdatedAt)
+			}
+
+			// this isn't perfect, since a PATCH could succeed without updating any
+			// fields (among other reasons), but just don't make a test for that or
+			// special case (the body or smth) to ignore it here!
+			// this is a decent approximation that the timestamp gets changed
+			if (time.Time(route.UpdatedAt)).Equal(time.Time(route.CreatedAt)) {
+				t.Log(buf.String())
+				t.Error("Test %d: expected updated_at to not be the same as created at, it wasn't: %v %v", i, route.CreatedAt, route.UpdatedAt)
+			}
+		}
+	}
+
 	cancel()
 	buf.Reset()
 }

--- a/api/server/routes_test.go
+++ b/api/server/routes_test.go
@@ -64,11 +64,11 @@ func (test *routeTestCase) run(t *testing.T, i int, buf *bytes.Buffer) {
 			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
 			if time.Time(route.CreatedAt).Before(time.Now().Add(-1 * time.Hour)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected created_at to be set on route, it wasn't: %v", i, route.CreatedAt)
+				t.Errorf("Test %d: expected created_at to be set on route, it wasn't: %s", i, route.CreatedAt)
 			}
 			if !(time.Time(route.CreatedAt)).Equal(time.Time(route.UpdatedAt)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to be set and same as created at, it wasn't: %v %v", i, route.CreatedAt, route.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to be set and same as created at, it wasn't: %s %s", i, route.CreatedAt, route.UpdatedAt)
 			}
 		}
 
@@ -76,7 +76,7 @@ func (test *routeTestCase) run(t *testing.T, i int, buf *bytes.Buffer) {
 			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
 			if time.Time(route.UpdatedAt).Before(time.Now().Add(-1 * time.Hour)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to be set on route, it wasn't: %v", i, route.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to be set on route, it wasn't: %s", i, route.UpdatedAt)
 			}
 
 			// this isn't perfect, since a PATCH could succeed without updating any
@@ -85,7 +85,7 @@ func (test *routeTestCase) run(t *testing.T, i int, buf *bytes.Buffer) {
 			// this is a decent approximation that the timestamp gets changed
 			if (time.Time(route.UpdatedAt)).Equal(time.Time(route.CreatedAt)) {
 				t.Log(buf.String())
-				t.Error("Test %d: expected updated_at to not be the same as created at, it wasn't: %v %v", i, route.CreatedAt, route.UpdatedAt)
+				t.Errorf("Test %d: expected updated_at to not be the same as created at, it wasn't: %s %s", i, route.CreatedAt, route.UpdatedAt)
 			}
 		}
 	}

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -516,6 +516,16 @@ definitions:
         default: 30
         format: int32
         description: Hot functions idle timeout before termination. Value in Seconds
+      created_at:
+        type: string
+        format: date-time
+        description: Time when route was created. Always in UTC.
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        description: Most recent time that route was updated. Always in UTC.
+        readOnly: true
 
   App:
     type: object
@@ -529,6 +539,16 @@ definitions:
         description: Application configuration, applied to all routes.
         additionalProperties:
           type: string
+      created_at:
+        type: string
+        format: date-time
+        description: Time when app was created. Always in UTC.
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        description: Most recent time that app was updated. Always in UTC.
+        readOnly: true
 
   Version:
     type: object

--- a/images/dind/build.sh
+++ b/images/dind/build.sh
@@ -1,3 +1,3 @@
 set -ex
 
-docker build --build-arg HTTP_PROXY -t fnproject/dind:latest .
+docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/dind:latest .

--- a/images/error/build.sh
+++ b/images/error/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-docker build -t fnproject/error .
+docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/error .

--- a/images/fn-test-utils/build.sh
+++ b/images/fn-test-utils/build.sh
@@ -1,2 +1,2 @@
 set -e
-docker build -t fnproject/fn-test-utils:latest .
+docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/fn-test-utils:latest .

--- a/test/fn-api-tests/routes_test.go
+++ b/test/fn-api-tests/routes_test.go
@@ -1,12 +1,10 @@
 package tests
 
-//
 import (
 	"testing"
 
 	"github.com/fnproject/fn/api/id"
 	"github.com/fnproject/fn_go/models"
-	"reflect"
 )
 
 func TestRoutes(t *testing.T) {
@@ -203,7 +201,7 @@ func TestRoutes(t *testing.T) {
 		routeHeaders["B"] = []string{"b"}
 		DeployRoute(t, s.Context, s.Client, s.AppName, s.RoutePath, s.Image, s.RouteType, s.Format, s.RouteConfig, routeHeaders)
 		sameRoute := DeployRoute(t, s.Context, s.Client, s.AppName, s.RoutePath, s.Image, s.RouteType, s.Format, s.RouteConfig, routeHeaders)
-		if ok := reflect.DeepEqual(sameRoute.Headers, routeHeaders); !ok {
+		if !models.Headers(sameRoute.Headers).Equals(models.Headers(routeHeaders)) {
 			t.Error("Route headers should remain the same after multiple deploys with exact the same parameters")
 		}
 		DeleteApp(t, s.Context, s.Client, s.AppName)

--- a/test/fn-api-tests/routes_test.go
+++ b/test/fn-api-tests/routes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/fnproject/fn/api/id"
+	api_models "github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn_go/models"
 )
 
@@ -201,7 +202,7 @@ func TestRoutes(t *testing.T) {
 		routeHeaders["B"] = []string{"b"}
 		DeployRoute(t, s.Context, s.Client, s.AppName, s.RoutePath, s.Image, s.RouteType, s.Format, s.RouteConfig, routeHeaders)
 		sameRoute := DeployRoute(t, s.Context, s.Client, s.AppName, s.RoutePath, s.Image, s.RouteType, s.Format, s.RouteConfig, routeHeaders)
-		if !models.Headers(sameRoute.Headers).Equals(models.Headers(routeHeaders)) {
+		if !api_models.Headers(sameRoute.Headers).Equals(api_models.Headers(routeHeaders)) {
 			t.Error("Route headers should remain the same after multiple deploys with exact the same parameters")
 		}
 		DeleteApp(t, s.Context, s.Client, s.AppName)


### PR DESCRIPTION
closes #367 

this finishes the time stamp saga for apps & routes, with created_at and updated_at on each one. should be pretty straight forward, there's some minor changes to tests / route init logic.

there are tests to ensure that these things are getting set. 