### PR TITLE
add benchmarks for ids

### DIFF
--- a/api/id/id.go
+++ b/api/id/id.go
@@ -47,7 +47,7 @@ func SetMachineIdHost(addr net.IP, port uint16) {
 func New() Id {
 	var id Id
 	t := time.Now()
-	// TODO optimize out division by constant (check assembly for compiler optimization)
+	// NOTE compiler optimizes out division by constant for us
 	ms := uint64(t.Unix())*1000 + uint64(t.Nanosecond()/int(time.Millisecond))
 	count := atomic.AddUint64(&counter, 1)
 

--- a/api/id/id_test.go
+++ b/api/id/id_test.go
@@ -1,0 +1,30 @@
+package id
+
+import (
+	"testing"
+)
+
+func BenchmarkGen(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		id := New()
+		_ = id
+	}
+}
+
+func BenchmarkMarshalText(b *testing.B) {
+	id := New()
+	for i := 0; i < b.N; i++ {
+		byts, _ := id.MarshalText()
+		_ = byts
+	}
+}
+
+func BenchmarkUnmarshalText(b *testing.B) {
+	id := New()
+	byts, _ := id.MarshalText()
+	for i := 0; i < b.N; i++ {
+		var id Id
+		id.UnmarshalText(byts)
+		_ = id
+	}
+}


### PR DESCRIPTION
... I was curious, may as well keep them

not bad, mostly `time.Now()` and the atomic add on high core machines might make this worse, anyway it's pretty good:

```
✗: go test -bench . -benchmem
goos: linux
goarch: amd64
pkg: github.com/fnproject/fn/api/id
BenchmarkGen-2                  20000000                73.7 ns/op             0 B/op          0 allocs/op
BenchmarkMarshalText-2          30000000                47.5 ns/op            32 B/op          1 allocs/op
BenchmarkUnmarshalText-2        100000000               17.6 ns/op             0 B/op          0 allocs/op
PASS
```