### PR TITLE
Selective releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,27 @@ jobs:
       - run: docker version
       - run: nproc
       - run: make clear-images
-      - run: make full-test -j $(nproc)
+
+      # Work out what needs rebuilding and what has changed
+      - run: |
+          ( ./changed-since-last.sh
+            echo "export DIND_NEEDED DIND_TAG DIND_PREV"
+            echo "export FN_NEEDED FN_TAG FN_PREV"
+          ) >> $BASH_ENV
+
+      # Rebuild the build tools if necessary
+      # This leaves local docker images around
+      - run: |
+          if [[ -n "$DIND_NEEDED" ]]; then
+            make build-dind
+          fi
+
+      # Rebuild fnserver if necessary
+      - run: |
+          if [[ -n "$FN_NEEDED" ]]; then
+            make full-test -j $(nproc)
+          fi
+
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
@@ -38,5 +58,10 @@ jobs:
               git config --global user.email "ci@fnproject.com"
               git config --global user.name "CI"
               git branch --set-upstream-to=origin/${CIRCLE_BRANCH} ${CIRCLE_BRANCH}
-              ./release.sh
+              if [[ -n "$DIND_NEEDED" ]]; then
+                make release-dind
+              fi
+              if [[ -n "$FN_NEEDED" ]]; then
+                make release-fnserver
+              fi
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ ENV D=/go/src/github.com/fnproject/fn
 ADD . $D
 RUN cd $D && go build -o fn-alpine && cp fn-alpine /tmp/
 
-# final stage
-FROM fnproject/dind:17.12
+# final stage: the local fnproject/dind:latest will be either built afresh or
+# whatever is the latest from master, depending on whether we're releasing
+# a newer cut.
+FROM fnproject/dind:latest
 WORKDIR /app
 COPY --from=build-env /tmp/fn-alpine /app/fnserver
 CMD ["./fnserver"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,15 @@ clear-images:
 	    docker images "$$i" --format '{{ .ID }}\t{{ .Repository }}\t{{ .Tag}}' | while read id repo tag; do \
 	        if [ "$$tag" = "<none>" ]; then docker rmi "$$id"; else docker rmi "$$repo:$$tag"; fi; done; done
 
-	         
+release-fnserver:
+	./release.sh
+
+build-dind:
+	(cd images/dind && ./build.sh)
+
+release-dind:
+	(cd images/dind && ./release.sh)
+
 fn-test-utils: checkfmt
 	cd images/fn-test-utils && ./build.sh
 

--- a/changed-since-last.sh
+++ b/changed-since-last.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/changed-since-last.sh
+++ b/changed-since-last.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -e
+
+# Has a subset of the tree changed since the last tag of a particular kind?
+# (If so, we'll need to rebuild and re-release, assuming the tests pass.)
+
+RELEASE_BRANCH=origin/master
+FIRST_COMMIT="$(git rev-list "$RELEASE_BRANCH" | tail -1)"
+
+FN_TAG="$(git tag --merged "$RELEASE_BRANCH" --sort='v:refname' '[0-9]*' | tail -1)"
+FN_PREV="$FN_TAG"
+[[ -z "$FN_TAG" ]] && FN_TAG="$FIRST_COMMIT"
+[[ -z "$FN_PREV" ]] && FN_PREV=0.0.0
+
+DIND_TAG="$(git tag --merged "$RELEASE_BRANCH" --sort='v:refname' 'dind-*' | tail -1)"
+DIND_PREV="$DIND_TAG"
+[[ -z "$DIND_TAG" ]] && DIND_TAG="$FIRST_COMMIT"
+[[ -z "$DIND_PREV" ]] && DIND_PREV=dind-0.0.0
+
+# Which pieces of the tree are changed since to each tag?
+# We are only interested in parts of the tree corresponding to each tag's aegis
+# We are *not* interested in solely-DIND changes if we're considering a release of fnserver
+
+# DIND bumps only if there are changes under images/dind.
+[[ -n "$(git diff --dirstat=files,0,cumulative "$DIND_TAG" | awk '$2 ~ /^(images\/dind)\/$/')" ]] && DIND_NEEDED=yes
+
+# FN bumps only if there are changes *other* than images/dind/
+[[ -n "$(git diff --dirstat=files,0,cumulative "$FN_TAG" | awk '$2 !~ /^(images\/dind)\/$/')" ]] && FN_NEEDED=yes
+
+# Finally, some of these pieces are used as build tools for later ones.
+[[ -n "$DIND_NEEDED" && -z "$FN_NEEDED" ]] && FN_NEEDED=dep
+
+cat <<-EOF
+	# Change summary: "dep" means a rebuild required due to a dependency change
+	DIND_NEEDED=$DIND_NEEDED
+	DIND_TAG="$DIND_TAG"
+	DIND_PREV="$DIND_PREV"
+
+	FN_NEEDED=$FN_NEEDED
+	FN_TAG="$FN_TAG"
+	FN_PREV="$FN_PREV"
+	EOF

--- a/images/dind/build.sh
+++ b/images/dind/build.sh
@@ -1,3 +1,17 @@
 set -ex
 
 docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/dind:latest .
+
+# Match version with Docker version
+version=$(docker run --rm -v "$PWD":/app treeder/bump  --extract --input "`docker -v`")
+echo "Version: $version"
+M=$(docker run --rm treeder/bump --format M --input "$version")
+Mm=$(docker run --rm treeder/bump --format M.m --input "$version")
+
+# Tag these up so that they're available for the local build process,
+# if necessary
+
+docker tag fnproject/dind:latest fnproject/dind:$version
+# be nice to have bump image do all of this tagging and pushing too (mount docker sock and do it all)
+docker tag fnproject/dind:$version fnproject/dind:$Mm
+docker tag fnproject/dind:$version fnproject/dind:$M

--- a/images/dind/release.sh
+++ b/images/dind/release.sh
@@ -1,6 +1,19 @@
-set -ex
+#!/bin/bash
 
-# ./build.sh
+set -exo pipefail
+
+# Ensure working dir is clean
+git status
+if [[ -z $(git status -s) ]]
+then
+  echo "tree is clean"
+else
+  echo "tree is dirty, please commit changes before running this"
+  exit 1
+fi
+
+# This script should be run after its sibliing, build.sh, and
+# after any related tests have passed.
 
 # Match version with Docker version
 version=$(docker run --rm -v "$PWD":/app treeder/bump  --extract --input "`docker -v`")
@@ -8,12 +21,24 @@ echo "Version: $version"
 M=$(docker run --rm treeder/bump --format M --input "$version")
 Mm=$(docker run --rm treeder/bump --format M.m --input "$version")
 
+# Calculate new release version
+DIND_NEW=$(echo "$DIND_PREV" | perl -pe 's/\d+\.\d+\.\K(\d+)/$1+1/e')
+
+# Add appropriate docker tags
 docker tag fnproject/dind:latest fnproject/dind:$version
 # be nice to have bump image do all of this tagging and pushing too (mount docker sock and do it all)
 docker tag fnproject/dind:$version fnproject/dind:$Mm
 docker tag fnproject/dind:$version fnproject/dind:$M
+docker tag fnproject/dind:$version fnproject/dind:release-$DIND_NEW
  
 docker push fnproject/dind:$version
 docker push fnproject/dind:$Mm
 docker push fnproject/dind:$M
+docker push fnproject/dind:release-$DIND_NEW
 docker push fnproject/dind:latest
+
+# Mark this release with a tag
+# No code changes so only the tag requires a push
+git tag -f -a "$DIND_NEW" -m "DIND release $DIND_NEW of $version"
+git push origin "$DIND_NEW"
+

--- a/release.sh
+++ b/release.sh
@@ -15,27 +15,15 @@ else
   exit 1
 fi
 
-git pull
-
-version_file="api/version/version.go"
-if [ -z $(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file) ]; then
-  echo "did not find semantic version in $version_file"
-  exit 1
-fi
-perl -i -pe 's/\d+\.\d+\.\K(\d+)/$1+1/e' $version_file
 version=$(grep -m1 -Eo "[0-9]+\.[0-9]+\.[0-9]+" $version_file)
 echo "Version: $version"
 
-make docker-build
-
-git add -u
-git commit -m "$image: $version release [skip ci]"
-git tag -f -a "$version" -m "version $version"
+# Push the version bump and tags laid down previously
+gtag=$image-$version
 git push
 git push origin $version
 
-# Finally tag and push docker images
-docker tag $user/$image:latest $user/$image:$version
+# Finally, push docker images
 docker push $user/$image:$version
 docker push $user/$image:latest
 


### PR DESCRIPTION
This needs a bit of an eyeball.

We check to see which bits of the tree have changed (this is a broad-grained test) before
forcing rebuilds of any dependencies (DIND in this case).

When it comes to releasing, we only release bits that've changed. Bump tags and versions
in code where necessary.

The fnserver release is basically unchanged; fnlb and DIND modified to work around it.

(I've added a handful of relevant reviewers as this is a bit fiddly.)