### PR TITLE
unexport all data abstractions on Server

### DIFF
--- a/api/server/apps_create.go
+++ b/api/server/apps_create.go
@@ -34,7 +34,7 @@ func (s *Server) handleAppCreate(c *gin.Context) {
 		return
 	}
 
-	app, err := s.Datastore().InsertApp(ctx, wapp.App)
+	app, err := s.datastore.InsertApp(ctx, wapp.App)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_delete.go
+++ b/api/server/apps_delete.go
@@ -17,7 +17,7 @@ func (s *Server) handleAppDelete(c *gin.Context) {
 
 	err := s.FireBeforeAppDelete(ctx, app)
 
-	err = s.Datastore().RemoveApp(ctx, app.Name)
+	err = s.datastore.RemoveApp(ctx, app.Name)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_get.go
+++ b/api/server/apps_get.go
@@ -18,7 +18,7 @@ func (s *Server) handleAppGet(c *gin.Context) {
 		return
 	}
 
-	app, err := s.Datastore().GetApp(ctx, appName)
+	app, err := s.datastore.GetApp(ctx, appName)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -20,7 +20,7 @@ func (s *Server) handleAppList(c *gin.Context) {
 		return
 	}
 
-	apps, err := s.Datastore().GetApps(ctx, filter)
+	apps, err := s.datastore.GetApps(ctx, filter)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/apps_update.go
+++ b/api/server/apps_update.go
@@ -37,7 +37,7 @@ func (s *Server) handleAppUpdate(c *gin.Context) {
 		return
 	}
 
-	app, err := s.Datastore().UpdateApp(ctx, wapp.App)
+	app, err := s.datastore.UpdateApp(ctx, wapp.App)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/call_get.go
+++ b/api/server/call_get.go
@@ -12,7 +12,7 @@ func (s *Server) handleCallGet(c *gin.Context) {
 
 	appName := c.MustGet(api.AppName).(string)
 	callID := c.Param(api.Call)
-	callObj, err := s.Datastore().GetCall(ctx, appName, callID)
+	callObj, err := s.datastore.GetCall(ctx, appName, callID)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/call_list.go
+++ b/api/server/call_list.go
@@ -27,11 +27,11 @@ func (s *Server) handleCallList(c *gin.Context) {
 		return
 	}
 
-	calls, err := s.Datastore().GetCalls(ctx, &filter)
+	calls, err := s.datastore.GetCalls(ctx, &filter)
 
 	if len(calls) == 0 {
 		// TODO this should be done in front of this handler to even get here...
-		_, err = s.Datastore().GetApp(c, appName)
+		_, err = s.datastore.GetApp(c, appName)
 	}
 
 	if err != nil {

--- a/api/server/call_logs.go
+++ b/api/server/call_logs.go
@@ -15,7 +15,7 @@ func (s *Server) handleCallLogGet(c *gin.Context) {
 	appName := c.MustGet(api.AppName).(string)
 	callID := c.Param(api.Call)
 
-	logReader, err := s.LogDB.GetLog(ctx, appName, callID)
+	logReader, err := s.logstore.GetLog(ctx, appName, callID)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/extension_points.go
+++ b/api/server/extension_points.go
@@ -20,7 +20,7 @@ func (s *Server) apiAppHandlerWrapperFunc(apiHandler fnext.ApiAppHandler) gin.Ha
 	return func(c *gin.Context) {
 		// get the app
 		appName := c.Param(api.CApp)
-		app, err := s.Datastore().GetApp(c.Request.Context(), appName)
+		app, err := s.datastore.GetApp(c.Request.Context(), appName)
 		if err != nil {
 			handleErrorResponse(c, err)
 			c.Abort()
@@ -41,7 +41,7 @@ func (s *Server) apiRouteHandlerWrapperFunc(apiHandler fnext.ApiRouteHandler) gi
 		context := c.Request.Context()
 		// get the app
 		appName := c.Param(api.CApp)
-		app, err := s.Datastore().GetApp(context, appName)
+		app, err := s.datastore.GetApp(context, appName)
 		if err != nil {
 			handleErrorResponse(c, err)
 			c.Abort()
@@ -54,7 +54,7 @@ func (s *Server) apiRouteHandlerWrapperFunc(apiHandler fnext.ApiRouteHandler) gi
 		}
 		// get the route TODO
 		routePath := "/" + c.Param(api.CRoute)
-		route, err := s.Datastore().GetRoute(context, appName, routePath)
+		route, err := s.datastore.GetRoute(context, appName, routePath)
 		if err != nil {
 			handleErrorResponse(c, err)
 			c.Abort()

--- a/api/server/listeners.go
+++ b/api/server/listeners.go
@@ -4,5 +4,5 @@ import "github.com/fnproject/fn/fnext"
 
 // AddCallListener adds a listener that will be fired before and after a function is executed.
 func (s *Server) AddCallListener(listener fnext.CallListener) {
-	s.Agent.AddCallListener(listener)
+	s.agent.AddCallListener(listener)
 }

--- a/api/server/prometheus_metrics.go
+++ b/api/server/prometheus_metrics.go
@@ -5,5 +5,5 @@ import (
 )
 
 func (s *Server) handlePrometheusMetrics(c *gin.Context) {
-	s.Agent.PromHandler().ServeHTTP(c.Writer, c.Request)
+	s.agent.PromHandler().ServeHTTP(c.Writer, c.Request)
 }

--- a/api/server/routes_create_update.go
+++ b/api/server/routes_create_update.go
@@ -57,7 +57,7 @@ func (s *Server) submitRoute(ctx context.Context, wroute *models.RouteWrapper) e
 	if err != nil {
 		return err
 	}
-	r, err := s.Datastore().InsertRoute(ctx, wroute.Route)
+	r, err := s.datastore.InsertRoute(ctx, wroute.Route)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (s *Server) submitRoute(ctx context.Context, wroute *models.RouteWrapper) e
 }
 
 func (s *Server) changeRoute(ctx context.Context, wroute *models.RouteWrapper) error {
-	r, err := s.Datastore().UpdateRoute(ctx, wroute.Route)
+	r, err := s.datastore.UpdateRoute(ctx, wroute.Route)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (s *Server) ensureRoute(ctx context.Context, method string, wroute *models.
 		}
 		return routeResponse{"Route successfully created", wroute.Route}, nil
 	case http.MethodPut:
-		_, err := s.Datastore().GetRoute(ctx, wroute.Route.AppName, wroute.Route.Path)
+		_, err := s.datastore.GetRoute(ctx, wroute.Route.AppName, wroute.Route.Path)
 		if err != nil && err == models.ErrRoutesNotFound {
 			err := s.submitRoute(ctx, wroute)
 			if err != nil {
@@ -111,7 +111,7 @@ func (s *Server) ensureRoute(ctx context.Context, method string, wroute *models.
 
 // ensureApp will only execute if it is on post or put. Patch is not allowed to create apps.
 func (s *Server) ensureApp(ctx context.Context, wroute *models.RouteWrapper, method string) error {
-	app, err := s.Datastore().GetApp(ctx, wroute.Route.AppName)
+	app, err := s.datastore.GetApp(ctx, wroute.Route.AppName)
 	if err != nil && err != models.ErrAppsNotFound {
 		return err
 	} else if app == nil {
@@ -126,7 +126,7 @@ func (s *Server) ensureApp(ctx context.Context, wroute *models.RouteWrapper, met
 			return err
 		}
 
-		_, err = s.Datastore().InsertApp(ctx, newapp)
+		_, err = s.datastore.InsertApp(ctx, newapp)
 		if err != nil {
 			return err
 		}

--- a/api/server/routes_delete.go
+++ b/api/server/routes_delete.go
@@ -14,12 +14,12 @@ func (s *Server) handleRouteDelete(c *gin.Context) {
 	appName := c.MustGet(api.AppName).(string)
 	routePath := path.Clean(c.MustGet(api.Path).(string))
 
-	if _, err := s.Datastore().GetRoute(ctx, appName, routePath); err != nil {
+	if _, err := s.datastore.GetRoute(ctx, appName, routePath); err != nil {
 		handleErrorResponse(c, err)
 		return
 	}
 
-	if err := s.Datastore().RemoveRoute(ctx, appName, routePath); err != nil {
+	if err := s.datastore.RemoveRoute(ctx, appName, routePath); err != nil {
 		handleErrorResponse(c, err)
 		return
 	}

--- a/api/server/routes_get.go
+++ b/api/server/routes_get.go
@@ -13,7 +13,7 @@ func (s *Server) handleRouteGet(c *gin.Context) {
 
 	appName := c.MustGet(api.AppName).(string)
 	routePath := path.Clean("/" + c.MustGet(api.Path).(string))
-	route, err := s.Datastore().GetRoute(ctx, appName, routePath)
+	route, err := s.datastore.GetRoute(ctx, appName, routePath)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/routes_list.go
+++ b/api/server/routes_list.go
@@ -19,13 +19,13 @@ func (s *Server) handleRouteList(c *gin.Context) {
 	// filter.PathPrefix = c.Query("path_prefix") TODO not hooked up
 	filter.Cursor, filter.PerPage = pageParams(c, true)
 
-	routes, err := s.Datastore().GetRoutesByApp(ctx, appName, &filter)
+	routes, err := s.datastore.GetRoutesByApp(ctx, appName, &filter)
 
 	// if there are no routes for the app, check if the app exists to return
 	// 404 if it does not
 	// TODO this should be done in front of this handler to even get here...
 	if err == nil && len(routes) == 0 {
-		_, err = s.Datastore().GetApp(ctx, appName)
+		_, err = s.datastore.GetApp(ctx, appName)
 	}
 
 	if err != nil {

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -55,7 +55,7 @@ func parseParams(params gin.Params) agent.Params {
 func (s *Server) serve(c *gin.Context, appName, path string) {
 	// GetCall can mod headers, assign an id, look up the route/app (cached),
 	// strip params, etc.
-	call, err := s.Agent.GetCall(
+	call, err := s.agent.GetCall(
 		agent.WithWriter(c.Writer), // XXX (reed): order matters [for now]
 		agent.FromRequest(appName, path, c.Request, parseParams(c.Params)),
 	)
@@ -85,7 +85,7 @@ func (s *Server) serve(c *gin.Context, appName, path string) {
 		model.Payload = buf.String()
 
 		// TODO idk where to put this, but agent is all runner really has...
-		err = s.Agent.Enqueue(c.Request.Context(), model)
+		err = s.agent.Enqueue(c.Request.Context(), model)
 		if err != nil {
 			handleErrorResponse(c, err)
 			return
@@ -95,7 +95,7 @@ func (s *Server) serve(c *gin.Context, appName, path string) {
 		return
 	}
 
-	err = s.Agent.Submit(call)
+	err = s.agent.Submit(call)
 	if err != nil {
 		// NOTE if they cancel the request then it will stop the call (kind of cool),
 		// we could filter that error out here too as right now it yells a little

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -17,10 +17,10 @@ func testRouterAsync(ds models.Datastore, mq models.MessageQueue, rnr agent.Agen
 	ctx := context.Background()
 
 	s := &Server{
-		Agent:     rnr,
+		agent:     rnr,
 		Router:    gin.New(),
 		datastore: ds,
-		MQ:        mq,
+		mq:        mq,
 		nodeType:  ServerTypeFull,
 	}
 

--- a/api/server/stats.go
+++ b/api/server/stats.go
@@ -7,5 +7,5 @@ import (
 )
 
 func (s *Server) handleStats(c *gin.Context) {
-	c.JSON(http.StatusOK, s.Agent.Stats())
+	c.JSON(http.StatusOK, s.agent.Stats())
 }


### PR DESCRIPTION
this patch has no behavior changes, changes are:

* server.Datastore() (uses in `api/server` only) -> server.datastore
* server.MQ -> server.mq
* server.LogDB -> server.logstore
* server.Agent -> server.agent

these were at a minimum not uniform. further, it's probably better to force
configuration through initialization in `server.New` to ensure thread safety
of referencing if someone does want to modify these as well as forcing things
into our initialization path and reducing the surface area of the Server
abstraction.