### PR TITLE
Fixes 404 responses from functions that go through NoRoute path.

### DIFF
--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"net/http"
 	"path"
 	"time"
@@ -16,21 +15,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// handleFunctionCall executes the function, for router handlers
 func (s *Server) handleFunctionCall(c *gin.Context) {
-	fmt.Println("handleFunctionCall")
 	err := s.handleFunctionCall2(c)
 	if err != nil {
-		fmt.Println("ERROR", err)
 		handleErrorResponse(c, err)
 	}
 }
 
-// handleFunctionCall executes the function.
+// handleFunctionCall2 executes the function and returns an error
 // Requires the following in the context:
 // * "app_name"
 // * "path"
 func (s *Server) handleFunctionCall2(c *gin.Context) error {
-	fmt.Println("handlefunc 2")
 	ctx := c.Request.Context()
 	var p string
 	r := ctx.Value(api.Path)

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"path"
 	"time"
@@ -40,7 +39,7 @@ func (s *Server) handleFunctionCall2(c *gin.Context) error {
 	var a string
 	ai := ctx.Value(api.AppName)
 	if ai == nil {
-		err := errors.New("app name not set")
+		err := models.ErrAppsMissingName
 		return err
 	}
 	a = ai.(string)

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -58,8 +58,8 @@ func TestRouteRunnerGet(t *testing.T) {
 
 		if rec.Code != test.expectedCode {
 			t.Log(buf.String())
-			t.Errorf("Test %d: Expected status code to be %d but was %d",
-				i, test.expectedCode, rec.Code)
+			t.Errorf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
 		}
 
 		if test.expectedError != nil {
@@ -104,8 +104,8 @@ func TestRouteRunnerPost(t *testing.T) {
 
 		if rec.Code != test.expectedCode {
 			t.Log(buf.String())
-			t.Errorf("Test %d: Expected status code to be %d but was %d",
-				i, test.expectedCode, rec.Code)
+			t.Errorf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
 		}
 
 		if test.expectedError != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -454,7 +454,6 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	}
 
 	engine.NoRoute(func(c *gin.Context) {
-		fmt.Println("IN NO ROUTE")
 		var err error
 		switch {
 		case s.nodeType == ServerTypeAPI && strings.HasPrefix(c.Request.URL.Path, "/r/"):
@@ -462,18 +461,9 @@ func (s *Server) bindHandlers(ctx context.Context) {
 		case s.nodeType == ServerTypeRunner && strings.HasPrefix(c.Request.URL.Path, "/v1/"):
 			err = models.ErrAPINotSupported
 		default:
-			// c.JSON(200, map[string]string{"yoooo": "dog"})
-			// c.Writer.WriteHeader(200)
-
 			err = s.handleFunctionCall2(c)
-			if err == nil {
-				fmt.Println("NIL ERR")
-				// var e models.APIError = models.ErrPathNotFound
-				// err = models.NewAPIError(e.Code(), fmt.Errorf("%v: %s", e.Error(), c.Request.URL.Path))
-			}
 		}
 		if err != nil {
-			fmt.Println("err in no route is", err)
 			handleErrorResponse(c, err)
 		}
 	})

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -24,8 +24,8 @@ import (
 	"github.com/fnproject/fn/api/version"
 	"github.com/fnproject/fn/fnext"
 	"github.com/gin-gonic/gin"
-	"github.com/opentracing/opentracing-go"
-	"github.com/openzipkin/zipkin-go-opentracing"
+	opentracing "github.com/opentracing/opentracing-go"
+	zipkintracer "github.com/openzipkin/zipkin-go-opentracing"
 	"github.com/sirupsen/logrus"
 )
 
@@ -454,6 +454,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	}
 
 	engine.NoRoute(func(c *gin.Context) {
+		fmt.Println("IN NO ROUTE")
 		var err error
 		switch {
 		case s.nodeType == ServerTypeAPI && strings.HasPrefix(c.Request.URL.Path, "/r/"):
@@ -461,10 +462,20 @@ func (s *Server) bindHandlers(ctx context.Context) {
 		case s.nodeType == ServerTypeRunner && strings.HasPrefix(c.Request.URL.Path, "/v1/"):
 			err = models.ErrAPINotSupported
 		default:
-			var e models.APIError = models.ErrPathNotFound
-			err = models.NewAPIError(e.Code(), fmt.Errorf("%v: %s", e.Error(), c.Request.URL.Path))
+			// c.JSON(200, map[string]string{"yoooo": "dog"})
+			// c.Writer.WriteHeader(200)
+
+			err = s.handleFunctionCall2(c)
+			if err == nil {
+				fmt.Println("NIL ERR")
+				// var e models.APIError = models.ErrPathNotFound
+				// err = models.NewAPIError(e.Code(), fmt.Errorf("%v: %s", e.Error(), c.Request.URL.Path))
+			}
 		}
-		handleErrorResponse(c, err)
+		if err != nil {
+			fmt.Println("err in no route is", err)
+			handleErrorResponse(c, err)
+		}
 	})
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -461,11 +461,10 @@ func (s *Server) bindHandlers(ctx context.Context) {
 		case s.nodeType == ServerTypeRunner && strings.HasPrefix(c.Request.URL.Path, "/v1/"):
 			err = models.ErrAPINotSupported
 		default:
-			err = s.handleFunctionCall2(c)
+			var e models.APIError = models.ErrPathNotFound
+			err = models.NewAPIError(e.Code(), fmt.Errorf("%v: %s", e.Error(), c.Request.URL.Path))
 		}
-		if err != nil {
-			handleErrorResponse(c, err)
-		}
+		handleErrorResponse(c, err)
 	})
 }
 

--- a/docs/developers/apps.md
+++ b/docs/developers/apps.md
@@ -48,7 +48,7 @@ http://abc.io/users -> function in users/ directory
 fn deploy --all
 ```
 
-If you're just testing locally, you can speed it up with the `--local` flag.
+If you're just testing locally, you can speed it up with the `--local` flag. Or if you want to deploy to a different app, use the `--app APPNAME` flag.
 
 ## Deploying a single function in the app
 
@@ -60,4 +60,5 @@ fn deploy hello
 
 ## Example app
 
+MOVE TO EXTERNAL REPO
 See https://github.com/fnproject/fn/tree/master/examples/apps/hellos for a simple example. Just clone it and run `fn deploy --all` to see it in action.

--- a/docs/developers/apps.md
+++ b/docs/developers/apps.md
@@ -60,5 +60,4 @@ fn deploy hello
 
 ## Example app
 
-MOVE TO EXTERNAL REPO
-See https://github.com/fnproject/fn/tree/master/examples/apps/hellos for a simple example. Just clone it and run `fn deploy --all` to see it in action.
+See https://github.com/treeder/fn-app-example for a simple example. Just clone it and run `fn deploy --all` to see it in action.


### PR DESCRIPTION
This fixes an issue where if the function call doesn't match a gin route, it would return a 404, even though the function ran fine. 

![screen shot 2018-01-04 at 11 42 09 am](https://user-images.githubusercontent.com/75826/34630698-24240cbc-f222-11e7-9b52-8f795b963c55.png)

Also, while trying to debug this, I made some of the function executing methods return an error which cleans things up a bit (IMO), and allows callers to know if something went wrong.