### PR TITLE
fn: non-blocking resource tracker and notification

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -451,7 +451,7 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, notifyChan chan err
 	common.Logger(ctx).WithFields(logrus.Fields{"currentStats": call.slots.getStats(), "isNeeded": isNeeded}).Info("Hot function launcher starting hot container")
 
 	select {
-	case tok := <-a.resources.GetResourceToken(ctx, call.Memory, uint64(call.CPUs), isAsync):
+	case tok := <-a.resources.GetResourceToken(ctx, call.Memory, uint64(call.CPUs), isAsync, isNB):
 		if tok != nil && tok.Error() != nil {
 			tryNotify(notifyChan, tok.Error())
 		} else if a.shutWg.AddSession(1) {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -409,6 +409,7 @@ func (a *agent) hotLauncher(ctx context.Context, call *call) {
 	for {
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		a.checkLaunch(ctx, call, notifyChan)
+		notifyChan = nil
 
 		select {
 		case <-a.shutWg.Closer(): // server shutdown

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -87,9 +87,6 @@ func NewAgentConfig() (*AgentConfig, error) {
 		return cfg, err
 	}
 
-	cfg.PreForkImage = os.Getenv(EnvPreForkImage)
-	cfg.PreForkCmd = os.Getenv(EnvPreForkCmd)
-
 	if _, ok := os.LookupEnv(EnvEnableNBResourceTracker); ok {
 		cfg.EnableNBResourceTracker = true
 	}

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -9,44 +9,46 @@ import (
 )
 
 type AgentConfig struct {
-	MinDockerVersion   string        `json:"min_docker_version"`
-	FreezeIdle         time.Duration `json:"freeze_idle_msecs"`
-	EjectIdle          time.Duration `json:"eject_idle_msecs"`
-	HotPoll            time.Duration `json:"hot_poll_msecs"`
-	HotLauncherTimeout time.Duration `json:"hot_launcher_timeout_msecs"`
-	AsyncChewPoll      time.Duration `json:"async_chew_poll_msecs"`
-	CallEndTimeout     time.Duration `json:"call_end_timeout"`
-	MaxCallEndStacking uint64        `json:"max_call_end_stacking"`
-	MaxResponseSize    uint64        `json:"max_response_size_bytes"`
-	MaxLogSize         uint64        `json:"max_log_size_bytes"`
-	MaxTotalCPU        uint64        `json:"max_total_cpu_mcpus"`
-	MaxTotalMemory     uint64        `json:"max_total_memory_bytes"`
-	MaxFsSize          uint64        `json:"max_fs_size_mb"`
-	PreForkPoolSize    uint64        `json:"pre_fork_pool_size"`
-	PreForkImage       string        `json:"pre_fork_image"`
-	PreForkCmd         string        `json:"pre_fork_pool_cmd"`
-	PreForkUseOnce     uint64        `json:"pre_fork_use_once"`
-	PreForkNetworks    string        `json:"pre_fork_networks"`
+	MinDockerVersion        string        `json:"min_docker_version"`
+	FreezeIdle              time.Duration `json:"freeze_idle_msecs"`
+	EjectIdle               time.Duration `json:"eject_idle_msecs"`
+	HotPoll                 time.Duration `json:"hot_poll_msecs"`
+	HotLauncherTimeout      time.Duration `json:"hot_launcher_timeout_msecs"`
+	AsyncChewPoll           time.Duration `json:"async_chew_poll_msecs"`
+	CallEndTimeout          time.Duration `json:"call_end_timeout"`
+	MaxCallEndStacking      uint64        `json:"max_call_end_stacking"`
+	MaxResponseSize         uint64        `json:"max_response_size_bytes"`
+	MaxLogSize              uint64        `json:"max_log_size_bytes"`
+	MaxTotalCPU             uint64        `json:"max_total_cpu_mcpus"`
+	MaxTotalMemory          uint64        `json:"max_total_memory_bytes"`
+	MaxFsSize               uint64        `json:"max_fs_size_mb"`
+	PreForkPoolSize         uint64        `json:"pre_fork_pool_size"`
+	PreForkImage            string        `json:"pre_fork_image"`
+	PreForkCmd              string        `json:"pre_fork_pool_cmd"`
+	PreForkUseOnce          uint64        `json:"pre_fork_use_once"`
+	PreForkNetworks         string        `json:"pre_fork_networks"`
+	EnableNBResourceTracker bool          `json:"enable_nb_resource_tracker"`
 }
 
 const (
-	EnvFreezeIdle         = "FN_FREEZE_IDLE_MSECS"
-	EnvEjectIdle          = "FN_EJECT_IDLE_MSECS"
-	EnvHotPoll            = "FN_HOT_POLL_MSECS"
-	EnvHotLauncherTimeout = "FN_HOT_LAUNCHER_TIMEOUT_MSECS"
-	EnvAsyncChewPoll      = "FN_ASYNC_CHEW_POLL_MSECS"
-	EnvCallEndTimeout     = "FN_CALL_END_TIMEOUT_MSECS"
-	EnvMaxCallEndStacking = "FN_MAX_CALL_END_STACKING"
-	EnvMaxResponseSize    = "FN_MAX_RESPONSE_SIZE"
-	EnvMaxLogSize         = "FN_MAX_LOG_SIZE_BYTES"
-	EnvMaxTotalCPU        = "FN_MAX_TOTAL_CPU_MCPUS"
-	EnvMaxTotalMemory     = "FN_MAX_TOTAL_MEMORY_BYTES"
-	EnvMaxFsSize          = "FN_MAX_FS_SIZE_MB"
-	EnvPreForkPoolSize    = "FN_EXPERIMENTAL_PREFORK_POOL_SIZE"
-	EnvPreForkImage       = "FN_EXPERIMENTAL_PREFORK_IMAGE"
-	EnvPreForkCmd         = "FN_EXPERIMENTAL_PREFORK_CMD"
-	EnvPreForkUseOnce     = "FN_EXPERIMENTAL_PREFORK_USE_ONCE"
-	EnvPreForkNetworks    = "FN_EXPERIMENTAL_PREFORK_NETWORKS"
+	EnvFreezeIdle              = "FN_FREEZE_IDLE_MSECS"
+	EnvEjectIdle               = "FN_EJECT_IDLE_MSECS"
+	EnvHotPoll                 = "FN_HOT_POLL_MSECS"
+	EnvHotLauncherTimeout      = "FN_HOT_LAUNCHER_TIMEOUT_MSECS"
+	EnvAsyncChewPoll           = "FN_ASYNC_CHEW_POLL_MSECS"
+	EnvCallEndTimeout          = "FN_CALL_END_TIMEOUT_MSECS"
+	EnvMaxCallEndStacking      = "FN_MAX_CALL_END_STACKING"
+	EnvMaxResponseSize         = "FN_MAX_RESPONSE_SIZE"
+	EnvMaxLogSize              = "FN_MAX_LOG_SIZE_BYTES"
+	EnvMaxTotalCPU             = "FN_MAX_TOTAL_CPU_MCPUS"
+	EnvMaxTotalMemory          = "FN_MAX_TOTAL_MEMORY_BYTES"
+	EnvMaxFsSize               = "FN_MAX_FS_SIZE_MB"
+	EnvPreForkPoolSize         = "FN_EXPERIMENTAL_PREFORK_POOL_SIZE"
+	EnvPreForkImage            = "FN_EXPERIMENTAL_PREFORK_IMAGE"
+	EnvPreForkCmd              = "FN_EXPERIMENTAL_PREFORK_CMD"
+	EnvPreForkUseOnce          = "FN_EXPERIMENTAL_PREFORK_USE_ONCE"
+	EnvPreForkNetworks         = "FN_EXPERIMENTAL_PREFORK_NETWORKS"
+	EnvEnableNBResourceTracker = "FN_ENABLE_NB_RESOURCE_TRACKER"
 
 	MaxDisabledMsecs = time.Duration(math.MaxInt64)
 )
@@ -83,6 +85,13 @@ func NewAgentConfig() (*AgentConfig, error) {
 
 	if err != nil {
 		return cfg, err
+	}
+
+	cfg.PreForkImage = os.Getenv(EnvPreForkImage)
+	cfg.PreForkCmd = os.Getenv(EnvPreForkCmd)
+
+	if _, ok := os.LookupEnv(EnvEnableNBResourceTracker); ok {
+		cfg.EnableNBResourceTracker = true
 	}
 
 	if cfg.EjectIdle == time.Duration(0) {

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -50,7 +50,7 @@ type slotQueue struct {
 	cond      *sync.Cond
 	slots     []*slotToken
 	nextId    uint64
-	signaller chan bool
+	signaller chan chan error
 	statsLock sync.Mutex // protects stats below
 	stats     slotQueueStats
 }
@@ -67,7 +67,7 @@ func NewSlotQueue(key string) *slotQueue {
 		key:       key,
 		cond:      sync.NewCond(new(sync.Mutex)),
 		slots:     make([]*slotToken, 0),
-		signaller: make(chan bool, 1),
+		signaller: make(chan chan error, 1),
 	}
 
 	return obj

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -166,13 +166,14 @@ func TestRouteRunnerFastFail(t *testing.T) {
 	rCfg := map[string]string{"ENABLE_HEADER": "yes", "ENABLE_FOOTER": "yes"} // enable container start/end header/footer
 	rImg := "fnproject/fn-test-utils"
 
+	app := &models.App{Name: "foo"}
+	app.SetDefaults()
+
 	ds := datastore.NewMockInit(
-		[]*models.App{
-			{Name: "foo", Config: models.Config{}},
-		},
+		[]*models.App{app},
 		[]*models.Route{
-			{Path: "/json", AppName: "foo", Image: rImg, Type: "sync", Format: "json", Memory: 80, Timeout: 30, IdleTimeout: 30, Config: rCfg},
-		}, nil,
+			{Path: "/json", AppID: app.ID, Image: rImg, Type: "sync", Format: "json", Memory: 80, Timeout: 30, IdleTimeout: 30, Config: rCfg},
+		},
 	)
 
 	rnr, cancelrnr := testRunner(t, ds)

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -172,7 +172,7 @@ func TestRouteRunnerFastFail(t *testing.T) {
 	ds := datastore.NewMockInit(
 		[]*models.App{app},
 		[]*models.Route{
-			{Path: "/json", AppID: app.ID, Image: rImg, Type: "sync", Format: "json", Memory: 80, Timeout: 30, IdleTimeout: 30, Config: rCfg},
+			{Path: "/json", AppID: app.ID, Image: rImg, Type: "sync", Format: "json", Memory: 70, Timeout: 30, IdleTimeout: 30, Config: rCfg},
 		},
 	)
 

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -150,8 +150,8 @@ func TestRouteRunnerFastFail(t *testing.T) {
 	buf := setLogBuffer()
 	isFailure := false
 
-	tweaker1 := envTweaker("FN_MAX_MEMORY", "134217728")           // 128MB
-	tweaker2 := envTweaker("FN_ENABLE_NB_RESOURCE_TRACKER", "yes") // enable fast-fail (no wait on CPU/Mem)
+	tweaker1 := envTweaker("FN_MAX_TOTAL_MEMORY_BYTES", "134217728") // 128MB
+	tweaker2 := envTweaker("FN_ENABLE_NB_RESOURCE_TRACKER", "yes")   // enable fast-fail (no wait on CPU/Mem)
 	defer tweaker1()
 	defer tweaker2()
 


### PR DESCRIPTION
For some types of errors, we might want to notify
the actual caller if the error is directly 1-1 tied
to that request. If hotLauncher is triggered with
signaller, then here we send a back communication
error notification channel. This is passed to
checkLaunch to send back synchronous responses
to the caller that initiated this hot container
launch.

This is useful if we want to run the agent in
quick fail mode, where instead of waiting for
CPU/Mem to become available, we prefer to fail
quick in order not to hold up the caller.
To support this, non-blocking resource tracker
option/functions are now available.

The solution is not perfect as signaller channels
may be lost and it might take additional signal attempts
for that call (each costs 200msec) to get this response.