### PR TITLE
fn: dind SIGINT and SIGCHLD changes

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -394,6 +394,8 @@ func (s *Server) startGears(ctx context.Context, cancel context.CancelFunc) {
 
 	logrus.WithField("type", s.nodeType).Infof("Fn serving on `%v`", listen)
 
+	installChildReaper()
+
 	server := http.Server{
 		Addr:    listen,
 		Handler: s.Router,

--- a/images/dind/preentry.sh
+++ b/images/dind/preentry.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -euo pipefail
 
 fsdriver=$(grep -Eh -w -m1 "overlay|aufs" /proc/filesystems | cut -f2)
 if [ $fsdriver == "overlay" ]; then
@@ -10,6 +10,8 @@ mtu=$(ip link show dev $(ip route |
                          awk '$1 == "default" { print $NF }') |
       awk '{for (i = 1; i <= NF; i++) if ($i == "mtu") print $(i+1)}')
 
+# activate job control, prevent docker process from receiving SIGINT
+set -m
 dockerd-entrypoint.sh --storage-driver=$fsdriver --mtu=$mtu &
 
 # give docker a few seconds


### PR DESCRIPTION
1) in dind, prevent SIGINT reaching to dockerd. This kills
docker and prevents shutdown as fn server is trying to stop.
2) as init process, always reap child processes.