### PR TITLE
Trivial fix to get 'make test' working on Mac

### DIFF
--- a/go-fmt.sh
+++ b/go-fmt.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Find all .go files except those under vendor/ or .git, run gofmt -l on them
-OUT=$(find ! \( -path ./vendor -prune \) ! \( -path ./.git -prune \) -name '*.go' -exec gofmt -l {} +)
+OUT=$(find . ! \( -path ./vendor -prune \) ! \( -path ./.git -prune \) -name '*.go' -exec gofmt -l {} +)
 
 if [ -n "$OUT" ]; then
   echo "$OUT"


### PR DESCRIPTION
Apparently GNU find lets you omit the directory but BSD find does not.