### PR TITLE
Change timedout to timeouts

### DIFF
--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -171,6 +171,6 @@ const (
 	runningMetricName   = "running"
 	completedMetricName = "completed"
 	failedMetricName    = "failed"
-	timedoutMetricName  = "timedout"
+	timedoutMetricName  = "timeouts"
 	errorsMetricName    = "errors"
 )


### PR DESCRIPTION
This PR changes the name of the Prometheus metric `fn_timedout` to `fn_timedouts`, as proposed in https://github.com/fnproject/fn/issues/691. 

This metric tells you the number of timed out function calls, or the number of timeouts that have occurred.



