### PR TITLE
use sync call for some api tests

### DIFF
--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -237,8 +237,8 @@ func APICallWithRetry(t *testing.T, attempts int, sleep time.Duration, callback 
 			t.Log("Exiting retry loop, API call was successful")
 			return nil
 		}
+		t.Logf("[%v] - Retrying API call after unsuccessful attempt with error: %v", i, err.Error())
 		time.Sleep(sleep)
-		t.Logf("[%v] - Retryting API call after unsuccessful attemt with error: %v", i, err.Error())
 	}
 	return err
 }


### PR DESCRIPTION
a lot of the logging tests use async calls which was flaky with timings. there
are a couple left that use async, that we need to test, but this reduces the
probability of the flaky tests flaking to 2/5 instead of 5/5.

the behaviors we are testing here we should not be testing through the api,
for this exact reason, we can test a ton of this in the agent itself and not
have to rely on timings. not taking that here, but this fixes circle ci
flaking out for a few days.