### PR TITLE
fn: add storage opt size support

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -19,6 +19,7 @@ type AgentConfig struct {
 	MaxLogSize         uint64        `json:"max_log_size_bytes"`
 	MaxTotalCPU        uint64        `json:"max_total_cpu_mcpus"`
 	MaxTotalMemory     uint64        `json:"max_total_memory_bytes"`
+	MaxFsSize          uint64        `json:"max_fs_size_mb"`
 }
 
 const (
@@ -31,6 +32,7 @@ const (
 	EnvMaxLogSize         = "FN_MAX_LOG_SIZE_BYTES"
 	EnvMaxTotalCPU        = "FN_MAX_TOTAL_CPU_MCPUS"
 	EnvMaxTotalMemory     = "FN_MAX_TOTAL_MEMORY_BYTES"
+	EnvMaxFsSize          = "FN_MAX_FS_SIZE_MB"
 
 	MaxDisabledMsecs = time.Duration(math.MaxInt64)
 )
@@ -53,6 +55,7 @@ func NewAgentConfig() (*AgentConfig, error) {
 	err = setEnvUint(err, EnvMaxLogSize, &cfg.MaxLogSize)
 	err = setEnvUint(err, EnvMaxTotalCPU, &cfg.MaxTotalCPU)
 	err = setEnvUint(err, EnvMaxTotalMemory, &cfg.MaxTotalMemory)
+	err = setEnvUint(err, EnvMaxFsSize, &cfg.MaxFsSize)
 
 	if err != nil {
 		return cfg, err

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -168,6 +168,13 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 		container.HostConfig.CPUPeriod = 100000
 	}
 
+	// If defined, impose file system size limit. In MB units.
+	if task.FsSize() != 0 {
+		container.HostConfig.StorageOpt = make(map[string]string)
+		sizeOption := fmt.Sprintf("%vM", task.FsSize())
+		container.HostConfig.StorageOpt["size"] = sizeOption
+	}
+
 	volumes := task.Volumes()
 	for _, mapping := range volumes {
 		hostDir := mapping[0]

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -33,6 +33,7 @@ func (f *taskDockerTest) WriteStat(context.Context, drivers.Stat) { /* TODO */ }
 func (f *taskDockerTest) Volumes() [][2]string                    { return [][2]string{} }
 func (f *taskDockerTest) Memory() uint64                          { return 256 * 1024 * 1024 }
 func (f *taskDockerTest) CPUs() uint64                            { return 0 }
+func (f *taskDockerTest) FsSize() uint64                          { return 0 }
 func (f *taskDockerTest) WorkDir() string                         { return "" }
 func (f *taskDockerTest) Close()                                  {}
 func (f *taskDockerTest) Input() io.Reader                        { return f.input }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -113,6 +113,9 @@ type ContainerTask interface {
 	// CPUs in milli CPU units
 	CPUs() uint64
 
+	// Filesystem size limit for the container, in megabytes.
+	FsSize() uint64
+
 	// WorkDir returns the working directory to use for the task. Empty string
 	// leaves it unset.
 	WorkDir() string


### PR DESCRIPTION
Added env FN_MAX_FS_SIZE_MB, which if defined and non-zero
is passed to docker as storage opt size. We do not validate
if this option is supported by docker currently. This is
because it's difficult to actually validate this since it
not only depends on storage driver and its backing filesystem,
but also the mount options used to mount that fs.