### PR TITLE
Adds extension points for runner pools in load-balanced mode (Patch 1/2)

### DIFF
--- a/api/models/runner_pool.go
+++ b/api/models/runner_pool.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+)
+
+// RunnerPool is the abstraction for getting an ordered list of runners to try for a call
+type RunnerPool interface {
+	Runners(call RunnerCall) []Runner
+	Shutdown()
+}
+
+// Runner is the interface to invoke the execution of a function call on a specific runner
+type Runner interface {
+	TryExec(ctx context.Context, call RunnerCall) (bool, error)
+	Close()
+	Address() string
+}
+
+// RunnerCall provides access to the necessary details of request in order for it to be
+// processed by a RunnerPool
+type RunnerCall interface {
+	SlotDeadline() time.Time
+	Request() *http.Request
+	ResponseWriter() io.Writer
+	StdErr() io.ReadWriteCloser
+	Model() *Call
+}

--- a/api/models/runner_pool.go
+++ b/api/models/runner_pool.go
@@ -9,14 +9,14 @@ import (
 
 // RunnerPool is the abstraction for getting an ordered list of runners to try for a call
 type RunnerPool interface {
-	Runners(call RunnerCall) []Runner
-	Shutdown()
+	Runners(call RunnerCall) ([]Runner, error)
+	Shutdown() error
 }
 
 // Runner is the interface to invoke the execution of a function call on a specific runner
 type Runner interface {
 	TryExec(ctx context.Context, call RunnerCall) (bool, error)
-	Close()
+	Close() error
 	Address() string
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -107,6 +107,7 @@ type Server struct {
 	rootMiddlewares []fnext.Middleware
 	apiMiddlewares  []fnext.Middleware
 	promExporter    *prometheus.Exporter
+	runnerPool      models.RunnerPool
 }
 
 func nodeTypeFromString(value string) ServerNodeType {
@@ -732,6 +733,12 @@ func (s *Server) bindHandlers(ctx context.Context) {
 // implements fnext.ExtServer
 func (s *Server) Datastore() models.Datastore {
 	return s.datastore
+}
+
+// WithRunnerPool provides an extension point for overriding
+// the default runner pool implementation when running in load-balanced mode
+func (s *Server) WithRunnerPool(runnerPool models.RunnerPool) {
+	s.runnerPool = runnerPool
 }
 
 // returns the unescaped ?cursor and ?perPage values

--- a/fnext/setup.go
+++ b/fnext/setup.go
@@ -38,6 +38,9 @@ type ExtServer interface {
 	// AddRouteEndpoint adds an endpoints to /v1/apps/:app/routes/:route/x
 	AddRouteEndpointFunc(method, path string, handler func(w http.ResponseWriter, r *http.Request, app *models.App, route *models.Route))
 
+	// WithRunnerPool overrides the default runner pool implementation when running in load-balanced mode
+	WithRunnerPool(runnerPool models.RunnerPool)
+
 	// Datastore returns the Datastore Fn is using
 	Datastore() models.Datastore
 }


### PR DESCRIPTION
This PR provides a common extension point and abstractions for running fn in load-balanced mode. A runner pool encapsulates a group of runners that are available to service a particular fn call. A runner implements a simple calling contract that allows the routing/lb layer to retry requests on other runners in case it is not available.

Note: This is the first of a series of independent patches for extracting node pool manager as a custom extension.