### PR TITLE
json format __definition__ omit whitespace between objects

### DIFF
--- a/docs/developers/function-format.md
+++ b/docs/developers/function-format.md
@@ -96,7 +96,6 @@ Internally functions receive data in the example format below:
     }
   }
 }
-BLANK LINE
 {
   NEXT INPUT OBJECT
 }
@@ -127,7 +126,6 @@ Function's output format should have the following format:
     }
   }
 }
-BLANK LINE
 {
   NEXT OUTPUT OBJECT
 }


### PR DESCRIPTION
http://json.org/ says: `Whitespace can be inserted between any pair of tokens. Excepting a few encoding details, that completely describes the language.`

we do not explicitly need the whitespace between objects in our json, it's entirely optional and soon we will even support it (#830)!