### PR TITLE
skip docker installation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - ARCH=amd64
     steps:
       - checkout
-      # update Go
+      # install Go
       - run: |
           go version
           go env GOROOT
@@ -21,11 +21,12 @@ jobs:
           wget https://storage.googleapis.com/golang/go$GOVERSION.$OS-$ARCH.tar.gz
           sudo tar -C /usr/local -xzf go$GOVERSION.$OS-$ARCH.tar.gz
       - run: go version
-      # update Docker
-      - run: |
-          docker version
-          sudo service docker stop
-          curl -fsSL https://get.docker.com/ | sudo sh
+      # install latest Docker
+      #- run: |
+          #sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
+          #sudo service docker stop
+          #curl -fsSL https://get.docker.com/ | sudo sh
+          #docker version
       - run: docker version
       - run: nproc
       - run: make full-test -j $(nproc)


### PR DESCRIPTION
this shaves 1 minute off of every build (~20%). we used to need 17.05 and had to install it ourselves, now we're provided 17.06, so our tests all work. I'm sure we'll run into needing to do this again in the future, but if we only have to do it periodically that'd be ok. i played with caching all of apt without much success, since docker is installed it sleeps 20s (could skirt this) but still took another 30s to stop old docker / install new one, this is 100% faster than that.