### PR TITLE
fn: hot container timer improvements

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -812,14 +812,15 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 		break
 	}
 
-	// if we can eject token, that means we are here due to
-	// abort/shutdown/timeout, attempt to eject and terminate,
+	// if we can acquire token, that means we are here due to
+	// abort/shutdown/timeout, attempt to acquire and terminate,
 	// otherwise continue processing the request
-	if call.slots.ejectSlot(ctx, s) {
+	if call.slots.acquireSlot(s) {
+		slot.Close(ctx)
 		return false
 	}
 
-	// In case, timer/ejectSlot failure landed us here, make
+	// In case, timer/acquireSlot failure landed us here, make
 	// sure to unfreeze.
 	if isFrozen {
 		err = cookie.Unfreeze(ctx)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -655,10 +655,7 @@ func stopTimer(timer *time.Timer) {
 	if timer.Stop() {
 		return
 	}
-	select {
-	case <-timer.C:
-	default:
-	}
+	<-timer.C
 }
 
 func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state ContainerState) {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -789,17 +789,17 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 		break
 	}
 
-	// request processing may take a long time, clean up timers now
-	ejectTicker.Stop()
-	freezeTimer.Stop()
-	idleTimer.Stop()
-
 	// if we can eject token, that means we are here due to
 	// abort/shutdown/timeout, attempt to eject and terminate,
 	// otherwise continue processing the request
 	if call.slots.ejectSlot(ctx, s) {
 		return false
 	}
+
+	// request processing may take a long time, clean up timers now
+	ejectTicker.Stop()
+	freezeTimer.Stop()
+	idleTimer.Stop()
 
 	if isFrozen {
 		err := cookie.Unfreeze(ctx)

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -77,13 +77,11 @@ func (a *slotQueue) acquireSlot(s *slotToken) bool {
 	}
 
 	a.cond.L.Lock()
-	if len(a.slots) > 0 {
-		// common case: acquired slots are usually at the end
-		for i := len(a.slots) - 1; i >= 0; i-- {
-			if a.slots[i].id == s.id {
-				a.slots = append(a.slots[:i], a.slots[i+1:]...)
-				break
-			}
+	// common case: acquired slots are usually at the end
+	for i := len(a.slots) - 1; i >= 0; i-- {
+		if a.slots[i].id == s.id {
+			a.slots = append(a.slots[:i], a.slots[i+1:]...)
+			break
 		}
 	}
 	a.cond.L.Unlock()

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -79,10 +79,12 @@ func (a *slotQueue) acquireSlot(s *slotToken) bool {
 	}
 
 	a.cond.L.Lock()
-	for i := 0; i < len(a.slots); i++ {
-		if a.slots[i].id == s.id {
-			a.slots = append(a.slots[:i], a.slots[i+1:]...)
-			break
+	if len(a.slots) > 0 {
+		for i := len(a.slots) - 1; i >= 0; i-- {
+			if a.slots[i].id == s.id {
+				a.slots = append(a.slots[:i], a.slots[i+1:]...)
+				break
+			}
 		}
 	}
 	a.cond.L.Unlock()

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -102,25 +102,22 @@ func TestSlotQueueBasic1(t *testing.T) {
 		tokens = append(tokens, tok)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	// Now according to LIFO semantics, we should get 9,8,7,6,5,4,3,2,1,0 if we dequeued right now.
-	// but let's eject 9
-	if !obj.ejectSlot(ctx, tokens[9]) {
-		t.Fatalf("Cannot eject slotToken: %#v", tokens[9])
+	// but let's acquire 9
+	if !obj.acquireSlot(tokens[9]) {
+		t.Fatalf("Cannot acquire slotToken: %#v", tokens[9])
 	}
-	// let eject 0
-	if !obj.ejectSlot(ctx, tokens[0]) {
-		t.Fatalf("Cannot eject slotToken: %#v", tokens[0])
+	// let acquire 0
+	if !obj.acquireSlot(tokens[0]) {
+		t.Fatalf("Cannot acquire slotToken: %#v", tokens[0])
 	}
-	// let eject 5
-	if !obj.ejectSlot(ctx, tokens[5]) {
-		t.Fatalf("Cannot eject slotToken: %#v", tokens[5])
+	// let acquire 5
+	if !obj.acquireSlot(tokens[5]) {
+		t.Fatalf("Cannot acquire slotToken: %#v", tokens[5])
 	}
-	// try ejecting 5 again, it should fail
-	if obj.ejectSlot(ctx, tokens[5]) {
-		t.Fatalf("Shouldn't be able to eject slotToken: %#v", tokens[5])
+	// try acquire 5 again, it should fail
+	if obj.acquireSlot(tokens[5]) {
+		t.Fatalf("Shouldn't be able to acquire slotToken: %#v", tokens[5])
 	}
 
 	err = checkGetTokenId(t, obj, timeout, 8)
@@ -128,9 +125,9 @@ func TestSlotQueueBasic1(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	// eject 7 before we can consume
-	if !obj.ejectSlot(ctx, tokens[7]) {
-		t.Fatalf("Cannot eject slotToken: %#v", tokens[2])
+	// acquire 7 before we can consume
+	if !obj.acquireSlot(tokens[7]) {
+		t.Fatalf("Cannot acquire slotToken: %#v", tokens[2])
 	}
 
 	err = checkGetTokenId(t, obj, timeout, 6)
@@ -222,15 +219,9 @@ func TestSlotQueueBasic3(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	// let's eject 1
-	if !obj.ejectSlot(ctx, token1) {
-		t.Fatalf("should fail to eject %#v", token1)
-	}
-	if !slot1.(*testSlot).isClosed {
-		t.Fatalf("%#v should be closed", token1)
+	// let's acquire 1
+	if !obj.acquireSlot(token1) {
+		t.Fatalf("should fail to acquire %#v", token1)
 	}
 
 	goMax := 10
@@ -267,13 +258,5 @@ func TestSlotQueueBasic3(t *testing.T) {
 	err = checkGetTokenId(t, obj, timeout, 2)
 	if err != context.DeadlineExceeded {
 		t.Fatalf(err.Error())
-	}
-
-	// both should be closed
-	if !slot1.(*testSlot).isClosed {
-		t.Fatalf("item1 should be closed")
-	}
-	if !slot2.(*testSlot).isClosed {
-		t.Fatalf("item2 should be closed")
 	}
 }

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -103,12 +103,12 @@ func TestSlotQueueBasic1(t *testing.T) {
 			t.Fatalf("Bad slotToken received: %#v", z)
 		}
 
-		if !z.acquireSlot() {
+		if !obj.acquireSlot(z) {
 			t.Fatalf("Cannot acquire slotToken received: %#v", z)
 		}
 
 		// second acquire shoudl fail
-		if z.acquireSlot() {
+		if obj.acquireSlot(z) {
 			t.Fatalf("Should not be able to acquire twice slotToken: %#v", z)
 		}
 
@@ -131,7 +131,7 @@ func TestSlotQueueBasic1(t *testing.T) {
 		}
 
 		// we shouldn't be able to consume an ejected slotToken
-		if z.acquireSlot() {
+		if obj.acquireSlot(z) {
 			t.Fatalf("We should not be able to acquire slotToken received: %#v", z)
 		}
 
@@ -148,7 +148,7 @@ func TestSlotQueueBasic1(t *testing.T) {
 			if z.id != 6 {
 				t.Fatalf("Should not get anything except for 6 from queue: %#v", z)
 			}
-			if !z.acquireSlot() {
+			if !obj.acquireSlot(z) {
 				t.Fatalf("cannot acquire token: %#v", z)
 			}
 		}
@@ -259,7 +259,7 @@ func TestSlotQueueBasic3(t *testing.T) {
 			t.Fatalf("2 should not yet be closed")
 		}
 
-		if !item.acquireSlot() {
+		if !obj.acquireSlot(item) {
 			t.Fatalf("2 acquire should not fail")
 		}
 

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -30,7 +30,7 @@ docker run -e VAR_NAME=VALUE ...
 | `FN_LOG_PREFIX` | If supplying a syslog url in `FN_LOG_DEST`, a prefix to add to each log line
 | `FN_API_CORS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
 | `FN_FREEZE_IDLE_MSECS` | Set this option to specify the amount of time to wait in milliseconds before pausing/freezing an idle hot container. Set to 0 to freeze idle containers without any delay. Set to negative integer to disable freeze/pause of idle hot containers. | 50 |
- `FN_EJECT_IDLE_MSECS` | Set this option to specify the amount of time to wait in milliseconds before attempting to terminate an idle hot container when the system is starved for CPU and Memory resources. Set to negative integer to disable this feature. | 1000 |
+ `FN_EJECT_IDLE_MSECS` | Set this option to specify the amount of time in milliseconds to periodically check to terminate an idle hot container if the system is starved for CPU and Memory resources. Set to negative integer to disable this feature. | 1000 |
 | `DOCKER_HOST` | Docker remote API URL. | /var/run/docker.sock |
 | `DOCKER_API_VERSION` | Docker remote API version. | 1.24 |
 | `DOCKER_TLS_VERIFY` | Set this option to enable/disable Docker remote API over TLS/SSL. | 0 |


### PR DESCRIPTION
With this change, now we are allocating the timers
when the container starts and managing them via
stop/clear as needed, which should not only be more
efficient, but also easier to follow.

For example, previously, if eject time out was
set to 10 secs, this could have delayed idle timeout
up to 10 secs as well. It is also not necessary to do
any math for elapsed time.