### PR TITLE
Removes FN_PARAM_xxx

### DIFF
--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -178,11 +178,6 @@ func TestCallConfigurationRequest(t *testing.T) {
 	expectedEnv["FN_METHOD"] = method
 	expectedEnv["FN_REQUEST_URL"] = url
 
-	// add expected parameters from URL
-	for _, val := range params {
-		expectedEnv[fmt.Sprintf("FN_PARAM_%s", val.Key)] = val.Value
-	}
-
 	// do this before the "real" headers get sucked in cuz they are formatted differently
 	expectedHeaders := make(http.Header)
 	for k, v := range expectedEnv {

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -113,11 +113,6 @@ func FromRequest(appName, path string, req *http.Request, params Params) CallOpt
 		envVars["FN_METHOD"] = req.Method
 		envVars["FN_REQUEST_URL"] = url
 
-		// params
-		for _, param := range params {
-			envVars[toEnvName("FN_PARAM", param.Key)] = param.Value
-		}
-
 		headerVars := make(map[string]string, len(req.Header))
 
 		for k, v := range req.Header {

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -41,7 +41,6 @@ You will also have access to a set of environment variables.
 * `FN_HEADER_$X` - the HTTP headers that were set for this request. Replace $X with the upper cased name of the header and replace dashes in the header with underscores.
   * `$X` - any [configuration values](https://github.com/fnproject/cli/blob/master/README.md#application-level-configuration) you've set
   for the Application or the Route. Replace X with the upper cased name of the config variable you set. Ex: `minio_secret=secret` will be exposed via MINIO_SECRET env var.
-* `FN_PARAM_$Y` - any variables found from parsing the URL. Replace $Y with any `:var` from the url.
 
 Warning: these may change before release.
 


### PR DESCRIPTION
Current:

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=1cc0625aeae0
FN_PARAM_app=foo
FN_TYPE=sync
FN_METHOD=GET
FN_PARAM_route=/testfn
FN_HEADER_Accept_Encoding=gzip
FN_HEADER_User_Agent=Go-http-client/1.1
FN_PATH=/testfn
FN_FORMAT=default
FN_APP_NAME=foo
FN_REQUEST_URL=http://localhost:8080/r/foo/testfn
FN_HEADER_Content_Type=application/json
FN_MEMORY=128
FN_CALL_ID=01C3DB9X4Y47WG600000000000
HOME=/root
Body
```

The FN_PARAM_app/route are the only values that will ever show up since it's the only matching gin route possible. And they already exist in FN_APP_NAME and FN_PATH. 

cc @zootalures 

  