### PR TITLE
fn: hot container IO mgmt changes

### DIFF
--- a/api/agent/protocol/default.go
+++ b/api/agent/protocol/default.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"context"
 	"io"
 )
 
@@ -9,6 +8,6 @@ import (
 type DefaultProtocol struct{}
 
 func (p *DefaultProtocol) IsStreamable() bool { return false }
-func (d *DefaultProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error {
+func (d *DefaultProtocol) Dispatch(ci CallInfo, w io.Writer) error {
 	return nil
 }

--- a/api/agent/protocol/factory.go
+++ b/api/agent/protocol/factory.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -15,8 +14,8 @@ type errorProto struct {
 	error
 }
 
-func (e errorProto) IsStreamable() bool                                           { return false }
-func (e errorProto) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error { return e }
+func (e errorProto) IsStreamable() bool                      { return false }
+func (e errorProto) Dispatch(ci CallInfo, w io.Writer) error { return e }
 
 // ContainerIO defines the interface used to talk to a hot function.
 // Internally, a protocol must know when to alternate between stdin and stdout.
@@ -25,9 +24,8 @@ type ContainerIO interface {
 	IsStreamable() bool
 
 	// Dispatch will handle sending stdin and stdout to a container. Implementers
-	// of Dispatch may format the input and output differently. Dispatch must respect
-	// the req.Context() timeout / cancellation.
-	Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error
+	// of Dispatch may format the input and output differently.
+	Dispatch(ci CallInfo, w io.Writer) error
 }
 
 // CallInfo is passed into dispatch with only the required data the protocols require

--- a/api/agent/protocol/http.go
+++ b/api/agent/protocol/http.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +22,7 @@ func (p *HTTPProtocol) IsStreamable() bool { return true }
 
 // TODO handle req.Context better with io.Copy. io.Copy could push us
 // over the timeout.
-func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error {
+func (h *HTTPProtocol) Dispatch(ci CallInfo, w io.Writer) error {
 	req := ci.Request()
 
 	req.RequestURI = ci.RequestURL() // force set to this, for DumpRequestTo to use

--- a/api/agent/protocol/json.go
+++ b/api/agent/protocol/json.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -147,7 +146,7 @@ func (h *JSONProtocol) writeJSONToContainer(ci CallInfo) error {
 	return err
 }
 
-func (h *JSONProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error {
+func (h *JSONProtocol) Dispatch(ci CallInfo, w io.Writer) error {
 	// write input into container
 	err := h.writeJSONToContainer(ci)
 	if err != nil {

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -266,9 +266,9 @@ func TestRouteRunnerTimeout(t *testing.T) {
 	}{
 		{"/r/myapp/cold", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
 		{"/r/myapp/cold", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
-		{"/r/myapp/hot", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot", `{"sleepTime": 50000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
 		{"/r/myapp/hot", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
-		{"/r/myapp/hot-json", `{"sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot-json", `{"sleepTime": 50000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
 		{"/r/myapp/hot-json", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
 		{"/r/myapp/bigmem-cold", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},
 		{"/r/myapp/bigmem-hot", `{"sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},


### PR DESCRIPTION
*) Remove go routine protocol Dispatch() to avoid unsafe
concurrent access to http.ResponseWriter headers map.
*) Swap go routine Dispatch() with channel IO select
to detect timeouts and also notify hot container to
shutdown in case of context cancel/timeout.
*) Close read/write pipe ends in hot container exit
to purge lingering IO in pipes.