### PR TITLE
Make PureRunner an Agent so that it encapsulates its grpc server

### DIFF
--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -173,12 +173,12 @@ func SetUpPureRunnerNode(ctx context.Context, nodeNum int) (*server.Server, erro
 	}
 	grpcAddr := fmt.Sprintf(":%d", 9190+nodeNum)
 	delegatedAgent := agent.NewSyncOnly(agent.NewCachedDataAccess(ds))
-	_, cancel := context.WithCancel(ctx)
+	cancelCtx, cancel := context.WithCancel(ctx)
 	prAgent, err := agent.NewPureRunner(cancel, grpcAddr, delegatedAgent, "", "", "")
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, server.WithAgent(prAgent))
+	opts = append(opts, server.WithAgent(prAgent), server.WithExtraCtx(cancelCtx))
 
 	return server.New(ctx, opts...), nil
 }

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -171,7 +171,14 @@ func SetUpPureRunnerNode(ctx context.Context, nodeNum int) (*server.Server, erro
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, server.WithAgent(agent.NewSyncOnly(agent.NewCachedDataAccess(ds))))
+	grpcAddr := fmt.Sprintf(":%d", 9190+nodeNum)
+	delegatedAgent := agent.NewSyncOnly(agent.NewCachedDataAccess(ds))
+	_, cancel := context.WithCancel(ctx)
+	prAgent, err := agent.NewPureRunner(cancel, grpcAddr, delegatedAgent, "", "", "")
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, server.WithAgent(prAgent))
 
 	return server.New(ctx, opts...), nil
 }


### PR DESCRIPTION
**PATCH 1/2 - blocks #849** 

This makes PureRunner a type of Agent and moves the grpc server initialization into the creation function.

This allows us to avoid having to create and start the grpc server in server.go, which was a bit of a smelly leakage from the PureRunner abstraction.