### PR TITLE
Use retry func while trying to ping SQL datastore

### DIFF
--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -1,17 +1,19 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/datastore/internal/datastoreutil"
 	"github.com/fnproject/fn/api/datastore/sql"
 	"github.com/fnproject/fn/api/models"
 	"github.com/sirupsen/logrus"
 )
 
-func New(dbURL string) (models.Datastore, error) {
-	ds, err := newds(dbURL) // teehee
+func New(ctx context.Context, dbURL string) (models.Datastore, error) {
+	ds, err := newds(ctx, dbURL) // teehee
 	if err != nil {
 		return nil, err
 	}
@@ -19,15 +21,16 @@ func New(dbURL string) (models.Datastore, error) {
 	return datastoreutil.MetricDS(datastoreutil.NewValidator(ds)), nil
 }
 
-func newds(dbURL string) (models.Datastore, error) {
+func newds(ctx context.Context, dbURL string) (models.Datastore, error) {
+	log := common.Logger(ctx)
 	u, err := url.Parse(dbURL)
 	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{"url": dbURL}).Fatal("bad DB URL")
+		log.WithError(err).WithFields(logrus.Fields{"url": dbURL}).Fatal("bad DB URL")
 	}
-	logrus.WithFields(logrus.Fields{"db": u.Scheme}).Debug("creating new datastore")
+	log.WithFields(logrus.Fields{"db": u.Scheme}).Debug("creating new datastore")
 	switch u.Scheme {
 	case "sqlite3", "postgres", "mysql":
-		return sql.New(u)
+		return sql.New(ctx, u)
 	default:
 		return nil, fmt.Errorf("db type not supported %v", u.Scheme)
 	}

--- a/api/datastore/sql/sql_test.go
+++ b/api/datastore/sql/sql_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"context"
 	"github.com/fnproject/fn/api/datastore/internal/datastoretest"
 	"github.com/fnproject/fn/api/datastore/internal/datastoreutil"
 	"github.com/fnproject/fn/api/models"
@@ -15,8 +16,8 @@ import (
 // * run all down migrations
 // * run all up migrations
 // [ then run tests against that db ]
-func newWithMigrations(url *url.URL) (*sqlStore, error) {
-	ds, err := newDS(url)
+func newWithMigrations(ctx context.Context, url *url.URL) (*sqlStore, error) {
+	ds, err := newDS(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +33,7 @@ func newWithMigrations(url *url.URL) (*sqlStore, error) {
 	}
 
 	// go through New, to ensure our Up logic works in there...
-	ds, err = newDS(url)
+	ds, err = newDS(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +42,7 @@ func newWithMigrations(url *url.URL) (*sqlStore, error) {
 }
 
 func TestDatastore(t *testing.T) {
+	ctx := context.Background()
 	defer os.RemoveAll("sqlite_test_dir")
 	u, err := url.Parse("sqlite3://sqlite_test_dir")
 	if err != nil {
@@ -48,7 +50,7 @@ func TestDatastore(t *testing.T) {
 	}
 	f := func(t *testing.T) models.Datastore {
 		os.RemoveAll("sqlite_test_dir")
-		ds, err := newDS(u)
+		ds, err := newDS(ctx, u)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,7 +69,7 @@ func TestDatastore(t *testing.T) {
 
 	both := func(u *url.URL) {
 		f := func(t *testing.T) models.Datastore {
-			ds, err := newDS(u)
+			ds, err := newDS(ctx, u)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -83,7 +85,7 @@ func TestDatastore(t *testing.T) {
 
 		f = func(t *testing.T) models.Datastore {
 			t.Log("with migrations now!")
-			ds, err := newWithMigrations(u)
+			ds, err := newWithMigrations(ctx, u)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/logs/log.go
+++ b/api/logs/log.go
@@ -4,21 +4,24 @@ import (
 	"fmt"
 	"net/url"
 
+	"context"
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/datastore/sql"
 	"github.com/fnproject/fn/api/logs/s3"
 	"github.com/fnproject/fn/api/models"
 	"github.com/sirupsen/logrus"
 )
 
-func New(dbURL string) (models.LogStore, error) {
+func New(ctx context.Context, dbURL string) (models.LogStore, error) {
+	log := common.Logger(ctx)
 	u, err := url.Parse(dbURL)
 	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{"url": dbURL}).Fatal("bad DB URL")
+		log.WithError(err).WithFields(logrus.Fields{"url": dbURL}).Fatal("bad DB URL")
 	}
-	logrus.WithFields(logrus.Fields{"db": u.Scheme}).Debug("creating log store")
+	log.WithFields(logrus.Fields{"db": u.Scheme}).Debug("creating log store")
 	switch u.Scheme {
 	case "sqlite3", "postgres", "mysql":
-		return sql.New(u)
+		return sql.New(ctx, u)
 	case "s3":
 		return s3.New(u)
 	default:

--- a/api/logs/log_test.go
+++ b/api/logs/log_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"context"
 	"github.com/fnproject/fn/api/datastore/sql"
 	logTesting "github.com/fnproject/fn/api/logs/testing"
 )
@@ -13,12 +14,13 @@ const tmpLogDb = "/tmp/func_test_log.db"
 
 func TestDatastore(t *testing.T) {
 	os.Remove(tmpLogDb)
+	ctx := context.Background()
 	uLog, err := url.Parse("sqlite3://" + tmpLogDb)
 	if err != nil {
 		t.Fatalf("failed to parse url: %v", err)
 	}
 
-	ds, err := sql.New(uLog)
+	ds, err := sql.New(ctx, uLog)
 	if err != nil {
 		t.Fatalf("failed to create sqlite3 datastore: %v", err)
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -98,9 +98,9 @@ func NewFromEnv(ctx context.Context, opts ...ServerOption) *Server {
 		defaultDB = fmt.Sprintf("sqlite3://%s/data/fn.db", curDir)
 		defaultMQ = fmt.Sprintf("bolt://%s/data/fn.mq", curDir)
 	}
-	opts = append(opts, WithDBURL(getEnv(EnvDBURL, defaultDB)))
+	opts = append(opts, WithDBURL(ctx, getEnv(EnvDBURL, defaultDB)))
 	opts = append(opts, WithMQURL(getEnv(EnvMQURL, defaultMQ)))
-	opts = append(opts, WithLogURL(getEnv(EnvLOGDBURL, "")))
+	opts = append(opts, WithLogURL(ctx, getEnv(EnvLOGDBURL, "")))
 	opts = append(opts, WithRunnerURL(getEnv(EnvRunnerURL, "")))
 	opts = append(opts, WithType(nodeType))
 	return New(ctx, opts...)
@@ -115,9 +115,9 @@ func pwd() string {
 	return strings.Replace(cwd, "\\", "/", -1)
 }
 
-func WithDBURL(dbURL string) ServerOption {
+func WithDBURL(ctx context.Context, dbURL string) ServerOption {
 	if dbURL != "" {
-		ds, err := datastore.New(dbURL)
+		ds, err := datastore.New(ctx, dbURL)
 		if err != nil {
 			logrus.WithError(err).Fatalln("Error initializing datastore.")
 		}
@@ -137,9 +137,9 @@ func WithMQURL(mqURL string) ServerOption {
 	return noop
 }
 
-func WithLogURL(logstoreURL string) ServerOption {
+func WithLogURL(ctx context.Context, logstoreURL string) ServerOption {
 	if ldb := logstoreURL; ldb != "" {
-		logDB, err := logs.New(logstoreURL)
+		logDB, err := logs.New(ctx, logstoreURL)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error initializing logs store.")
 		}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -206,6 +206,7 @@ func WithAgent(agent agent.Agent) ServerOption {
 // New creates a new Functions server with the opts given. For convenience, users may
 // prefer to use NewFromEnv but New is more flexible if needed.
 func New(ctx context.Context, opts ...ServerOption) *Server {
+	log := common.Logger(ctx)
 	s := &Server{
 		Router: gin.New(),
 		// Almost everything else is configured through opts (see NewFromEnv for ex.) or below
@@ -217,7 +218,7 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 		}
 		err := opt(ctx, s)
 		if err != nil {
-			common.Logger(ctx).WithError(err).Fatal("Error during server opt initialization.")
+			log.WithError(err).Fatal("Error during server opt initialization.")
 		}
 	}
 
@@ -230,18 +231,18 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 	switch s.nodeType {
 	case ServerTypeAPI:
 		if s.agent != nil {
-			logrus.Info("shutting down agent configured for api node")
+			log.Info("shutting down agent configured for api node")
 			s.agent.Close()
 		}
 		s.agent = nil
 	case ServerTypeRunner:
 		if s.agent == nil {
-			logrus.Fatal("No agent started for a runner node, add FN_RUNNER_API_URL to configuration.")
+			log.Fatal("No agent started for a runner node, add FN_RUNNER_API_URL to configuration.")
 		}
 	default:
 		s.nodeType = ServerTypeFull
 		if s.datastore == nil || s.logstore == nil || s.mq == nil {
-			logrus.Fatal("Full nodes must configure FN_DB_URL, FN_LOG_URL, FN_MQ_URL.")
+			log.Fatal("Full nodes must configure FN_DB_URL, FN_LOG_URL, FN_MQ_URL.")
 		}
 
 		// TODO force caller to use WithAgent option? at this point we need to use the ds/ls/mq configured after all opts are run.

--- a/api/server/server_options.go
+++ b/api/server/server_options.go
@@ -8,17 +8,19 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type ServerOption func(*Server)
+type ServerOption func(context.Context, *Server) error
 
-func EnableShutdownEndpoint(halt context.CancelFunc) ServerOption {
-	return func(s *Server) {
+func EnableShutdownEndpoint(ctx context.Context, halt context.CancelFunc) ServerOption {
+	return func(ctx context.Context, s *Server) error {
 		s.Router.GET("/shutdown", s.handleShutdown(halt))
+		return nil
 	}
 }
 
 func LimitRequestBody(max int64) ServerOption {
-	return func(s *Server) {
+	return func(ctx context.Context, s *Server) error {
 		s.Router.Use(limitRequestBody(max))
+		return nil
 	}
 }
 

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/server/router"
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/id"

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/server/router"
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/id"

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -100,7 +100,7 @@ func getErrorResponse(t *testing.T, rec *httptest.ResponseRecorder) models.Error
 
 func prepareDB(ctx context.Context, t *testing.T) (models.Datastore, models.LogStore, func()) {
 	os.Remove(tmpDatastoreTests)
-	ds, err := datastore.New("sqlite3://" + tmpDatastoreTests)
+	ds, err := datastore.New(ctx, "sqlite3://"+tmpDatastoreTests)
 	if err != nil {
 		t.Fatalf("Error when creating datastore: %s", err)
 	}

--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -71,7 +71,7 @@ func getServerWithCancel() (*server.Server, context.CancelFunc) {
 			dbURL = fmt.Sprintf("sqlite3://%s", tmpDb)
 		}
 
-		s = server.New(ctx, server.WithDBURL(dbURL), server.WithMQURL(mqURL))
+		s = server.New(ctx, server.WithDBURL(ctx, dbURL), server.WithMQURL(mqURL))
 
 		go s.Start(ctx)
 		started := false

--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -71,7 +71,7 @@ func getServerWithCancel() (*server.Server, context.CancelFunc) {
 			dbURL = fmt.Sprintf("sqlite3://%s", tmpDb)
 		}
 
-		s = server.New(ctx, server.WithDBURL(ctx, dbURL), server.WithMQURL(mqURL))
+		s = server.New(ctx, server.WithDBURL(dbURL), server.WithMQURL(mqURL))
 
 		go s.Start(ctx)
 		started := false


### PR DESCRIPTION
 - implements retry func specifically for SQL datastore ping
 - fmt fixes
 - using sqlx.Db.PingContext instead of sqlx.Db.Ping
 - propogate context to SQL datastore
