### PR TITLE
Hot protocols improvements (for 662)

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -564,23 +564,21 @@ func (s *hotSlot) exec(ctx context.Context, call *call) error {
 	// TODO we REALLY need to wait for dispatch to return before conceding our slot
 }
 
-func specialHeader(k string) bool {
-	return k == "Fn_call_id" || k == "Fn_method" || k == "Fn_request_url"
-}
-
 func (a *agent) prepCold(ctx context.Context, call *call, tok ResourceToken, ch chan Slot) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "agent_prep_cold")
 	defer span.Finish()
 
 	call.containerState.UpdateState(ctx, ContainerStateStart, call.slots)
 
-	// add additional headers to the config to shove everything into env vars for cold
+	// add Fn-specific information to the config to shove everything into env vars for cold
+	call.Config["FN_DEADLINE"] = strfmt.DateTime(call.execDeadline).String()
+	call.Config["FN_METHOD"] = call.Model().Method
+	call.Config["FN_REQUEST_URL"] = call.Model().URL
+	call.Config["FN_CALL_ID"] = call.Model().ID
+
+	// User headers are prefixed with FN_HEADER and shoved in the env vars too
 	for k, v := range call.Headers {
-		if !specialHeader(k) {
-			k = "FN_HEADER_" + k
-		} else {
-			k = strings.ToUpper(k) // for compat, FN_CALL_ID, etc. in env for cold
-		}
+		k = "FN_HEADER_" + k
 		call.Config[k] = strings.Join(v, ", ")
 	}
 

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fnproject/fn/api/id"
 	"github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn/fnext"
+	"github.com/go-openapi/strfmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -168,9 +168,6 @@ func TestCallConfigurationRequest(t *testing.T) {
 	}
 
 	expectedHeaders := make(http.Header)
-	expectedHeaders.Add("FN_CALL_ID", model.ID)
-	expectedHeaders.Add("FN_METHOD", method)
-	expectedHeaders.Add("FN_REQUEST_URL", url)
 
 	expectedHeaders.Add("MYREALHEADER", "FOOLORD")
 	expectedHeaders.Add("MYREALHEADER", "FOOPEASANT")

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -233,16 +233,6 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 	c.slotDeadline = slotDeadline
 	c.execDeadline = execDeadline
 
-	execDeadlineStr := strfmt.DateTime(execDeadline).String()
-
-	// these 2 headers buckets are the same but for posterity!
-	if c.Headers == nil {
-		c.Headers = make(http.Header)
-		c.req.Header = c.Headers
-	}
-	c.Headers.Set("FN_DEADLINE", execDeadlineStr)
-	c.req.Header.Set("FN_DEADLINE", execDeadlineStr)
-
 	return &c, nil
 }
 

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -78,11 +78,6 @@ func FromRequest(appName, path string, req *http.Request) CallOpt {
 			}
 		}
 
-		// add our per call headers in here
-		req.Header.Set("FN_METHOD", req.Method)
-		req.Header.Set("FN_REQUEST_URL", reqURL(req))
-		req.Header.Set("FN_CALL_ID", id)
-
 		// this ensures that there is an image, path, timeouts, memory, etc are valid.
 		// NOTE: this means assign any changes above into route's fields
 		err = route.Validate()

--- a/api/agent/protocol/factory.go
+++ b/api/agent/protocol/factory.go
@@ -76,7 +76,10 @@ func (ci callInfoImpl) Deadline() strfmt.DateTime {
 		// something meaningful.
 		// This assumes StartedAt was set to something other than the default.
 		// If that isn't set either, then how many things have gone wrong?
-		// TODO: assert or panic in that case
+		if ci.call.StartedAt == strfmt.NewDateTime() {
+			// We just panic if StartedAt is the default (i.e. not set)
+			panic("No context deadline and zero-value StartedAt - this should never happen")
+		}
 		deadline = ((time.Time)(ci.call.StartedAt)).Add(time.Duration(ci.call.Timeout) * time.Second)
 	}
 	return strfmt.DateTime(deadline)

--- a/api/agent/protocol/http.go
+++ b/api/agent/protocol/http.go
@@ -25,6 +25,9 @@ func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) e
 
 	req.RequestURI = ci.RequestURL() // force set to this, for req.Write to use (TODO? still?)
 
+	// Add execution deadline as a header for this protocol
+	req.Header.Set("FN_DEADLINE", ci.Deadline().String())
+
 	// req.Write handles if the user does not specify content length
 	err := req.Write(h.in)
 	if err != nil {

--- a/api/agent/protocol/http.go
+++ b/api/agent/protocol/http.go
@@ -25,8 +25,11 @@ func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) e
 
 	req.RequestURI = ci.RequestURL() // force set to this, for req.Write to use (TODO? still?)
 
-	// Add execution deadline as a header for this protocol
+	// Add Fn-specific headers for this protocol
 	req.Header.Set("FN_DEADLINE", ci.Deadline().String())
+	req.Header.Set("FN_METHOD", ci.Method())
+	req.Header.Set("FN_REQUEST_URL", ci.RequestURL())
+	req.Header.Set("FN_CALL_ID", ci.CallID())
 
 	// req.Write handles if the user does not specify content length
 	err := req.Write(h.in)

--- a/api/agent/protocol/json.go
+++ b/api/agent/protocol/json.go
@@ -20,6 +20,7 @@ type jsonio struct {
 type CallRequestHTTP struct {
 	// TODO request method ?
 	Type       string      `json:"type"`
+	Method     string      `json:"method"`
 	RequestURL string      `json:"request_url"`
 	Headers    http.Header `json:"headers"`
 }

--- a/api/agent/protocol/json.go
+++ b/api/agent/protocol/json.go
@@ -100,6 +100,17 @@ func (h *JSONProtocol) writeJSONToContainer(ci CallInfo) error {
 		return err
 	}
 
+	// deadline
+	err = writeString(err, h.in, ",")
+	err = writeString(err, h.in, `"deadline":`)
+	if err != nil {
+		return err
+	}
+	err = stdin.Encode(ci.Deadline().String())
+	if err != nil {
+		return err
+	}
+
 	// body
 	err = writeString(err, h.in, ",")
 	err = writeString(err, h.in, `"body":`)

--- a/api/agent/protocol/json_test.go
+++ b/api/agent/protocol/json_test.go
@@ -124,7 +124,15 @@ func TestJSONProtocolwriteJSONInputRequestWithData(t *testing.T) {
 	}
 	if incomingReq.Protocol.Type != ci.ProtocolType() {
 		t.Errorf("Call protocol type assertion mismatch: expected: %s, got %s",
-			ci.call.Type, incomingReq.Protocol.Type)
+			ci.ProtocolType(), incomingReq.Protocol.Type)
+	}
+	if incomingReq.Protocol.Method != ci.Method() {
+		t.Errorf("Call protocol method assertion mismatch: expected: %s, got %s",
+			ci.Method(), incomingReq.Protocol.Method)
+	}
+	if incomingReq.Protocol.RequestURL != ci.RequestURL() {
+		t.Errorf("Call protocol request URL assertion mismatch: expected: %s, got %s",
+			ci.RequestURL(), incomingReq.Protocol.RequestURL)
 	}
 }
 
@@ -157,6 +165,18 @@ func TestJSONProtocolwriteJSONInputRequestWithoutData(t *testing.T) {
 	if !models.Headers(ci.req.Header).Equals(models.Headers(incomingReq.Protocol.Headers)) {
 		t.Errorf("Request headers assertion mismatch: expected: %s, got %s",
 			ci.req.Header, incomingReq.Protocol.Headers)
+	}
+	if incomingReq.Protocol.Type != ci.ProtocolType() {
+		t.Errorf("Call protocol type assertion mismatch: expected: %s, got %s",
+			ci.ProtocolType(), incomingReq.Protocol.Type)
+	}
+	if incomingReq.Protocol.Method != ci.Method() {
+		t.Errorf("Call protocol method assertion mismatch: expected: %s, got %s",
+			ci.Method(), incomingReq.Protocol.Method)
+	}
+	if incomingReq.Protocol.RequestURL != ci.RequestURL() {
+		t.Errorf("Call protocol request URL assertion mismatch: expected: %s, got %s",
+			ci.RequestURL(), incomingReq.Protocol.RequestURL)
 	}
 }
 

--- a/docs/developers/function-format.md
+++ b/docs/developers/function-format.md
@@ -84,9 +84,12 @@ Internally functions receive data in the example format below:
 {
   "call_id": "123",
   "content_type": "application/json",
+  "type":"sync",
+  "deadline":"2018-01-30T16:52:39.786Z",
   "body": "{\"some\":\"input\"}",
   "protocol": {
     "type": "http",
+    "method": "POST",
     "request_url": "http://localhost:8080/r/myapp/myfunc?q=hi",
     "headers": {
       "Content-Type": ["application/json"],
@@ -95,13 +98,15 @@ Internally functions receive data in the example format below:
   }
 }
 BLANK LINE
-{ 
+{
   NEXT INPUT OBJECT
 }
 ```
 
 * call_id - the unique ID for the call.
 * content_type - format of the `body` parameter.
+* type - whether the call was sync or async.
+* deadline - a time limit for the call, based on function timeout.
 * protocol - arbitrary map of protocol specific data. The above example shows what the HTTP protocol handler passes in. Subject to change and reduces reusability of your functions. **USE AT YOUR OWN RISK**.
 
 Under `protocol`, `headers` contains all of the HTTP headers exactly as defined in the incoming request.


### PR DESCRIPTION
Closes #662.

_This change will require FDKs which handle the `json` function format to be updated._

This change moves some Fn-specific fields around in the JSON protocol structure, thus improving the handling of Fn-specific fields that would otherwise end up in FN-prefixed headers. The rationale for this is in #662.

Fn-specific stuff (Call ID, request url, etc) that used to be stored in the headers of the `models.Call` is now instead added by the protocol dispatchers at the right time, so that the model reflects what the user has originally provided. The HTTP protocol dispatcher still creates Fn-prefixed headers, because that's the only way it can pass information to the function, but the JSON protocol can provide the information directly in JSON fields.