### PR TITLE
Add a timeout to the net dialer

### DIFF
--- a/api/agent/nodepool/grpc/grpc_pool.go
+++ b/api/agent/nodepool/grpc/grpc_pool.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/fnproject/fn/api/agent"
@@ -263,7 +262,8 @@ func runnerConnection(address string, pki *pkiData) (*grpc.ClientConn, pb.Runner
 		}
 	}
 
-	conn, err := grpcutil.DialWithBackoff(ctx, address, creds, grpc.DefaultBackoffConfig)
+	// we want to set a very short timeout to fail-fast if something goes wrong
+	conn, err := grpcutil.DialWithBackoff(ctx, address, creds, 100*time.Millisecond, grpc.DefaultBackoffConfig)
 	if err != nil {
 		logrus.WithError(err).Error("Unable to connect to runner node")
 	}
@@ -282,15 +282,6 @@ func (r *gRPCRunner) TryExec(ctx context.Context, call agent.Call) (bool, error)
 	logrus.WithField("runner_addr", r.address).Debug("Attempting to place call")
 	r.wg.Add(1)
 	defer r.wg.Done()
-	// If the connection is not READY, we want to fail-fast.
-	// There are some cases where the connection stays in CONNECTING, for example if the
-	// runner dies not gracefully (e.g. unplug the cable), the connection get stuck until
-	// the context times out.
-	// https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
-	if r.conn.GetState() != connectivity.Ready {
-		logrus.WithField("runner_address", r.address).Debug("Runner connection is not ready")
-		return false, nil
-	}
 
 	// Get app and route information
 	// Construct model.Call with CONFIG in it already

--- a/grpcutil/dial.go
+++ b/grpcutil/dial.go
@@ -17,17 +17,17 @@ import (
 )
 
 // DialWithBackoff creates a grpc connection using backoff strategy for reconnections
-func DialWithBackoff(ctx context.Context, address string, creds credentials.TransportCredentials, backoffCfg grpc.BackoffConfig) (*grpc.ClientConn, error) {
-	return dial(ctx, address, creds, grpc.WithBackoffConfig(backoffCfg))
+func DialWithBackoff(ctx context.Context, address string, creds credentials.TransportCredentials, timeout time.Duration, backoffCfg grpc.BackoffConfig) (*grpc.ClientConn, error) {
+	return dial(ctx, address, creds, timeout, grpc.WithBackoffConfig(backoffCfg))
 }
 
 // uses grpc connection backoff protocol https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
-func dial(ctx context.Context, address string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func dial(ctx context.Context, address string, creds credentials.TransportCredentials, timeoutDialer time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 
 	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		conn, err := (&net.Dialer{Cancel: ctx.Done()}).Dial("tcp", address)
+		conn, err := (&net.Dialer{Cancel: ctx.Done(), Timeout: timeoutDialer}).Dial("tcp", address)
 		if err != nil {
 			logrus.WithField("grpc_addr", address).Warn("Failed to dial grpc connection")
 			return nil, err

--- a/poolmanager/client.go
+++ b/poolmanager/client.go
@@ -2,6 +2,7 @@ package poolmanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/fnproject/fn/grpcutil"
 	model "github.com/fnproject/fn/poolmanager/grpc"
@@ -30,7 +31,7 @@ func newRemoteClient(serverAddr string, cert string, key string, ca string) (rem
 		return nil, err
 	}
 
-	conn, err := grpcutil.DialWithBackoff(ctx, serverAddr, creds, grpc.DefaultBackoffConfig)
+	conn, err := grpcutil.DialWithBackoff(ctx, serverAddr, creds, 300*time.Millisecond, grpc.DefaultBackoffConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change add the option to set a timeout for the dialer used in
making gRPC connection, with that we remove the check on the state of
the connections and therefore remove any potential race conditions.