### PR TITLE
Add options to impose server-side mandated limits on container resources

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -146,6 +146,13 @@ func New(da DataAccess, fl FunctionLimits) Agent {
 		ServerVersion: "17.06.0",
 	})
 
+	if fl.MaxFilesystemSize() != 0 {
+		supported := driver.SupportsLimit(nil, drivers.LimitFilesystem)
+		if !supported {
+			logrus.Fatal("Can't set FN_MAX_FUNC_FILESYSTEM_SIZE, storage driver does not support quotas")
+		}
+	}
+
 	freezeIdleMsecs, err := getEnvMsecs("FN_FREEZE_IDLE_MSECS", 50*time.Millisecond)
 	if err != nil {
 		logrus.WithError(err).Fatal("error initializing freeze idle delay")

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -649,8 +649,8 @@ func (a *agent) prepCold(ctx context.Context, call *call, tok ResourceToken, ch 
 		memory = min(memory, a.limits.MaxMemory())
 	}
 	cpus := uint64(call.CPUs)
-	if a.limits.MaxMemory() != 0 {
-		memory = min(memory, a.limits.MaxMemory())
+	if a.limits.MaxCPUs() != 0 {
+		cpus = min(cpus, a.limits.MaxCPUs())
 	}
 	filesystem := uint64(call.FilesystemSize)
 	if a.limits.MaxFilesystemSize() != 0 {
@@ -712,8 +712,8 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 		memory = min(memory, a.limits.MaxMemory())
 	}
 	cpus := uint64(call.CPUs)
-	if a.limits.MaxMemory() != 0 {
-		memory = min(memory, a.limits.MaxMemory())
+	if a.limits.MaxCPUs() != 0 {
+		cpus = min(cpus, a.limits.MaxCPUs())
 	}
 	filesystem := uint64(call.FilesystemSize)
 	if a.limits.MaxFilesystemSize() != 0 {

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type noLimits struct {}
-func (nl noLimits) MaxMemory() uint64 { return 0 }
-func (nl noLimits) MaxCPUs() uint64 { return 0 }
+type noLimits struct{}
+
+func (nl noLimits) MaxMemory() uint64         { return 0 }
+func (nl noLimits) MaxCPUs() uint64           { return 0 }
 func (nl noLimits) MaxFilesystemSize() uint64 { return 0 }
 
 func init() {

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type noLimits struct {}
+func (nl noLimits) MaxMemory() uint64 { return 0 }
+func (nl noLimits) MaxCPUs() uint64 { return 0 }
+func (nl noLimits) MaxFilesystemSize() uint64 { return 0 }
+
 func init() {
 	// TODO figure out some sane place to stick this
 	formatter := &logrus.TextFormatter{
@@ -91,7 +96,7 @@ func TestCallConfigurationRequest(t *testing.T) {
 		}, nil,
 	)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	w := httptest.NewRecorder()
@@ -233,7 +238,7 @@ func TestCallConfigurationModel(t *testing.T) {
 	// FromModel doesn't need a datastore, for now...
 	ds := datastore.NewMockInit(nil, nil, nil)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	callI, err := a.GetCall(FromModel(cm))
@@ -303,7 +308,7 @@ func TestAsyncCallHeaders(t *testing.T) {
 	// FromModel doesn't need a datastore, for now...
 	ds := datastore.NewMockInit(nil, nil, nil)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	callI, err := a.GetCall(FromModel(cm))
@@ -398,7 +403,7 @@ func TestSubmitError(t *testing.T) {
 	// FromModel doesn't need a datastore, for now...
 	ds := datastore.NewMockInit(nil, nil, nil)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	callI, err := a.GetCall(FromModel(cm))
@@ -454,7 +459,7 @@ func TestHTTPWithoutContentLengthWorks(t *testing.T) {
 		}, nil,
 	)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	bodOne := `{"echoContent":"yodawg"}`
@@ -517,7 +522,7 @@ func TestGetCallReturnsResourceImpossibility(t *testing.T) {
 	// FromModel doesn't need a datastore, for now...
 	ds := datastore.NewMockInit(nil, nil, nil)
 
-	a := New(NewCachedDataAccess(NewDirectDataAccess(ds, ds, new(mqs.Mock))))
+	a := New(NewCachedDataAccess(NewDirectDataAccess(ds, ds, new(mqs.Mock))), noLimits{})
 	defer a.Close()
 
 	_, err := a.GetCall(FromModel(call))
@@ -623,7 +628,7 @@ func TestPipesAreClear(t *testing.T) {
 		}, nil,
 	)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	// test read this body after 5s (after call times out) and make sure we don't get yodawg
@@ -773,7 +778,7 @@ func TestPipesDontMakeSpuriousCalls(t *testing.T) {
 		}, nil,
 	)
 
-	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)))
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), noLimits{})
 	defer a.Close()
 
 	bodOne := `{"echoContent":"yodawg"}`

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -27,6 +27,16 @@ func (nl noLimits) MaxMemory() uint64         { return 0 }
 func (nl noLimits) MaxCPUs() uint64           { return 0 }
 func (nl noLimits) MaxFilesystemSize() uint64 { return 0 }
 
+type withLimits struct {
+	memory uint64
+	cpus   uint64
+	fs     uint64
+}
+
+func (wl withLimits) MaxMemory() uint64         { return wl.memory }
+func (wl withLimits) MaxCPUs() uint64           { return wl.cpus }
+func (wl withLimits) MaxFilesystemSize() uint64 { return wl.fs }
+
 func init() {
 	// TODO figure out some sane place to stick this
 	formatter := &logrus.TextFormatter{
@@ -529,6 +539,69 @@ func TestGetCallReturnsResourceImpossibility(t *testing.T) {
 	_, err := a.GetCall(FromModel(call))
 	if err != models.ErrCallTimeoutServerBusy {
 		t.Fatal("did not get expected err, got: ", err)
+	}
+}
+
+func TestUseResourceImpossibilityToTestMemoryLimitClampingLogic(t *testing.T) {
+	// We have a call requesting masses of memory exactly like in the test
+	// above, but we set a service-mandated limit on the agent so the call can
+	// now be satisfied.
+	call := &models.Call{
+		AppName:     "yo",
+		Path:        "/yoyo",
+		Image:       "fnproject/fn-test-utils",
+		Type:        "sync",
+		Format:      "http",
+		Timeout:     1,
+		IdleTimeout: 2,
+		Memory:      math.MaxUint64,
+	}
+
+	// FromModel doesn't need a datastore, for now...
+	ds := datastore.NewMockInit(nil, nil, nil)
+
+	a := New(NewCachedDataAccess(NewDirectDataAccess(ds, ds, new(mqs.Mock))), withLimits{memory: 128})
+	defer a.Close()
+
+	_, err := a.GetCall(FromModel(call))
+	if err != nil {
+		t.Fatal("Expected GetCall to succeed with clamped memory limit, got: ", err)
+	}
+}
+
+func TestUseResourceImpossibilityToTestCPULimitClampingLogic(t *testing.T) {
+	// We have a call requesting masses of CPUs, we verify that it fails to be
+	// processed with no limits, and succeeds with a clamped limit.
+	call := &models.Call{
+		AppName:     "yo",
+		Path:        "/yoyo",
+		Image:       "fnproject/fn-test-utils",
+		Type:        "sync",
+		Format:      "http",
+		Timeout:     1,
+		IdleTimeout: 2,
+		CPUs:        models.MaxMilliCPUs,
+	}
+
+	// FromModel doesn't need a datastore, for now...
+	ds := datastore.NewMockInit(nil, nil, nil)
+
+	// Fail without the clamp
+	a := New(NewCachedDataAccess(NewDirectDataAccess(ds, ds, new(mqs.Mock))), noLimits{})
+	defer a.Close()
+
+	_, err := a.GetCall(FromModel(call))
+	if err != models.ErrCallTimeoutServerBusy {
+		t.Fatal("did not get expected err, got: ", err)
+	}
+
+	// Add the clamp and succeed
+	a2 := New(NewCachedDataAccess(NewDirectDataAccess(ds, ds, new(mqs.Mock))), withLimits{cpus: 1000})
+	defer a2.Close()
+
+	_, err = a2.GetCall(FromModel(call))
+	if err != nil {
+		t.Fatal("Expected GetCall to succeed with clamped CPU limit, got: ", err)
 	}
 }
 

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -201,7 +201,9 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 		return nil, errors.New("no model or request provided for call")
 	}
 
-	if !a.resources.IsResourcePossible(c.Memory, uint64(c.CPUs), c.Type == models.TypeAsync) {
+	clampedMemory := nonZeroMin(c.Memory, a.limits.MaxMemory())
+	clampedCPUs := nonZeroMin(uint64(c.CPUs), a.limits.MaxCPUs())
+	if !a.resources.IsResourcePossible(clampedMemory, clampedCPUs, c.Type == models.TypeAsync) {
 		// if we're not going to be able to run this call on this machine, bail here.
 		return nil, models.ErrCallTimeoutServerBusy
 	}

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -94,16 +94,17 @@ func FromRequest(appName, path string, req *http.Request) CallOpt {
 			Type:   route.Type,
 			Format: route.Format,
 			// Payload: TODO,
-			Priority:    new(int32), // TODO this is crucial, apparently
-			Timeout:     route.Timeout,
-			IdleTimeout: route.IdleTimeout,
-			Memory:      route.Memory,
-			CPUs:        route.CPUs,
-			Config:      buildConfig(app, route),
-			Headers:     req.Header,
-			CreatedAt:   strfmt.DateTime(time.Now()),
-			URL:         reqURL(req),
-			Method:      req.Method,
+			Priority:       new(int32), // TODO this is crucial, apparently
+			Timeout:        route.Timeout,
+			IdleTimeout:    route.IdleTimeout,
+			Memory:         route.Memory,
+			CPUs:           route.CPUs,
+			FilesystemSize: 0, // TODO make it configurable per route as well
+			Config:         buildConfig(app, route),
+			Headers:        req.Header,
+			CreatedAt:      strfmt.DateTime(time.Now()),
+			URL:            reqURL(req),
+			Method:         req.Method,
 		}
 
 		c.req = req

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -158,6 +158,13 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 		container.HostConfig.CPUPeriod = 100000
 	}
 
+	// Impose limits on filesystem size if specified. Translate megabytes to an appropriate option string.
+	if task.FilesystemSize() != 0 {
+		container.HostConfig.StorageOpt = make(map[string]string)
+		sizeOption := fmt.Sprintf("%vM", task.FilesystemSize())
+		container.HostConfig.StorageOpt["size"] = sizeOption
+	}
+
 	volumes := task.Volumes()
 	for _, mapping := range volumes {
 		hostDir := mapping[0]

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -221,9 +221,9 @@ func (drv *DockerDriver) SupportsLimit(ctx context.Context, l drivers.Limit) boo
 			return false // We can't know
 		}
 		if info.Driver == "overlay2" ||
-		   info.Driver == "devicemapper" ||
-		   info.Driver == "zfs" ||
-		   info.Driver == "btrfs" {
+			info.Driver == "devicemapper" ||
+			info.Driver == "zfs" ||
+			info.Driver == "btrfs" {
 			return true
 		}
 		return false

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -213,6 +213,25 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 	return &cookie{id: task.Id(), task: task, drv: drv}, nil
 }
 
+func (drv *DockerDriver) SupportsLimit(ctx context.Context, l drivers.Limit) bool {
+	if l == drivers.LimitFilesystem {
+		// We need to check whether the docker filesystem used supports it
+		info, err := drv.docker.Info(ctx)
+		if err != nil {
+			return false // We can't know
+		}
+		if info.Driver == "overlay2" ||
+		   info.Driver == "devicemapper" ||
+		   info.Driver == "zfs" ||
+		   info.Driver == "btrfs" {
+			return true
+		}
+		return false
+	}
+	// All backends support cpu and memory limits
+	return true
+}
+
 type cookie struct {
 	id   string
 	task drivers.ContainerTask

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -32,6 +32,7 @@ func (f *taskDockerTest) WriteStat(context.Context, drivers.Stat) { /* TODO */ }
 func (f *taskDockerTest) Volumes() [][2]string                    { return [][2]string{} }
 func (f *taskDockerTest) Memory() uint64                          { return 256 * 1024 * 1024 }
 func (f *taskDockerTest) CPUs() uint64                            { return 0 }
+func (f *taskDockerTest) FilesystemSize() uint64                  { return 0 }
 func (f *taskDockerTest) WorkDir() string                         { return "" }
 func (f *taskDockerTest) Close()                                  {}
 func (f *taskDockerTest) Input() io.Reader                        { return f.input }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -104,8 +104,11 @@ type ContainerTask interface {
 	// 0 is unlimited.
 	Memory() uint64
 
-	// CPUs in milli CPU units
+	// CPUs in milli CPU units.
 	CPUs() uint64
+
+	// Filesystem size limit for the container, in megabytes.
+	FilesystemSize() uint64
 
 	// WorkDir returns the working directory to use for the task. Empty string
 	// leaves it unset.

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -50,6 +50,13 @@ type WaitResult interface {
 	Wait(context.Context) (RunResult, error)
 }
 
+type Limit int
+const (
+	LimitMemory     Limit = iota
+	LimitCPU        Limit = iota
+	LimitFilesystem Limit = iota
+)
+
 type Driver interface {
 	// Prepare can be used in order to do any preparation that a specific driver
 	// may need to do before running the task, and can be useful to put
@@ -60,6 +67,10 @@ type Driver interface {
 	//
 	// The returned cookie should respect the task's timeout when it is run.
 	Prepare(ctx context.Context, task ContainerTask) (Cookie, error)
+
+	// SupportsLimit can be used to check if this driver supports limitations of
+	// a particular type (memory, cpu, etc) when executing tasks.
+	SupportsLimit(ctx context.Context, l Limit) bool
 }
 
 // RunResult indicates only the final state of the task.

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -51,6 +51,7 @@ type WaitResult interface {
 }
 
 type Limit int
+
 const (
 	LimitMemory     Limit = iota
 	LimitCPU        Limit = iota

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -20,6 +20,10 @@ func (m *Mocker) Prepare(context.Context, drivers.ContainerTask) (drivers.Cookie
 	return &cookie{m}, nil
 }
 
+func (m *Mocker) SupportsLimit(context.Context, drivers.Limit) bool {
+	return false
+}
+
 type cookie struct {
 	m *Mocker
 }

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -123,6 +123,9 @@ type Call struct {
 	// *) as floating point number "0.1" which is 1/10 of a CPU
 	CPUs MilliCPUs `json:"cpus,omitempty" db:"-"`
 
+	// FilesystemSize is a limit to the size of the filesystem this call is allowed to have, in MB.
+	FilesystemSize uint64 `json:"filesystem_size,omitempty" db:"-"`
+
 	// Config is the set of configuration variables for the call
 	Config Config `json:"config,omitempty" db:"-"`
 

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -17,9 +17,10 @@ import (
 	"github.com/fnproject/fn/api/mqs"
 )
 
-type noLimits struct {}
-func (nl noLimits) MaxMemory() uint64 { return 0 }
-func (nl noLimits) MaxCPUs() uint64 { return 0 }
+type noLimits struct{}
+
+func (nl noLimits) MaxMemory() uint64         { return 0 }
+func (nl noLimits) MaxCPUs() uint64           { return 0 }
 func (nl noLimits) MaxFilesystemSize() uint64 { return 0 }
 
 func testRunner(t *testing.T, args ...interface{}) (agent.Agent, context.CancelFunc) {

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/fnproject/fn/api/mqs"
 )
 
+type noLimits struct {}
+func (nl noLimits) MaxMemory() uint64 { return 0 }
+func (nl noLimits) MaxCPUs() uint64 { return 0 }
+func (nl noLimits) MaxFilesystemSize() uint64 { return 0 }
+
 func testRunner(t *testing.T, args ...interface{}) (agent.Agent, context.CancelFunc) {
 	ds := datastore.NewMock()
 	var mq models.MessageQueue = &mqs.Mock{}
@@ -28,7 +33,7 @@ func testRunner(t *testing.T, args ...interface{}) (agent.Agent, context.CancelF
 			mq = arg
 		}
 	}
-	r := agent.New(agent.NewDirectDataAccess(ds, ds, mq))
+	r := agent.New(agent.NewDirectDataAccess(ds, ds, mq), noLimits{})
 	return r, func() { r.Close() }
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -77,8 +77,9 @@ type functionLimits struct {
 	maxCPUs           uint64
 	maxFilesystemSize uint64
 }
-func (fl functionLimits) MaxMemory() uint64 { return fl.maxMemory }
-func (fl functionLimits) MaxCPUs() uint64 { return fl.maxCPUs }
+
+func (fl functionLimits) MaxMemory() uint64         { return fl.maxMemory }
+func (fl functionLimits) MaxCPUs() uint64           { return fl.maxCPUs }
 func (fl functionLimits) MaxFilesystemSize() uint64 { return fl.maxFilesystemSize }
 
 type Server struct {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -108,8 +109,13 @@ func NewFromEnv(ctx context.Context, opts ...ServerOption) *Server {
 	opts = append(opts, WithDBURL(getEnv(EnvDBURL, defaultDB)))
 	opts = append(opts, WithMQURL(getEnv(EnvMQURL, defaultMQ)))
 	opts = append(opts, WithLogURL(getEnv(EnvLOGDBURL, "")))
-	opts = append(opts, WithRunnerURL(getEnv(EnvRunnerURL, "")))
 	opts = append(opts, WithType(nodeType))
+
+	// Agent handling depends on node type and several other options so it must be the last processed option.
+	// Also we only need to create an agent if this is not an API node.
+	if nodeType != ServerTypeAPI {
+		opts = append(opts, WithAgentFromEnv())
+	}
 	return New(ctx, opts...)
 }
 
@@ -175,19 +181,6 @@ func WithLogURL(logstoreURL string) ServerOption {
 	}
 }
 
-func WithRunnerURL(runnerURL string) ServerOption {
-	return func(ctx context.Context, s *Server) error {
-		if runnerURL != "" {
-			cl, err := hybrid.NewClient(runnerURL)
-			if err != nil {
-				return err
-			}
-			s.agent = agent.New(agent.NewCachedDataAccess(cl))
-		}
-		return nil
-	}
-}
-
 func WithType(t ServerNodeType) ServerOption {
 	return func(ctx context.Context, s *Server) error {
 		s.nodeType = t
@@ -223,6 +216,37 @@ func WithAgent(agent agent.Agent) ServerOption {
 	}
 }
 
+// WithAgentFromEnv must be provided as the last server option because it relies
+// on all other options being set first.
+func WithAgentFromEnv() ServerOption {
+	return func(ctx context.Context, s *Server) error {
+		switch s.nodeType {
+		case ServerTypeAPI:
+			return errors.New("Should not initialize an agent for an Fn API node.")
+		case ServerTypeRunner:
+			runnerURL := getEnv(EnvRunnerURL, "")
+			if runnerURL == "" {
+				return errors.New("No FN_RUNNER_API_URL provided for an Fn Runner node.")
+			}
+			cl, err := hybrid.NewClient(runnerURL)
+			if err != nil {
+				return err
+			}
+			s.agent = agent.New(agent.NewCachedDataAccess(cl))
+		default:
+			s.nodeType = ServerTypeFull
+			if s.logstore == nil { // TODO seems weird?
+				s.logstore = s.datastore
+			}
+			if s.datastore == nil || s.logstore == nil || s.mq == nil {
+				return errors.New("Full nodes must configure FN_DB_URL, FN_LOG_URL, FN_MQ_URL.")
+			}
+			s.agent = agent.New(agent.NewCachedDataAccess(agent.NewDirectDataAccess(s.datastore, s.logstore, s.mq)))
+		}
+		return nil
+	}
+}
+
 // New creates a new Functions server with the opts given. For convenience, users may
 // prefer to use NewFromEnv but New is more flexible if needed.
 func New(ctx context.Context, opts ...ServerOption) *Server {
@@ -245,33 +269,15 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 		}
 	}
 
-	if s.logstore == nil { // TODO seems weird?
-		s.logstore = s.datastore
-	}
-
-	// TODO we maybe should use the agent.DirectDataAccess in the /runner endpoints server side?
-
+	// Check that WithAgent options have been processed correctly.
 	switch s.nodeType {
 	case ServerTypeAPI:
 		if s.agent != nil {
-			log.Info("shutting down agent configured for api node")
-			s.agent.Close()
-		}
-		s.agent = nil
-	case ServerTypeRunner:
-		if s.agent == nil {
-			log.Fatal("No agent started for a runner node, add FN_RUNNER_API_URL to configuration.")
+			log.Fatal("Incorrect configuration, API nodes must not have an agent initialized.")
 		}
 	default:
-		s.nodeType = ServerTypeFull
-		if s.datastore == nil || s.logstore == nil || s.mq == nil {
-			log.Fatal("Full nodes must configure FN_DB_URL, FN_LOG_URL, FN_MQ_URL.")
-		}
-
-		// TODO force caller to use WithAgent option? at this point we need to use the ds/ls/mq configured after all opts are run.
 		if s.agent == nil {
-			// TODO for tests we don't want cache, really, if we force WithAgent this can be fixed. cache needs to be moved anyway so that runner nodes can use it...
-			s.agent = agent.New(agent.NewCachedDataAccess(agent.NewDirectDataAccess(s.datastore, s.logstore, s.mq)))
+			log.Fatal("Incorrect configuration, non-API nodes must have an agent initialized.")
 		}
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -208,30 +208,45 @@ func WithType(t ServerNodeType) ServerOption {
 
 func WithMaxMemory(mm string) ServerOption {
 	return func(ctx context.Context, s *Server) error {
-		i, err := strconv.ParseUint(mm, 10, 64)
-		if err != nil {
-			s.limits.maxMemory = i
+		if mm != "" {
+			i, err := strconv.ParseUint(mm, 10, 64)
+			if err != nil {
+				s.limits.maxMemory = i
+				return nil
+			}
+			return err
 		}
+		s.limits.maxMemory = 0
 		return nil
 	}
 }
 
 func WithMaxCPUs(mc string) ServerOption {
 	return func(ctx context.Context, s *Server) error {
-		i, err := strconv.ParseUint(mc, 10, 64)
-		if err != nil {
-			s.limits.maxCPUs = i
+		if mc != "" {
+			i, err := strconv.ParseUint(mc, 10, 64)
+			if err != nil {
+				s.limits.maxCPUs = i
+				return nil
+			}
+			return err
 		}
+		s.limits.maxCPUs = 0
 		return nil
 	}
 }
 
 func WithMaxFS(mfs string) ServerOption {
 	return func(ctx context.Context, s *Server) error {
-		i, err := strconv.ParseUint(mfs, 10, 64)
-		if err != nil {
-			s.limits.maxFilesystemSize = i
+		if mfs != "" {
+			i, err := strconv.ParseUint(mfs, 10, 64)
+			if err != nil {
+				s.limits.maxFilesystemSize = i
+				return nil
+			}
+			return err
 		}
+		s.limits.maxFilesystemSize = 0
 		return nil
 	}
 }

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -219,10 +219,7 @@ func TestApiNode(t *testing.T) {
 	ds, logDB, close := prepareDB(ctx, t)
 	defer close()
 
-	rnr, rnrcancel := testRunner(t, ds)
-	defer rnrcancel()
-
-	srv := testServer(ds, &mqs.Mock{}, logDB, rnr, ServerTypeAPI)
+	srv := testServer(ds, &mqs.Mock{}, logDB, nil, ServerTypeAPI)
 
 	for _, test := range []struct {
 		name              string

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -29,6 +29,9 @@ docker run -e VAR_NAME=VALUE ...
 | `FN_LOG_DEST` | Set a url to send logs to, instead of stderr. [scheme://][host][:port][/path]; default scheme to udp:// if none given, possible schemes: { udp, tcp, file }
 | `FN_LOG_PREFIX` | If supplying a syslog url in `FN_LOG_DEST`, a prefix to add to each log line
 | `FN_API_CORS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
+| `FN_MAX_FUNC_MEMORY `| Impose an absolute cap (in megabytes) to the memory usage of any function container running on the node. This is in addition to function-configured limits. | 0 (no limit) |
+| `FN_MAX_FUNC_CPUS `| Impose an absolute cap (in milli-CPUs) to the CPU quota of any function container running on the node. This is in addition to function-configured limits. | 0 (no limit) |
+| `FN_MAX_FUNC_FILESYSTEM_SIZE `| Impose an absolute cap (in megabytes) to the disk space usage of any function container running on the node. | 0 (no limit) |
 | `DOCKER_HOST` | Docker remote API URL. | /var/run/docker.sock |
 | `DOCKER_API_VERSION` | Docker remote API version. | 1.24 |
 | `DOCKER_TLS_VERIFY` | Set this option to enable/disable Docker remote API over TLS/SSL. | 0 |

--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -72,7 +72,7 @@ func getServerWithCancel() (*server.Server, context.CancelFunc) {
 			dbURL = fmt.Sprintf("sqlite3://%s", tmpDb)
 		}
 
-		s = server.New(ctx, server.WithDBURL(dbURL), server.WithMQURL(mqURL))
+		s = server.New(ctx, server.WithDBURL(dbURL), server.WithMQURL(mqURL), server.WithAgentFromEnv())
 
 		go s.Start(ctx)
 		started := false


### PR DESCRIPTION
This change introduces configurable server-side mandated limits on CPU, memory and disk usage. It required a little bit of refactoring in the agent package.

This is the start of a broader work on managing resource usage on Fn nodes and preventing one function from causing disruption to other functions by overusing resources. It's a complex issue and this is just a part of it.
The goal is not just to defend from malicious agents, but also accidental mistakes (e.g. rogue loop writing terabytes to disk).

Functions already have CPU and memory limits set as part of their configuration, but this is more about introducing service-mandated limits - so, the actual limits to function resources will be the minimum between the service-mandated limits and the limits requested by the function developer.