### PR TITLE
Add calls metric

### DIFF
--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -1,8 +1,9 @@
 package agent
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TODO this should expose:
@@ -48,24 +49,31 @@ type FunctionStats struct {
 }
 
 var (
+	fnCalls = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "fn_api_calls",
+			Help: "Function calls by app and path",
+		},
+		[](string){"app", "path"},
+	)
 	fnQueued = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fn_api_queued",
-			Help: "Queued requests by path",
+			Help: "Queued requests by app and path",
 		},
 		[](string){"app", "path"},
 	)
 	fnRunning = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fn_api_running",
-			Help: "Running requests by path",
+			Help: "Running requests by app and path",
 		},
 		[](string){"app", "path"},
 	)
 	fnCompleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "fn_api_completed",
-			Help: "Completed requests by path",
+			Help: "Completed requests by app and path",
 		},
 		[](string){"app", "path"},
 	)
@@ -79,6 +87,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(fnCalls)
 	prometheus.MustRegister(fnQueued)
 	prometheus.MustRegister(fnRunning)
 	prometheus.MustRegister(fnFailed)
@@ -104,6 +113,7 @@ func (s *stats) Enqueue(app string, path string) {
 	s.queue++
 	s.getStatsForFunction(path).queue++
 	fnQueued.WithLabelValues(app, path).Inc()
+	fnCalls.WithLabelValues(app, path).Inc()
 
 	s.mu.Unlock()
 }

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -49,8 +49,8 @@ type FunctionStats struct {
 }
 
 var (
-	fnCalls = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	fnCalls = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Name: "fn_api_calls",
 			Help: "Function calls by app and path",
 		},


### PR DESCRIPTION
This PR adds a new Prometheus counter metric `fn_api_calls` which gives the number of function calls that have been made since the Fn server was started. 

As with the Prometheus metrics `fn_api_queued`, `fn_api_running`, `fn_api_completed` and `fn_api_failed` the labels `app` and `path` are set.

Note that the `/stats` API call has *not* been extended to return this metric since it is considered deprecated and will be removed at some point.

Note also that as with the Prometheus metrics `fn_api_queued`, `fn_api_running`, `fn_api_completed` and `fn_api_failed`, the Prometheus go client is called directly by the agent code. It is planned to change this in the future so that the agent code calls the open tracing API instead, but that will be a separate change.

This new metric is required by the new statistics API: see the requirement in https://github.com/fnproject/fn/issues/514
  