### PR TITLE
allow user configured agent in full node

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -204,6 +204,10 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 
 	switch s.nodeType {
 	case ServerTypeAPI:
+		if s.agent != nil {
+			logrus.Info("shutting down agent configured for api node")
+			s.agent.Close()
+		}
 		s.agent = nil
 	case ServerTypeRunner:
 		if s.agent == nil {
@@ -215,9 +219,11 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 			logrus.Fatal("Full nodes must configure FN_DB_URL, FN_LOG_URL, FN_MQ_URL.")
 		}
 
-		// TODO force caller to use WithAgent option ?
-		// TODO for tests we don't want cache, really, if we force WithAgent this can be fixed. cache needs to be moved anyway so that runner nodes can use it...
-		s.agent = agent.New(agent.NewCachedDataAccess(agent.NewDirectDataAccess(s.datastore, s.logstore, s.mq)))
+		// TODO force caller to use WithAgent option? at this point we need to use the ds/ls/mq configured after all opts are run.
+		if s.agent == nil {
+			// TODO for tests we don't want cache, really, if we force WithAgent this can be fixed. cache needs to be moved anyway so that runner nodes can use it...
+			s.agent = agent.New(agent.NewCachedDataAccess(agent.NewDirectDataAccess(s.datastore, s.logstore, s.mq)))
+		}
 	}
 
 	setMachineID()

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -168,7 +168,7 @@ func TestRunnerNode(t *testing.T) {
 
 	// Add route with an API server using the same DB
 	{
-		apiServer := testServer(ds, &mqs.Mock{}, logDB, rnr, ServerTypeAPI)
+		apiServer := testServer(ds, &mqs.Mock{}, logDB, nil, ServerTypeAPI)
 		_, rec := routerRequest(t, apiServer.Router, "POST", "/v1/apps/myapp/routes", bytes.NewBuffer([]byte(`{ "route": { "name": "myroute", "path": "/myroute", "image": "fnproject/hello", "type": "sync" } }`)))
 		if rec.Code != http.StatusOK {
 			t.Errorf("Expected status code 200 when creating sync route, but got %d", rec.Code)


### PR DESCRIPTION
this should keep the old default behavior but allow users to pass in a
configured agent to configure the server themselves, without having to worry
about a russian agent being a british agent.

also closes any agent given to an api node.

closes #623