### PR TITLE
add FN_LOG_DEST for logs, fixup init

### DIFF
--- a/api/common/logging.go
+++ b/api/common/logging.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 
@@ -18,6 +19,12 @@ func SetLogLevel(ll string) {
 		logLevel = logrus.InfoLevel
 	}
 	logrus.SetLevel(logLevel)
+
+	// this effectively just adds more gin log goodies
+	gin.SetMode(gin.ReleaseMode)
+	if logLevel == logrus.DebugLevel {
+		gin.SetMode(gin.DebugMode)
+	}
 }
 
 func SetLogDest(to, prefix string) {

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -26,6 +26,8 @@ docker run -e VAR_NAME=VALUE ...
 | `FN_API_URL` | The primary Fn API URL to that this instance will talk to. In a production environment, this would be your load balancer URL. | N/A |
 | `FN_PORT `| Sets the port to run on | 8080 |
 | `FN_LOG_LEVEL` | Set to DEBUG to enable debugging | INFO |
+| `FN_LOG_DEST` | Set a url to send logs to, instead of stderr. [scheme://][host][:port][/path]; default scheme to udp:// if none given, possible schemes: { udp, tcp, file }
+| `FN_LOG_PREFIX` | If supplying a syslog url in `FN_LOG_DEST`, a prefix to add to each log line
 | `FN_API_CORS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
 | `DOCKER_HOST` | Docker remote API URL. | /var/run/docker.sock |
 | `DOCKER_API_VERSION` | Docker remote API version. | 1.24 |


### PR DESCRIPTION
* FN_LOG_DEST can point to a remote logging place (papertrail, whatever)
* FN_LOG_PREFIX can add a prefix onto each log line sent to FN_LOG_DEST

default remains stderr with no prefix. users need this to send to various
logging backends, though it could be done operationally, this is somewhat
simpler.

we were doing some configuration stuff inside of init() for some of the global
things. even though they're global, it's nice to keep them all in the normal
server init path.

we have had strange issues with the tracing setup, I tested the last repro of
this repeatedly and didn't have any luck reproducing it, though maybe it comes
back.