### PR TITLE
removed unused item in swagger (#626)

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -553,13 +553,6 @@ definitions:
         description: Most recent time that app was updated. Always in UTC.
         readOnly: true
 
-  Version:
-    type: object
-    properties:
-      version:
-        type: string
-        readOnly: true
-
   RoutesWrapper:
     type: object
     required:


### PR DESCRIPTION
(#626) the Version is unused in the swagger.  Remove that
item from the definitions.