### PR TITLE
fn: resource and slot cancel and broadcast improvements

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -344,15 +344,15 @@ func (a *agent) hotLauncher(ctx context.Context, callObj *call) {
 			continue
 		}
 
-		resourceCtx, cancel := context.WithCancel(context.Background())
+		ctxResource, cancelResource := context.WithCancel(context.Background())
 		logger.WithFields(logrus.Fields{
 			"currentStats":  curStats,
 			"previousStats": curStats,
 		}).Info("Hot function launcher starting hot container")
 
 		select {
-		case tok, isOpen := <-a.resources.GetResourceToken(resourceCtx, callObj.Memory, uint64(callObj.CPUs), isAsync):
-			cancel()
+		case tok, isOpen := <-a.resources.GetResourceToken(ctxResource, callObj.Memory, uint64(callObj.CPUs), isAsync):
+			cancelResource()
 			if isOpen {
 				a.wg.Add(1)
 				go func(ctx context.Context, call *call, tok ResourceToken) {
@@ -364,13 +364,13 @@ func (a *agent) hotLauncher(ctx context.Context, callObj *call) {
 				callObj.slots.queueSlot(&hotSlot{done: make(chan struct{}), err: models.ErrCallTimeoutServerBusy})
 			}
 		case <-time.After(timeout):
-			cancel()
+			cancelResource()
 			if a.slotMgr.deleteSlotQueue(callObj.slots) {
 				logger.Info("Hot function launcher timed out")
 				return
 			}
 		case <-a.shutdown: // server shutdown
-			cancel()
+			cancelResource()
 			return
 		}
 	}
@@ -378,8 +378,8 @@ func (a *agent) hotLauncher(ctx context.Context, callObj *call) {
 
 // waitHot pings and waits for a hot container from the slot queue
 func (a *agent) waitHot(ctx context.Context, call *call) (Slot, error) {
-	ch, cancel := call.slots.startDequeuer()
-	defer cancel()
+
+	ch := call.slots.startDequeuer(ctx)
 
 	// 1) if we can get a slot immediately, grab it.
 	// 2) if we don't, send a signaller every 200ms until we do.

--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -16,13 +16,13 @@ func (a *agent) asyncDequeue() {
 	defer cancel()
 
 	for {
-		ch, cancelWait := a.resources.WaitAsyncResource()
+		ctxResource, cancelResource := context.WithCancel(context.Background())
 		select {
 		case <-a.shutdown:
-			cancelWait()
+			cancelResource()
 			return
-		case <-ch:
-			cancelWait()
+		case <-a.resources.WaitAsyncResource(ctxResource):
+			cancelResource()
 			// TODO we _could_ return a token here to reserve the ram so that there's
 			// not a race between here and Submit but we're single threaded
 			// dequeueing and retries handled gracefully inside of Submit if we run

--- a/api/agent/resource.go
+++ b/api/agent/resource.go
@@ -24,7 +24,7 @@ const (
 // A simple resource (memory, cpu, disk, etc.) tracker for scheduling.
 // TODO: add cpu, disk, network IO for future
 type ResourceTracker interface {
-	WaitAsyncResource() (chan struct{}, context.CancelFunc)
+	WaitAsyncResource(ctx context.Context) chan struct{}
 	// returns a closed channel if the resource can never me met.
 	GetResourceToken(ctx context.Context, memory uint64, cpuQuota uint64, isAsync bool) <-chan ResourceToken
 }
@@ -115,6 +115,7 @@ func (a *resourceTracker) GetResourceToken(ctx context.Context, memory uint64, c
 	memory = memory * Mem1MB
 
 	c := a.cond
+	isWaiting := false
 	ch := make(chan ResourceToken)
 
 	if !a.isResourcePossible(memory, cpuQuota, isAsync) {
@@ -123,11 +124,22 @@ func (a *resourceTracker) GetResourceToken(ctx context.Context, memory uint64, c
 	}
 
 	go func() {
+		<-ctx.Done()
+		c.L.Lock()
+		if isWaiting {
+			c.Broadcast()
+		}
+		c.L.Unlock()
+	}()
+
+	go func() {
 		c.L.Lock()
 
+		isWaiting = true
 		for !a.isResourceAvailableLocked(memory, cpuQuota, isAsync) && ctx.Err() == nil {
 			c.Wait()
 		}
+		isWaiting = false
 
 		if ctx.Err() != nil {
 			c.L.Unlock()
@@ -184,24 +196,28 @@ func (a *resourceTracker) GetResourceToken(ctx context.Context, memory uint64, c
 
 // WaitAsyncResource will send a signal on the returned channel when RAM and CPU in-use
 // in the async area is less than high water mark
-func (a *resourceTracker) WaitAsyncResource() (chan struct{}, context.CancelFunc) {
+func (a *resourceTracker) WaitAsyncResource(ctx context.Context) chan struct{} {
 	ch := make(chan struct{}, 1)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	isWaiting := false
 	c := a.cond
 
-	myCancel := func() {
-		cancel()
+	go func() {
+		<-ctx.Done()
 		c.L.Lock()
-		c.Broadcast()
+		if isWaiting {
+			c.Broadcast()
+		}
 		c.L.Unlock()
-	}
+	}()
 
 	go func() {
 		c.L.Lock()
+		isWaiting = true
 		for (a.ramAsyncUsed >= a.ramAsyncHWMark || a.cpuAsyncUsed >= a.cpuAsyncHWMark) && ctx.Err() == nil {
 			c.Wait()
 		}
+		isWaiting = false
 		c.L.Unlock()
 
 		if ctx.Err() == nil {
@@ -209,7 +225,7 @@ func (a *resourceTracker) WaitAsyncResource() (chan struct{}, context.CancelFunc
 		}
 	}()
 
-	return ch, myCancel
+	return ch
 }
 
 func minUint64(a, b uint64) uint64 {


### PR DESCRIPTION
*) Context argument does not wake up the waiters correctly upon
cancellation/timeout. Returning a cancel function clarifies
this and honors this contract better.
*) Avoid unnecessary broadcasts in slot and resource.