### PR TITLE
fix undefined string slot key

### DIFF
--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -326,16 +326,11 @@ func getSlotQueueKey(call *call) string {
 	}
 
 	var buf [sha1.Size]byte
-	byts := hash.Sum(buf[:0])
-	return unsafeString(byts)
+	hash.Sum(buf[:0])
+	return string(buf[:])
 }
 
 // WARN: this is read only
 func unsafeBytes(a string) []byte {
 	return *(*[]byte)(unsafe.Pointer(&a))
-}
-
-// WARN: this is read only
-func unsafeString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
 }


### PR DESCRIPTION
while escape analysis didn't lie that the bytes underlying this string escaped
to the heap, the reference to them died and led to us getting an undefined
byte array underlying the string.

sadly, this makes 4 allocs here (still down from 31), but only adds 100ns per
op. I still don't get why 'buf' and 'byts' escape to the heap, blaming faulty
escape analysis code. we could reduce one of them i guess, the hash sum
though will still escape.

this one is kind of impossible to write a test for.

found this from doing benchmarking stuff and was getting weird behavior at the
end of runs where calls didn't find a slot, ran bisect on a known-good commit
from a couple weeks ago and found that it was this. voila. this could explain
the variance from the slack dude's benchmarks, too. anyway, confirmed that
this fixes the issue.