### PR TITLE
Add new Prom metrics fn_timeout and fn_errors

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -254,6 +254,11 @@ func (a *agent) Submit(callI Call) error {
 	} else {
 		// decrement running count, increment failed count
 		a.stats.Failed(ctx, callI.Model().AppName, callI.Model().Path)
+
+		if err == context.DeadlineExceeded {
+			//increment the timedout count (this is in addition to incrementing the failed count)
+			a.stats.Timedout(ctx)
+		}
 	}
 
 	// TODO: we need to allocate more time to store the call + logs in case the call timed out,

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -227,10 +227,10 @@ func transformTimeout(e error, isRetriable bool) error {
 func (a *agent) handleStatsDequeue(ctx context.Context, call *call, err error) {
 	if err == context.DeadlineExceeded {
 		a.stats.Dequeue(ctx, call.AppName, call.Path)
-    // note that this is not a timeout from the perspective of the caller, so don't increment the timeout count
+		// note that this is not a timeout from the perspective of the caller, so don't increment the timeout count
 	} else {
 		a.stats.DequeueAndFail(ctx, call.AppName, call.Path)
- 		a.stats.IncrementErrors(ctx)
+		a.stats.IncrementErrors(ctx)
 	}
 }
 
@@ -242,7 +242,7 @@ func (a *agent) handleStatsEnd(ctx context.Context, call *call, err error) {
 	} else {
 		// decrement running count, increment failed count
 		a.stats.Failed(ctx, call.AppName, call.Path)
-    // increment the timeout or errors count, as appropriate
+		// increment the timeout or errors count, as appropriate
 		if err == context.DeadlineExceeded {
 			a.stats.IncrementTimedout(ctx)
 		} else {

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -141,12 +141,12 @@ func (s *stats) DequeueAndFail(ctx context.Context, app string, path string) {
 	s.mu.Unlock()
 }
 
-func (s *stats) Timedout(ctx context.Context) {
-	s.mu.Lock()
-
+func (s *stats) IncrementTimedout(ctx context.Context) {
 	common.IncrementCounter(ctx, timedoutMetricName)
+}
 
-	s.mu.Unlock()
+func (s *stats) IncrementErrors(ctx context.Context) {
+	common.IncrementCounter(ctx, errorsMetricName)
 }
 
 func (s *stats) Stats() Stats {
@@ -172,4 +172,5 @@ const (
 	completedMetricName = "completed"
 	failedMetricName    = "failed"
 	timedoutMetricName  = "timedout"
+	errorsMetricName    = "errors"
 )

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -94,7 +94,7 @@ func (s *stats) DequeueAndStart(ctx context.Context, app string, path string) {
 
 	s.running++
 	s.getStatsForFunction(path).running++
-	common.IncrementGauge(ctx, runningSuffix)
+	common.IncrementGauge(ctx, runningMetricName)
 
 	s.mu.Unlock()
 }
@@ -104,7 +104,7 @@ func (s *stats) Complete(ctx context.Context, app string, path string) {
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	common.DecrementGauge(ctx, runningSuffix)
+	common.DecrementGauge(ctx, runningMetricName)
 
 	s.complete++
 	s.getStatsForFunction(path).complete++
@@ -168,7 +168,7 @@ func (s *stats) Stats() Stats {
 const (
 	queuedMetricName    = "queued"
 	callsMetricName     = "calls"
-	runningSuffix       = "running"
+	runningMetricName   = "running"
 	completedMetricName = "completed"
 	failedMetricName    = "failed"
 	timedoutMetricName  = "timedout"

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -118,7 +118,7 @@ func (s *stats) Failed(ctx context.Context, app string, path string) {
 
 	s.running--
 	s.getStatsForFunction(path).running--
-	common.DecrementGauge(ctx, runningSuffix)
+	common.DecrementGauge(ctx, runningMetricName)
 
 	s.failed++
 	s.getStatsForFunction(path).failed++

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -141,6 +141,14 @@ func (s *stats) DequeueAndFail(ctx context.Context, app string, path string) {
 	s.mu.Unlock()
 }
 
+func (s *stats) Timedout(ctx context.Context) {
+	s.mu.Lock()
+
+	common.IncrementCounter(ctx, timedoutMetricName)
+
+	s.mu.Unlock()
+}
+
 func (s *stats) Stats() Stats {
 	var stats Stats
 	s.mu.Lock()
@@ -163,4 +171,5 @@ const (
 	runningSuffix       = "running"
 	completedMetricName = "completed"
 	failedMetricName    = "failed"
+	timedoutMetricName  = "timedout"
 )


### PR DESCRIPTION
This PR extends the set of basic metrics to add two more:

* `fn_timedout` -count of function calls that have not completed successfully because they timed out
* `fn_errors` - count of function calls that have not completed successfully because of an error (and because of a timeout)

This is in addition to the existing metrics

* `fn_failed` - count of function calls that have not completed successfully because of an error or timeout
* `fn_completed` - count of function calls that have completed successfully
* `fn_calls` - count of function calls that have made

So 

`calls` = `completed` + `failed`
`calls` = `completed + `errors` + `timedout`

These new metrics are required by the stats API: https://github.com/fnproject/fn/issues/514

I have extended the `ext-statsapi` tests to test these two new metrics for both cold and hot functions and for functions that succeed, deliberately timeout, or panic.
