### PR TITLE
fn: remove cold implementation

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -247,7 +247,6 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 		// Non-streaming protocols can execute only 1 request and
 		// also need an upper bound on container running time.
 		c.maxRequests = 1
-		c.maxAliveDeadline = execDeadline
 	}
 
 	return &c, nil
@@ -269,10 +268,6 @@ type call struct {
 	// limit total requests that can be run on this container
 	// default: zero - unlimited
 	maxRequests uint64
-
-	// max alloved deadline for the container to run
-	// for streaming requests this should be unlimited/zero
-	maxAliveDeadline time.Time
 }
 
 func (c *call) Model() *models.Call { return c.Call }

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -243,6 +243,11 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 			k = "FN_HEADER_" + k
 			c.Call.Config[k] = strings.Join(v, ", ")
 		}
+
+		// Non-streaming protocols can execute only 1 request and
+		// also need an upper bound on container running time.
+		c.maxRequests = 1
+		c.maxAliveDeadline = execDeadline
 	}
 
 	return &c, nil
@@ -260,6 +265,14 @@ type call struct {
 	slotDeadline time.Time
 	execDeadline time.Time
 	requestState RequestState
+
+	// limit total requests that can be run on this container
+	// default: zero - unlimited
+	maxRequests uint64
+
+	// max alloved deadline for the container to run
+	// for streaming requests this should be unlimited/zero
+	maxAliveDeadline time.Time
 }
 
 func (c *call) Model() *models.Call { return c.Call }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -91,9 +91,6 @@ type ContainerTask interface {
 	// Image returns the runtime specific image to run.
 	Image() string
 
-	// Timeout specifies the maximum time a task is allowed to run. Return 0 to let it run forever.
-	Timeout() time.Duration
-
 	// Driver will write output log from task execution to these writers. Must be
 	// non-nil. Use io.Discard if log is irrelevant.
 	Logger() (stdout, stderr io.Writer)

--- a/api/agent/protocol/default.go
+++ b/api/agent/protocol/default.go
@@ -6,9 +6,34 @@ import (
 )
 
 // DefaultProtocol is the protocol used by cold-containers
-type DefaultProtocol struct{}
+type DefaultProtocol struct {
+	in  io.WriteCloser
+	out io.Reader
+}
 
 func (p *DefaultProtocol) IsStreamable() bool { return false }
+
 func (d *DefaultProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) error {
-	return nil
+
+	// Here we perform I/O in their own go routines. We do not assume any ordering such
+	// as request/response in 'default' protocol. In other words, output may arrive
+	// before we finish providing input.
+
+	errApp := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(d.in, ci.Input())
+		d.in.Close()
+		errApp <- err
+	}()
+
+	go func() {
+		_, err := io.Copy(w, d.out)
+		errApp <- err
+	}()
+
+	err := <-errApp
+	if err == nil {
+		err = <-errApp
+	}
+	return err
 }

--- a/api/agent/protocol/factory.go
+++ b/api/agent/protocol/factory.go
@@ -157,14 +157,14 @@ func (p Protocol) MarshalJSON() ([]byte, error) {
 
 // New creates a valid protocol handler from a I/O pipe representing containers
 // stdin/stdout.
-func New(p Protocol, in io.Writer, out io.Reader) ContainerIO {
+func New(p Protocol, in io.WriteCloser, out io.Reader) ContainerIO {
 	switch p {
 	case HTTP:
 		return &HTTPProtocol{in, out}
 	case JSON:
 		return &JSONProtocol{in, out}
 	case Default, Empty:
-		return &DefaultProtocol{}
+		return &DefaultProtocol{in, out}
 	}
 	return &errorProto{errInvalidProtocol}
 }


### PR DESCRIPTION
Cold requests/containers now become execute-once
hot containers. There's no visible change to users
and/or operators.