### PR TITLE
Remove replicated expvar handler

### DIFF
--- a/api/server/profile.go
+++ b/api/server/profile.go
@@ -2,31 +2,14 @@ package server
 
 import (
 	"expvar"
-	"fmt"
-	"net/http"
 	"net/http/pprof"
 
 	"github.com/gin-gonic/gin"
 )
 
-// Replicated from expvar.go as not public.
-func expVars(w http.ResponseWriter, r *http.Request) {
-	first := true
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\n")
-	expvar.Do(func(kv expvar.KeyValue) {
-		if !first {
-			fmt.Fprintf(w, ",\n")
-		}
-		first = false
-		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
-	})
-	fmt.Fprintf(w, "\n}\n")
-}
-
 func profilerSetup(router *gin.Engine, path string) {
 	engine := router.Group(path)
-	engine.Any("/vars", gin.WrapF(expVars))
+	engine.Any("/vars", gin.WrapF(expvar.Handler().ServeHTTP))
 	engine.Any("/pprof/", gin.WrapF(pprof.Index))
 	engine.Any("/pprof/cmdline", gin.WrapF(pprof.Cmdline))
 	engine.Any("/pprof/profile", gin.WrapF(pprof.Profile))


### PR DESCRIPTION
expvar package exports Handler which can be directly used instead of copying the expvarHandler function.