### PR TITLE
fn: URL parsing updates to fix json request_url

### DIFF
--- a/api/agent/protocol/factory.go
+++ b/api/agent/protocol/factory.go
@@ -72,7 +72,7 @@ func (ci callInfoImpl) Request() *http.Request {
 	return ci.req
 }
 func (ci callInfoImpl) RequestURL() string {
-	return ci.req.URL.RequestURI()
+	return ci.call.URL
 }
 
 func (ci callInfoImpl) Headers() map[string][]string {

--- a/api/agent/protocol/json_test.go
+++ b/api/agent/protocol/json_test.go
@@ -16,7 +16,7 @@ type RequestData struct {
 	A string `json:"a"`
 }
 
-func setupRequest(data interface{}) *http.Request {
+func setupRequest(data interface{}) *callInfoImpl {
 	req := &http.Request{
 		Method: http.MethodPost,
 		URL: &url.URL{
@@ -40,15 +40,20 @@ func setupRequest(data interface{}) *http.Request {
 		_ = json.NewEncoder(&buf).Encode(data)
 	}
 	req.Body = ioutil.NopCloser(&buf)
-	return req
+
+	call := &models.Call{Type: "json"}
+
+	// fixup URL in models.Call
+	call.URL = req.URL.String()
+
+	ci := &callInfoImpl{call, req}
+	return ci
 }
 
 func TestJSONProtocolwriteJSONInputRequestWithData(t *testing.T) {
 	rDataBefore := RequestData{A: "a"}
-	req := setupRequest(rDataBefore)
+	ci := setupRequest(rDataBefore)
 	r, w := io.Pipe()
-	call := &models.Call{Type: "json"}
-	ci := &callInfoImpl{call, req}
 	proto := JSONProtocol{w, r}
 	go func() {
 		err := proto.writeJSONToContainer(ci)
@@ -77,18 +82,15 @@ func TestJSONProtocolwriteJSONInputRequestWithData(t *testing.T) {
 		t.Errorf("Request data assertion mismatch: expected: %s, got %s",
 			rDataBefore.A, rDataAfter.A)
 	}
-	if incomingReq.Protocol.Type != call.Type {
+	if incomingReq.Protocol.Type != ci.call.Type {
 		t.Errorf("Call protocol type assertion mismatch: expected: %s, got %s",
-			call.Type, incomingReq.Protocol.Type)
+			ci.call.Type, incomingReq.Protocol.Type)
 	}
 }
 
 func TestJSONProtocolwriteJSONInputRequestWithoutData(t *testing.T) {
-	req := setupRequest(nil)
-
-	call := &models.Call{Type: "json"}
+	ci := setupRequest(nil)
 	r, w := io.Pipe()
-	ci := &callInfoImpl{call, req}
 	proto := JSONProtocol{w, r}
 	go func() {
 		err := proto.writeJSONToContainer(ci)
@@ -112,18 +114,15 @@ func TestJSONProtocolwriteJSONInputRequestWithoutData(t *testing.T) {
 		t.Errorf("Request body assertion mismatch: expected: %s, got %s",
 			"<empty-string>", incomingReq.Body)
 	}
-	if !models.Headers(req.Header).Equals(models.Headers(incomingReq.Protocol.Headers)) {
+	if !models.Headers(ci.req.Header).Equals(models.Headers(incomingReq.Protocol.Headers)) {
 		t.Errorf("Request headers assertion mismatch: expected: %s, got %s",
-			req.Header, incomingReq.Protocol.Headers)
+			ci.req.Header, incomingReq.Protocol.Headers)
 	}
 }
 
 func TestJSONProtocolwriteJSONInputRequestWithQuery(t *testing.T) {
-	req := setupRequest(nil)
-
+	ci := setupRequest(nil)
 	r, w := io.Pipe()
-	call := &models.Call{Type: "json"}
-	ci := &callInfoImpl{call, req}
 	proto := JSONProtocol{w, r}
 	go func() {
 		err := proto.writeJSONToContainer(ci)
@@ -143,8 +142,8 @@ func TestJSONProtocolwriteJSONInputRequestWithQuery(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if incomingReq.Protocol.RequestURL != req.URL.RequestURI() {
+	if incomingReq.Protocol.RequestURL != ci.call.URL {
 		t.Errorf("Request URL does not match protocol URL: expected: %s, got %s",
-			req.URL.RequestURI(), incomingReq.Protocol.RequestURL)
+			ci.call.URL, incomingReq.Protocol.RequestURL)
 	}
 }

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -40,6 +40,8 @@ func TestRouteRunnerAsyncExecution(t *testing.T) {
 			{Name: "myapp", Config: map[string]string{"app": "true"}},
 		},
 		[]*models.Route{
+			{Type: "async", Path: "/hot-http", AppName: "myapp", Image: "fnproject/fn-test-utils", Format: "http", Config: map[string]string{"test": "true"}, Memory: 128, Timeout: 4, IdleTimeout: 30},
+			{Type: "async", Path: "/hot-json", AppName: "myapp", Image: "fnproject/fn-test-utils", Format: "json", Config: map[string]string{"test": "true"}, Memory: 128, Timeout: 4, IdleTimeout: 30},
 			{Type: "async", Path: "/myroute", AppName: "myapp", Image: "fnproject/hello", Config: map[string]string{"test": "true"}, Memory: 128, Timeout: 30, IdleTimeout: 30},
 			{Type: "async", Path: "/myerror", AppName: "myapp", Image: "fnproject/error", Config: map[string]string{"test": "true"}, Memory: 128, Timeout: 30, IdleTimeout: 30},
 			{Type: "async", Path: "/myroute/:param", AppName: "myapp", Image: "fnproject/hello", Config: map[string]string{"test": "true"}, Memory: 128, Timeout: 30, IdleTimeout: 30},
@@ -55,6 +57,8 @@ func TestRouteRunnerAsyncExecution(t *testing.T) {
 		expectedEnv  map[string]string
 	}{
 		{"/r/myapp/myroute", ``, map[string][]string{}, http.StatusAccepted, map[string]string{"TEST": "true", "APP": "true"}},
+		{"/r/myapp/hot-http", `{"sleepTime": 0, "isDebug": true}`, map[string][]string{}, http.StatusAccepted, map[string]string{"TEST": "true", "APP": "true"}},
+		{"/r/myapp/hot-json", `{"sleepTime": 0, "isDebug": true}`, map[string][]string{}, http.StatusAccepted, map[string]string{"TEST": "true", "APP": "true"}},
 		// FIXME: this just hangs
 		//{"/r/myapp/myroute/1", ``, map[string][]string{}, http.StatusAccepted, map[string]string{"TEST": "true", "APP": "true"}},
 		{"/r/myapp/myerror", ``, map[string][]string{}, http.StatusAccepted, map[string]string{"TEST": "true", "APP": "true"}},

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -245,6 +245,7 @@ func TestRouteRunnerTimeout(t *testing.T) {
 		[]*models.Route{
 			{Path: "/cold", AppName: "myapp", Image: "fnproject/fn-test-utils", Type: "sync", Memory: 128, Timeout: 4, IdleTimeout: 30},
 			{Path: "/hot", AppName: "myapp", Image: "fnproject/fn-test-utils", Type: "sync", Format: "http", Memory: 128, Timeout: 4, IdleTimeout: 30},
+			{Path: "/hot-json", AppName: "myapp", Image: "fnproject/fn-test-utils", Type: "sync", Format: "json", Memory: 128, Timeout: 4, IdleTimeout: 30},
 			{Path: "/bigmem-cold", AppName: "myapp", Image: "fnproject/fn-test-utils", Type: "sync", Memory: hugeMem, Timeout: 1, IdleTimeout: 30},
 			{Path: "/bigmem-hot", AppName: "myapp", Image: "fnproject/fn-test-utils", Type: "sync", Format: "http", Memory: hugeMem, Timeout: 1, IdleTimeout: 30},
 		}, nil,
@@ -267,6 +268,8 @@ func TestRouteRunnerTimeout(t *testing.T) {
 		{"/r/myapp/cold", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
 		{"/r/myapp/hot", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
 		{"/r/myapp/hot", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
+		{"/r/myapp/hot-json", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot-json", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
 		{"/r/myapp/bigmem-cold", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},
 		{"/r/myapp/bigmem-hot", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},
 	} {

--- a/images/fn-test-utils/Gopkg.lock
+++ b/images/fn-test-utils/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/fnproject/fdk-go"
   packages = ["."]
-  revision = "ce12b15e559bb56980c4134cbeadb99db9cd563a"
+  revision = "2d62538bfa636d3135c957ec7b78f2bedeeffa3d"
 
 [solve-meta]
   analyzer-name = "dep"


### PR DESCRIPTION
*) Updated fn-test-utils to latest fdk-go
*) Added hot-json to runner tests
*) Removed anon function in FromRequest which had
a side effect to set req.URL.Host. This is now more
explicit and eliminates some corresponding logic in
protocol http.
*) in gin, http request RequestURI is not set, removed
code that references this. (use Call.URL instead)