### PR TITLE
add a license printing script 

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -55,9 +55,6 @@ import:
 - package: github.com/docker/docker
   version: cdf870bd0b5fa678b10ef2708cca7ad776b4913c
 - package: github.com/pkg/errors
-- package: gopkg.in/mgo.v2
-  subpackages:
-  - bson
 - package: github.com/jmoiron/sqlx
 - package: github.com/mattn/go-sqlite3
 - package: github.com/minio/minio-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -76,7 +76,6 @@ import:
   subpackages:
   - kubernetes
 - package: github.com/emicklei/go-restful-swagger12
-- package: github.com/juju/ratelimit
 - package: golang.org/x/sys
   version: master
   subpackages:

--- a/licenses.sh
+++ b/licenses.sh
@@ -24,9 +24,28 @@ license() {
     return
   fi
 
-  moz=$(grep -rs "This Source Code Form is subject to the terms of the Mozilla" vendor/$1)
+  moz=$(grep -rs "Mozilla Public License" vendor/$1)
   if [[ ! -z $moz ]]; then
     echo "$1 Mozilla Public License 2.0"
+    return
+  fi
+
+  isc=$(grep -rs "Permission to use, copy, modify, and distribute this software for any" vendor/$1)
+  if [[ ! -z $isc ]]; then
+    echo "$1 ISC License"
+    return
+  fi
+
+  unlicense=$(grep -rs "This is free and unencumbered software released into the public domain." vendor/$1)
+  if [[ ! -z $unlicense ]]; then
+    echo "$1 Unlicense"
+    return
+  fi
+
+  cc=$(grep -rs "creativecommons" vendor/$1)
+  if [[ ! -z $cc ]]; then
+    echo "$1 Creative Commons"
+    return
   fi
 
   # TODO others

--- a/licenses.sh
+++ b/licenses.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+license() {
+  apache=$(grep -rs "Apache License, Version 2.0" vendor/$1)
+  if [[ ! -z $apache ]]; then
+    echo "$1 Apache 2.0"
+    return
+  fi
+
+  bsd_file=$(grep -lrs "Redistribution and use in source and binary forms, with or without" vendor/$1 | head -n 1)
+  if [[ ! -z $bsd_file ]]; then
+    bsd3=$(grep "this software without specific prior written permission" $bsd_file)
+    if [[ ! -z $bsd3 ]]; then
+      echo "$1 BSD 3"
+    else
+      echo "$1 BSD 2"
+    fi
+    return
+  fi
+
+  mit=$(grep -rs "Permission is hereby granted, free of charge" vendor/$1)
+  if [[ ! -z $mit ]]; then
+    echo "$1 MIT"
+    return
+  fi
+
+  moz=$(grep -rs "This Source Code Form is subject to the terms of the Mozilla" vendor/$1)
+  if [[ ! -z $moz ]]; then
+    echo "$1 Mozilla Public License 2.0"
+  fi
+
+  # TODO others
+
+  echo "$1 No License Found"
+}
+
+deps=$(cat glide.lock | grep -E '\- name:' | awk '{print $3}')
+
+for dep in $deps; do
+  license $dep
+done


### PR DESCRIPTION
this takes info from glide.lock, which covers all our external dependencies,
and then searches for a LICENSE in each of them. the good news is that it
covers all of our stuff right now, there are none without a license we can't
find. the bad news is, it's not very robust. this seemed to be a manual
process so this is markedly better.

removed 2 deps we had in glide.yaml that we aren't actually using, should go
away next update. one we just don't need to explicitly get (there are likely others)

to run: `./licenses.sh` -- we can likely generate a csv if that's preferable and put
it somewhere. we can also likely use this in the future to make sure we have a
handle on licenses in CI / make sure we don't use GPL / etc. 
  