### PR TITLE
add pprof endpoints, additional spans

### DIFF
--- a/api/agent/protocol/http.go
+++ b/api/agent/protocol/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/fnproject/fn/api/models"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // HTTPProtocol converts stdin/stdout streams into HTTP/1.1 compliant
@@ -22,6 +23,9 @@ type HTTPProtocol struct {
 func (p *HTTPProtocol) IsStreamable() bool { return true }
 
 func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "dispatch_http")
+	defer span.Finish()
+
 	req := ci.Request()
 
 	req.RequestURI = ci.RequestURL() // force set to this, for req.Write to use (TODO? still?)
@@ -32,17 +36,24 @@ func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) e
 	req.Header.Set("FN_REQUEST_URL", ci.RequestURL())
 	req.Header.Set("FN_CALL_ID", ci.CallID())
 
+	span, _ = opentracing.StartSpanFromContext(ctx, "dispatch_http_write_request")
 	// req.Write handles if the user does not specify content length
 	err := req.Write(h.in)
+	span.Finish()
 	if err != nil {
 		return err
 	}
 
+	span, _ = opentracing.StartSpanFromContext(ctx, "dispatch_http_read_response")
 	resp, err := http.ReadResponse(bufio.NewReader(h.out), ci.Request())
+	span.Finish()
 	if err != nil {
 		return models.NewAPIError(http.StatusBadGateway, fmt.Errorf("invalid http response from function err: %v", err))
 	}
 	defer resp.Body.Close()
+
+	span, _ = opentracing.StartSpanFromContext(ctx, "dispatch_http_write_response")
+	defer span.Finish()
 
 	rw, ok := w.(http.ResponseWriter)
 	if !ok {

--- a/api/server/profile.go
+++ b/api/server/profile.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Replicated from expvar.go as not public.
+func expVars(w http.ResponseWriter, r *http.Request) {
+	first := true
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "{\n")
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
+}
+
+func profilerSetup(router *gin.Engine, path string) {
+	engine := router.Group(path)
+	engine.Any("/vars", gin.WrapF(expVars))
+	engine.Any("/pprof/", gin.WrapF(pprof.Index))
+	engine.Any("/pprof/cmdline", gin.WrapF(pprof.Cmdline))
+	engine.Any("/pprof/profile", gin.WrapF(pprof.Profile))
+	engine.Any("/pprof/symbol", gin.WrapF(pprof.Symbol))
+	engine.Any("/pprof/block", gin.WrapF(pprof.Handler("block").ServeHTTP))
+	engine.Any("/pprof/heap", gin.WrapF(pprof.Handler("heap").ServeHTTP))
+	engine.Any("/pprof/goroutine", gin.WrapF(pprof.Handler("goroutine").ServeHTTP))
+	engine.Any("/pprof/threadcreate", gin.WrapF(pprof.Handler("threadcreate").ServeHTTP))
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -305,7 +305,9 @@ func WithTracer(zipkinURL string) ServerOption {
 
 		if zipkinHTTPEndpoint != "" {
 			// Custom PrometheusCollector and Zipkin HTTPCollector
-			httpCollector, zipErr := zipkintracer.NewHTTPCollector(zipkinHTTPEndpoint, zipkintracer.HTTPLogger(logger))
+			httpCollector, zipErr := zipkintracer.NewHTTPCollector(zipkinHTTPEndpoint,
+				zipkintracer.HTTPLogger(logger), zipkintracer.HTTPMaxBacklog(1000),
+			)
 			if zipErr != nil {
 				logrus.WithError(zipErr).Fatalln("couldn't start Zipkin trace collector")
 			}
@@ -433,6 +435,8 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	// TODO: move the following under v1
 	engine.GET("/stats", s.handleStats)
 	engine.GET("/metrics", s.handlePrometheusMetrics)
+
+	profilerSetup(engine, "/debug")
 
 	if s.nodeType != ServerTypeRunner {
 		v1 := engine.Group("/v1")


### PR DESCRIPTION
i would split this commit in two if i were a good dev.

the pprof stuff is really useful and this only samples when called. this is
pretty standard go service stuff. expvar is cool, too.

the additional spannos have turned up some interesting tid bits... gonna slide
em in