### PR TITLE
disable fail whale logs

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -150,10 +150,7 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 		// turn off logs since we're collecting them from attach
 		HostConfig: &docker.HostConfig{
 			LogConfig: docker.LogConfig{
-				Type: "json-file", // o/w attach does not work
-				Config: map[string]string{
-					"max-size": "1m",
-				},
+				Type: "none",
 			},
 		},
 		Context: ctx,
@@ -351,7 +348,7 @@ func (drv *DockerDriver) run(ctx context.Context, container string, task drivers
 
 	waiter, err := drv.docker.AttachToContainerNonBlocking(ctx, docker.AttachToContainerOptions{
 		Container: container, OutputStream: mwOut, ErrorStream: mwErr,
-		Stream: true, Logs: true, Stdout: true, Stderr: true,
+		Stream: true, Stdout: true, Stderr: true,
 		Stdin: true, InputStream: task.Input()})
 	if err != nil && ctx.Err() == nil {
 		// ignore if ctx has errored, rewrite status lay below


### PR DESCRIPTION
we have been getting these from attach all this time and never needed these
anyway.

I ran cpu profiles of dockerd and this was 90% of docker cpu usage (json
logs). woot. this will reduce i/o quite a bit, and we don't have to worry
about them taking up any disk space either.

from tests i get about 50% speedup with these off. the hunt continues...