### PR TITLE
remove arbitrary docker build in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       - run: docker version
       - run: nproc
       - run: make full-test -j $(nproc)
-      - run: make docker-build -j $(nproc)
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then


### PR DESCRIPTION
`release.sh` does this upon release anyway, this is the last step in the
build. while nice to verify this, it does take 2 minutes on every branch
build, which is almost 1/3 of our build time now.