### PR TITLE
limit log size in containers

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -147,8 +147,16 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 			AttachStdin:  true,
 			StdinOnce:    true,
 		},
-		HostConfig: &docker.HostConfig{},
-		Context:    ctx,
+		// turn off logs since we're collecting them from attach
+		HostConfig: &docker.HostConfig{
+			LogConfig: docker.LogConfig{
+				Type: "json-file", // o/w attach does not work
+				Config: map[string]string{
+					"max-size": "1m",
+				},
+			},
+		},
+		Context: ctx,
 	}
 
 	// Translate milli cpus into CPUQuota & CPUPeriod (see Linux cGroups CFS cgroup v1 documentation)


### PR DESCRIPTION
closes #317

we could fiddle with this, but we need to at least bound these. this
accomplishes that. 1m is picked since that's our default max log size for the
time being per call, it also takes a little time to generate that many bytes
through logs, typically (i.e. without trying to). I tested with 0, which
spiked the i/o rate on my machine because it's constantly deleting the json
log file. I also tested with 1k and it was similar (for a task that generated
about 1k in logs quickly) -- in testing, this halved my throughput, whereas
using 1m did not change the throughput at all. trying the 'none' driver and
'syslog' driver weren't great, 'none' turns off all stderr and 'syslog' blocks
every log line (boo). anyway, this option seems to have no effect on the
output we get in 'attach', which is what we really care about (i.e. docker is
not logically capping this, just swapping out the log file).

using 1m for this, e.g. if we have 500 hot containers on a machine we have
potentially half a gig of worthless logs laying around. we don't need the
docker logs laying around at all really, but short of writing a storage driver
ourselves there don't seem to be too many better options. open to idears, but
this is likely to hold us over for some time.