### PR TITLE
fn: better slot/container/request state tracking

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -180,8 +180,39 @@ func (a *agent) Submit(callI Call) error {
 	return err
 }
 
+func (a *agent) startStateTrackers(ctx context.Context, call *call) {
+
+	if protocol.IsStreamable(protocol.Protocol(call.Format)) {
+		// For hot requests, we use a long lived slot queue, which we use to manage hot containers
+		var isNew bool
+		call.slots, isNew = a.slotMgr.getSlotQueue(call)
+		if isNew {
+			go a.hotLauncher(ctx, call)
+		}
+	} else {
+		// For cold containers, we track the container state in call
+		call.containerState = NewContainerState()
+	}
+
+	call.requestState = NewRequestState()
+	call.requestState.UpdateState(ctx, RequestStateWait, call.slots)
+}
+
+func (a *agent) endStateTrackers(ctx context.Context, call *call) {
+
+	call.requestState.UpdateState(ctx, RequestStateDone, call.slots)
+
+	// For cold containers, we are done with the container.
+	if call.containerState != nil {
+		call.containerState.UpdateState(ctx, ContainerStateDone, call.slots)
+	}
+}
+
 func (a *agent) submit(ctx context.Context, call *call) error {
 	a.stats.Enqueue(ctx, call.AppName, call.Path)
+
+	a.startStateTrackers(ctx, call)
+	defer a.endStateTrackers(ctx, call)
 
 	slot, err := a.getSlot(ctx, call)
 	if err != nil {
@@ -226,10 +257,10 @@ func transformTimeout(e error, isRetriable bool) error {
 func (a *agent) handleStatsDequeue(ctx context.Context, call *call, err error) {
 	if err == context.DeadlineExceeded {
 		a.stats.Dequeue(ctx, call.AppName, call.Path)
-		a.stats.IncrementTooBusy(ctx)
+		IncrementTooBusy(ctx)
 	} else {
 		a.stats.DequeueAndFail(ctx, call.AppName, call.Path)
-		a.stats.IncrementErrors(ctx)
+		IncrementErrors(ctx)
 	}
 }
 
@@ -243,9 +274,9 @@ func (a *agent) handleStatsEnd(ctx context.Context, call *call, err error) {
 		a.stats.Failed(ctx, call.AppName, call.Path)
 		// increment the timeout or errors count, as appropriate
 		if err == context.DeadlineExceeded {
-			a.stats.IncrementTimedout(ctx)
+			IncrementTimedout(ctx)
 		} else {
-			a.stats.IncrementErrors(ctx)
+			IncrementErrors(ctx)
 		}
 	}
 }
@@ -282,19 +313,8 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_get_slot")
 	defer span.Finish()
 
-	isHot := protocol.IsStreamable(protocol.Protocol(call.Format))
-	if isHot {
-		start := time.Now()
-
-		// For hot requests, we use a long lived slot queue, which we use to manage hot containers
-		var isNew bool
-		call.slots, isNew = a.slotMgr.getSlotQueue(call)
-		if isNew {
-			go a.hotLauncher(ctx, call)
-		}
-
+	if protocol.IsStreamable(protocol.Protocol(call.Format)) {
 		s, err := a.waitHot(ctx, call)
-		call.slots.exitStateWithLatency(SlotQueueWaiter, uint64(time.Now().Sub(start).Seconds()*1000))
 		return s, err
 	}
 
@@ -351,18 +371,24 @@ func (a *agent) checkLaunch(ctx context.Context, call *call) {
 	if !isNeeded {
 		return
 	}
-	common.Logger(ctx).WithFields(logrus.Fields{"currentStats": curStats, "isNeeded": isNeeded}).Info("Hot function launcher starting hot container")
+
+	state := NewContainerState()
+	state.UpdateState(ctx, ContainerStateWait, call.slots)
+
+	common.Logger(ctx).WithFields(logrus.Fields{"currentStats": call.slots.getStats(), "isNeeded": isNeeded}).Info("Hot function launcher starting hot container")
 
 	select {
 	case tok := <-a.resources.GetResourceToken(ctx, call.Memory, uint64(call.CPUs), isAsync):
 		a.wg.Add(1) // add waiter in this thread
 		go func() {
 			// NOTE: runHot will not inherit the timeout from ctx (ignore timings)
-			a.runHot(ctx, call, tok)
+			a.runHot(ctx, call, tok, state)
 			a.wg.Done()
 		}()
 	case <-ctx.Done(): // timeout
+		state.UpdateState(ctx, ContainerStateDone, call.slots)
 	case <-a.shutdown: // server shutdown
+		state.UpdateState(ctx, ContainerStateDone, call.slots)
 	}
 }
 
@@ -418,6 +444,8 @@ func (a *agent) launchCold(ctx context.Context, call *call) (Slot, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_launch_cold")
 	defer span.Finish()
 
+	call.containerState.UpdateState(ctx, ContainerStateWait, call.slots)
+
 	select {
 	case tok := <-a.resources.GetResourceToken(ctx, call.Memory, uint64(call.CPUs), isAsync):
 		go a.prepCold(ctx, call, tok, ch)
@@ -441,6 +469,7 @@ func (a *agent) launchCold(ctx context.Context, call *call) (Slot, error) {
 // implements Slot
 type coldSlot struct {
 	cookie drivers.Cookie
+	waiter drivers.WaitResult
 	tok    ResourceToken
 	err    error
 }
@@ -453,12 +482,10 @@ func (s *coldSlot) exec(ctx context.Context, call *call) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_cold_exec")
 	defer span.Finish()
 
-	waiter, err := s.cookie.Run(ctx)
-	if err != nil {
-		return err
-	}
+	call.requestState.UpdateState(ctx, RequestStateExec, call.slots)
+	call.containerState.UpdateState(ctx, ContainerStateBusy, call.slots)
 
-	res, err := waiter.Wait(ctx)
+	res, err := s.waiter.Wait(ctx)
 	if err != nil {
 		return err
 	} else if res.Error() != nil {
@@ -476,6 +503,7 @@ func (s *coldSlot) Close() error {
 		// removal latency
 		s.cookie.Close(context.Background()) // ensure container removal, separate ctx
 	}
+
 	if s.tok != nil {
 		s.tok.Close()
 	}
@@ -504,11 +532,10 @@ func (s *hotSlot) exec(ctx context.Context, call *call) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_hot_exec")
 	defer span.Finish()
 
+	call.requestState.UpdateState(ctx, RequestStateExec, call.slots)
+
 	// link the container id and id in the logs [for us!]
 	common.Logger(ctx).WithField("container_id", s.container.id).Info("starting call")
-
-	start := time.Now()
-	defer func() { call.slots.recordLatency(SlotQueueRunner, uint64(time.Now().Sub(start).Seconds()*1000)) }()
 
 	// swap in the new stderr logger & stat accumulator
 	oldStderr := s.container.swap(call.stderr, &call.Stats)
@@ -542,6 +569,8 @@ func (a *agent) prepCold(ctx context.Context, call *call, tok ResourceToken, ch 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_prep_cold")
 	defer span.Finish()
 
+	call.containerState.UpdateState(ctx, ContainerStateStart, call.slots)
+
 	// add additional headers to the config to shove everything into env vars for cold
 	for k, v := range call.Headers {
 		if !specialHeader(k) {
@@ -567,8 +596,20 @@ func (a *agent) prepCold(ctx context.Context, call *call, tok ResourceToken, ch 
 
 	// pull & create container before we return a slot, so as to be friendly
 	// about timing out if this takes a while...
-	cookie, err := a.driver.Prepare(ctx, container)
-	slot := &coldSlot{cookie, tok, err}
+	var err error
+	var cookie drivers.Cookie
+	var waiter drivers.WaitResult
+
+	cookie, err = a.driver.Prepare(ctx, container)
+	if err == nil {
+		waiter, err = cookie.Run(ctx)
+	}
+
+	if waiter != nil {
+		call.containerState.UpdateState(ctx, ContainerStateIdle, call.slots)
+	}
+
+	slot := &coldSlot{cookie, waiter, tok, err}
 	select {
 	case ch <- slot:
 	case <-ctx.Done():
@@ -576,7 +617,7 @@ func (a *agent) prepCold(ctx context.Context, call *call, tok ResourceToken, ch 
 	}
 }
 
-func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken) {
+func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state ContainerState) {
 	// IMPORTANT: get a context that has a child span / logger but NO timeout
 	// TODO this is a 'FollowsFrom'
 	ctx = opentracing.ContextWithSpan(context.Background(), opentracing.SpanFromContext(ctx))
@@ -590,8 +631,8 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken) {
 
 	proto := protocol.New(protocol.Protocol(call.Format), stdinWrite, stdoutRead)
 
-	start := time.Now()
-	call.slots.enterState(SlotQueueStarter)
+	state.UpdateState(ctx, ContainerStateStart, call.slots)
+	defer state.UpdateState(ctx, ContainerStateDone, call.slots)
 
 	cid := id.New().String()
 
@@ -617,7 +658,6 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken) {
 
 	cookie, err := a.driver.Prepare(ctx, container)
 	if err != nil {
-		call.slots.exitStateWithLatency(SlotQueueStarter, uint64(time.Now().Sub(start).Seconds()*1000))
 		call.slots.queueSlot(&hotSlot{done: make(chan struct{}), err: err})
 		return
 	}
@@ -625,15 +665,12 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken) {
 
 	waiter, err := cookie.Run(ctx)
 	if err != nil {
-		call.slots.exitStateWithLatency(SlotQueueStarter, uint64(time.Now().Sub(start).Seconds()*1000))
 		call.slots.queueSlot(&hotSlot{done: make(chan struct{}), err: err})
 		return
 	}
 
 	// container is running
-	call.slots.enterState(SlotQueueRunner)
-	call.slots.exitStateWithLatency(SlotQueueStarter, uint64(time.Now().Sub(start).Seconds()*1000))
-	defer call.slots.exitState(SlotQueueRunner)
+	state.UpdateState(ctx, ContainerStateIdle, call.slots)
 
 	// buffered, in case someone has slot when waiter returns but isn't yet listening
 	errC := make(chan error, 1)
@@ -653,30 +690,27 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken) {
 			}
 
 			done := make(chan struct{})
-			start := time.Now()
-			call.slots.enterState(SlotQueueIdle)
+			state.UpdateState(ctx, ContainerStateIdle, call.slots)
 			s := call.slots.queueSlot(&hotSlot{done, proto, errC, container, nil})
 
 			select {
 			case <-s.trigger:
-				call.slots.exitStateWithLatency(SlotQueueIdle, uint64(time.Now().Sub(start).Seconds()*1000))
 			case <-time.After(time.Duration(call.IdleTimeout) * time.Second):
 				if call.slots.ejectSlot(s) {
-					call.slots.exitStateWithLatency(SlotQueueIdle, uint64(time.Now().Sub(start).Seconds()*1000))
 					logger.Info("Canceling inactive hot function")
 					return
 				}
 			case <-ctx.Done(): // container shutdown
 				if call.slots.ejectSlot(s) {
-					call.slots.exitStateWithLatency(SlotQueueIdle, uint64(time.Now().Sub(start).Seconds()*1000))
 					return
 				}
 			case <-a.shutdown: // server shutdown
 				if call.slots.ejectSlot(s) {
-					call.slots.exitStateWithLatency(SlotQueueIdle, uint64(time.Now().Sub(start).Seconds()*1000))
 					return
 				}
 			}
+
+			state.UpdateState(ctx, ContainerStateBusy, call.slots)
 			// IMPORTANT: if we fail to eject the slot, it means that a consumer
 			// just dequeued this and acquired the slot. In other words, we were
 			// late in ejectSlots(), so we have to execute this request in this

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -249,14 +249,16 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 type call struct {
 	*models.Call
 
-	da           DataAccess
-	w            io.Writer
-	req          *http.Request
-	stderr       io.ReadWriteCloser
-	ct           callTrigger
-	slots        *slotQueue
-	slotDeadline time.Time
-	execDeadline time.Time
+	da             DataAccess
+	w              io.Writer
+	req            *http.Request
+	stderr         io.ReadWriteCloser
+	ct             callTrigger
+	slots          *slotQueue
+	slotDeadline   time.Time
+	execDeadline   time.Time
+	requestState   RequestState
+	containerState ContainerState
 }
 
 func (c *call) Model() *models.Call { return c.Call }

--- a/api/agent/state_trackers.go
+++ b/api/agent/state_trackers.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/fnproject/fn/api/common"
+)
+
+type RequestStateType int
+type ContainerStateType int
+
+type containerState struct {
+	lock  sync.Mutex
+	state ContainerStateType
+	start time.Time
+}
+
+type requestState struct {
+	lock  sync.Mutex
+	state RequestStateType
+	start time.Time
+}
+
+type ContainerState interface {
+	UpdateState(ctx context.Context, newState ContainerStateType, slots *slotQueue)
+}
+type RequestState interface {
+	UpdateState(ctx context.Context, newState RequestStateType, slots *slotQueue)
+}
+
+func NewRequestState() RequestState {
+	return &requestState{}
+}
+
+func NewContainerState() ContainerState {
+	return &containerState{}
+}
+
+const (
+	RequestStateNone RequestStateType = iota // uninitialized
+	RequestStateWait                         // request is waiting
+	RequestStateExec                         // request is executing
+	RequestStateDone                         // request is done
+	RequestStateMax
+)
+
+const (
+	ContainerStateNone  ContainerStateType = iota // uninitialized
+	ContainerStateWait                            // resource (cpu + mem) waiting
+	ContainerStateStart                           // launching
+	ContainerStateIdle                            // running idle
+	ContainerStateBusy                            // running busy
+	ContainerStateDone                            // exited/failed/done
+	ContainerStateMax
+)
+
+var containerGaugeKeys = [ContainerStateMax]string{
+	"",
+	"container_wait_total",
+	"container_start_total",
+	"container_idle_total",
+	"container_busy_total",
+	"container_done_total",
+}
+var containerTimeKeys = [ContainerStateMax]string{
+	"",
+	"container_wait_duration_seconds",
+	"container_start_duration_seconds",
+	"container_idle_duration_seconds",
+	"container_busy_duration_seconds",
+}
+
+func (c *requestState) UpdateState(ctx context.Context, newState RequestStateType, slots *slotQueue) {
+
+	var now time.Time
+	var oldState RequestStateType
+
+	c.lock.Lock()
+
+	// we can only advance our state forward
+	if c.state < newState {
+
+		now = time.Now()
+		oldState = c.state
+		c.state = newState
+		c.start = now
+	}
+
+	c.lock.Unlock()
+
+	if now.IsZero() {
+		return
+	}
+
+	// reflect this change to slot mgr if defined (AKA hot)
+	if slots != nil {
+		slots.enterRequestState(newState)
+		slots.exitRequestState(oldState)
+	}
+}
+
+func (c *containerState) UpdateState(ctx context.Context, newState ContainerStateType, slots *slotQueue) {
+
+	var now time.Time
+	var oldState ContainerStateType
+	var before time.Time
+
+	c.lock.Lock()
+
+	// except for 1) switching back to idle from busy (hot containers) or 2)
+	// to waiting from done, otherwise we can only move forward in states
+	if c.state < newState ||
+		(c.state == ContainerStateBusy && newState == ContainerStateIdle) ||
+		(c.state == ContainerStateDone && newState == ContainerStateIdle) {
+
+		now = time.Now()
+		oldState = c.state
+		before = c.start
+		c.state = newState
+		c.start = now
+	}
+
+	c.lock.Unlock()
+
+	if now.IsZero() {
+		return
+	}
+
+	// reflect this change to slot mgr if defined (AKA hot)
+	if slots != nil {
+		slots.enterContainerState(newState)
+		slots.exitContainerState(oldState)
+	}
+
+	// update old state stats
+	gaugeKey := containerGaugeKeys[oldState]
+	if gaugeKey != "" {
+		common.DecrementGauge(ctx, gaugeKey)
+	}
+	timeKey := containerTimeKeys[oldState]
+	if timeKey != "" {
+		common.PublishElapsedTimeHistogram(ctx, timeKey, before, now)
+	}
+
+	// update new state stats
+	gaugeKey = containerGaugeKeys[newState]
+	if gaugeKey != "" {
+		common.IncrementGauge(ctx, gaugeKey)
+	}
+}

--- a/api/common/metrics.go
+++ b/api/common/metrics.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+	"time"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -104,6 +106,14 @@ func PublishHistogramToSpan(span opentracing.Span, key string, value float64) {
 	// The collector will replace that prefix with "fn_" and use the result as the Prometheus metric name.
 	fieldname := FieldnamePrefixHistogram + key
 	span.LogFields(log.Float64(fieldname, value))
+}
+
+// PublishElapsedTimeToSpan publishes the specifed histogram elapsed time since start
+// It does this by logging an appropriate field value to a tracing span
+// Use this when the current tracing span is long-lived and you want the metric to be visible before it ends
+func PublishElapsedTimeHistogram(ctx context.Context, key string, start, end time.Time) {
+	elapsed := float64(end.Sub(start).Seconds())
+	PublishHistogram(ctx, key, elapsed)
 }
 
 const (


### PR DESCRIPTION
*) in stats.go no need to lock span log (aka common/metrics.go calls)
*) tracker code to simplify agent side and also track request vs container states.
*) slots code a bit clearer since 'waiters' is actually queued requests, versus 'starter' means starting containers.
*) for cold cookie run moved into prepCold() as this is part of container spawn/start phase as std IO is tied up to the container, with this we consider waiting on 'waiter' channel period is the 'execution' phase. This is not entirely true, but a close enough approximation.
*) container states get logged in spans as histograms (for time), and gauge (for counts)