### PR TITLE
Fix for MTU problems in some k8s environments

### DIFF
--- a/images/dind/README.md
+++ b/images/dind/README.md
@@ -5,6 +5,10 @@ This is the base image for all docker-in-docker images.
 The difference between this and the official `docker` images are that this will choose the best
 filesystem automatically. The official ones use `vfs` (bad) by default unless you pass in a flag.
 
+It will also attempt to mirror the default external interface's MTU to the dind network; this
+addresses a problem with running dind-based images on a kubernetes cluster with an overlay
+network that takes a chunk out of pods' MTUs.
+
 ## Usage
 
 Just use this as your base image and use CMD for your program, **NOT ENTRYPOINT**. This will handle the rest.

--- a/images/dind/preentry.sh
+++ b/images/dind/preentry.sh
@@ -6,6 +6,15 @@ if [ $fsdriver == "overlay" ]; then
   fsdriver="overlay2"
 fi
 
+mkdir -p /etc/docker
+/bin/cat > /etc/docker/daemon.json <<EOF
+{
+  "mtu": $(ip link show dev $(ip route |
+                              awk '$1 == "default" { print $NF }') |
+           awk '{for (i = 1; i <= NF; i++) if ($i == "mtu") print $(i+1)}')
+}
+EOF
+
 dockerd-entrypoint.sh --storage-driver=$fsdriver &
 
 # give docker a few seconds


### PR DESCRIPTION
This should probably be pushed back into the base image, and/or
upstream into dind's master.

In many k8s environments the host docker uses an overlay network
which'll take bytes away from the effective MTU of outer
containers; eg, vxlan needs 50 bytes, often leaving a 1450 MTU
on the container running dind and fn-api.

In such an arrangement, packets exceeding the smaller MTU may be
invisibly dropped as they travel across the dind's docker0
bridge. This mostly surfaces as a failure of functions to be able
to reliably talk to external services. (Note, the failure may be
intermittent depending on the profile of the resulting TCP
communication.)

A robust fix for this is to intercept the startup of the dind
dockerd and ensure that /etc/docker/daemon.json (currently
absent) contains the following setting:

{
  "mtu": 1450
}

(or whatever the MTU on the external interface may be). This
should be autosized so the container works in a variety of
deployments.

The problem does not arise when using an embedded
/var/run/docker.sock - or when running with dind on a host that
can supply 1500-byte MTUs to containers on the 'host' docker.