### PR TITLE
fn: initial "network" option to routes

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -92,8 +92,9 @@ func FromRequest(appName, path string, req *http.Request) CallOpt {
 			Path:    route.Path,
 			Image:   route.Image,
 			// Delay: 0,
-			Type:   route.Type,
-			Format: route.Format,
+			Type:    route.Type,
+			Network: route.Network,
+			Format:  route.Format,
 			// Payload: TODO,
 			Priority:    new(int32), // TODO this is crucial, apparently
 			Timeout:     route.Timeout,
@@ -127,6 +128,7 @@ func buildConfig(app *models.App, route *models.Route) models.Config {
 	// TODO: might be a good idea to pass in: "FN_BASE_PATH" = fmt.Sprintf("/r/%s", appName) || "/" if using DNS entries per app
 	conf["FN_MEMORY"] = fmt.Sprintf("%d", route.Memory)
 	conf["FN_TYPE"] = route.Type
+	conf["FN_NETWORK"] = route.Network
 
 	CPUs := route.CPUs.String()
 	if CPUs != "" {

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -159,6 +159,10 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 		Context: ctx,
 	}
 
+	if !task.IsNetEnabled() {
+		container.Config.NetworkDisabled = true
+	}
+
 	// Translate milli cpus into CPUQuota & CPUPeriod (see Linux cGroups CFS cgroup v1 documentation)
 	// eg: task.CPUQuota() of 8000 means CPUQuota of 8 * 100000 usecs in 100000 usec period,
 	// which is approx 8 CPUS in CFS world.

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -37,6 +37,7 @@ func (f *taskDockerTest) FsSize() uint64                          { return 0 }
 func (f *taskDockerTest) WorkDir() string                         { return "" }
 func (f *taskDockerTest) Close()                                  {}
 func (f *taskDockerTest) Input() io.Reader                        { return f.input }
+func (f *taskDockerTest) IsNetEnabled() bool                      { return true }
 
 func TestRunnerDocker(t *testing.T) {
 	dkr := NewDocker(drivers.Config{})

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -116,6 +116,9 @@ type ContainerTask interface {
 	// Filesystem size limit for the container, in megabytes.
 	FsSize() uint64
 
+	// Is Network enabled?
+	IsNetEnabled() bool
+
 	// WorkDir returns the working directory to use for the task. Empty string
 	// leaves it unset.
 	WorkDir() string

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -292,6 +292,8 @@ func getSlotQueueKey(call *call) string {
 	hash.Write(unsafeBytes("\x00"))
 	hash.Write(unsafeBytes(call.Format))
 	hash.Write(unsafeBytes("\x00"))
+	hash.Write(unsafeBytes(call.Network))
+	hash.Write(unsafeBytes("\x00"))
 
 	// these are all static in size we only need to delimit the whole block of them
 	var byt [8]byte

--- a/api/datastore/sql/migrations/8_add_network.go
+++ b/api/datastore/sql/migrations/8_add_network.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up8(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE routes ADD network varchar(16);")
+	return err
+}
+
+func down8(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE routes DROP COLUMN network;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(8),
+		UpFunc:      up8,
+		DownFunc:    down8,
+	})
+}

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -48,6 +48,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	timeout int NOT NULL,
 	idle_timeout int NOT NULL,
 	type varchar(16) NOT NULL,
+	network varchar(16),
 	headers text NOT NULL,
 	config text NOT NULL,
 	created_at text,
@@ -83,7 +84,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 }
 
 const (
-	routeSelector = `SELECT app_name, path, image, format, memory, cpus, type, timeout, idle_timeout, headers, config, created_at, updated_at FROM routes`
+	routeSelector = `SELECT app_name, path, image, format, memory, cpus, type, network, timeout, idle_timeout, headers, config, created_at, updated_at FROM routes`
 	callSelector  = `SELECT id, created_at, started_at, completed_at, status, app_name, path, stats, error FROM calls`
 )
 
@@ -430,6 +431,7 @@ func (ds *sqlStore) InsertRoute(ctx context.Context, route *models.Route) (*mode
 			memory,
 			cpus,
 			type,
+			network,
 			timeout,
 			idle_timeout,
 			headers,
@@ -445,6 +447,7 @@ func (ds *sqlStore) InsertRoute(ctx context.Context, route *models.Route) (*mode
 			:memory,
 			:cpus,
 			:type,
+			:network,
 			:timeout,
 			:idle_timeout,
 			:headers,
@@ -486,6 +489,7 @@ func (ds *sqlStore) UpdateRoute(ctx context.Context, newroute *models.Route) (*m
 			memory = :memory,
 			cpus = :cpus,
 			type = :type,
+			network = :network,
 			timeout = :timeout,
 			idle_timeout = :idle_timeout,
 			headers = :headers,

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -25,6 +25,15 @@ const (
 	FormatJSON = "json"
 )
 
+const (
+	// NetworkNone ...
+	NetworkNone = ""
+	// NetworkDefault ...
+	NetworkDefault = "default"
+	// NetworkDisabled ...
+	NetworkDisabled = "disabled"
+)
+
 var possibleStatuses = [...]string{"delayed", "queued", "running", "success", "error", "cancelled"}
 
 type CallLog struct {
@@ -94,6 +103,9 @@ type Call struct {
 
 	// Format is the format to pass input into the function.
 	Format string `json:"format,omitempty" db:"-"`
+
+	// Network is the networking model used in the function.
+	Network string `json:"network,omitempty" db:"-"`
 
 	// Payload for the call. This is only used by async calls, to store their input.
 	// TODO should we copy it into here too for debugging sync?

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -26,10 +26,8 @@ const (
 )
 
 const (
-	// NetworkNone ...
-	NetworkNone = ""
 	// NetworkDefault ...
-	NetworkDefault = "default"
+	NetworkDefault = ""
 	// NetworkDisabled ...
 	NetworkDisabled = "disabled"
 )

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -112,6 +112,10 @@ var (
 		code:  http.StatusBadRequest,
 		error: errors.New("Invalid route Format"),
 	}
+	ErrRoutesInvalidNetwork = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Invalid route Network"),
+	}
 	ErrRoutesMissingAppName = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Missing route AppName"),

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -33,6 +33,7 @@ type Route struct {
 	Headers     Headers         `json:"headers,omitempty" db:"headers"`
 	Type        string          `json:"type" db:"type"`
 	Format      string          `json:"format" db:"format"`
+	Network     string          `json:"network,omitempty" db:"network"`
 	Timeout     int32           `json:"timeout" db:"timeout"`
 	IdleTimeout int32           `json:"idle_timeout" db:"idle_timeout"`
 	Config      Config          `json:"config,omitempty" db:"config"`
@@ -52,6 +53,10 @@ func (r *Route) SetDefaults() {
 
 	if r.Format == "" {
 		r.Format = FormatDefault
+	}
+
+	if r.Network == NetworkNone {
+		r.Network = NetworkDefault
 	}
 
 	if r.Headers == nil {
@@ -115,6 +120,10 @@ func (r *Route) Validate() error {
 		return ErrRoutesInvalidFormat
 	}
 
+	if r.Network != NetworkNone && r.Network != NetworkDefault && r.Network != NetworkDisabled {
+		return ErrRoutesInvalidNetwork
+	}
+
 	if r.Timeout <= 0 ||
 		(r.Type == TypeSync && r.Timeout > MaxSyncTimeout) ||
 		(r.Type == TypeAsync && r.Timeout > MaxAsyncTimeout) {
@@ -166,6 +175,7 @@ func (r1 *Route) Equals(r2 *Route) bool {
 	eq = eq && r1.Headers.Equals(r2.Headers)
 	eq = eq && r1.Type == r2.Type
 	eq = eq && r1.Format == r2.Format
+	eq = eq && r1.Network == r2.Network
 	eq = eq && r1.Timeout == r2.Timeout
 	eq = eq && r1.IdleTimeout == r2.IdleTimeout
 	eq = eq && r1.Config.Equals(r2.Config)
@@ -202,6 +212,9 @@ func (r *Route) Update(new *Route) {
 	}
 	if new.Format != "" {
 		r.Format = new.Format
+	}
+	if new.Network != "" {
+		r.Network = new.Network
 	}
 	if new.Headers != nil {
 		if r.Headers == nil {

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -55,7 +55,7 @@ func (r *Route) SetDefaults() {
 		r.Format = FormatDefault
 	}
 
-	if r.Network == NetworkNone {
+	if r.Network == "" {
 		r.Network = NetworkDefault
 	}
 
@@ -120,7 +120,7 @@ func (r *Route) Validate() error {
 		return ErrRoutesInvalidFormat
 	}
 
-	if r.Network != NetworkNone && r.Network != NetworkDefault && r.Network != NetworkDisabled {
+	if r.Network != NetworkDefault && r.Network != NetworkDisabled {
 		return ErrRoutesInvalidNetwork
 	}
 

--- a/api/models/route_test.go
+++ b/api/models/route_test.go
@@ -14,6 +14,7 @@ func TestRouteSimple(t *testing.T) {
 		CPUs:        100,
 		Type:        "sync",
 		Format:      "http",
+		Network:     "",
 		Timeout:     10,
 		IdleTimeout: 10,
 	}
@@ -38,5 +39,23 @@ func TestRouteSimple(t *testing.T) {
 	err = route2.Validate()
 	if err == nil {
 		t.Fatalf("should have failed route: %#v", route2)
+	}
+
+	route3 := &Route{
+		AppName:     "test",
+		Path:        "/some",
+		Image:       "foo",
+		Memory:      128,
+		CPUs:        100,
+		Type:        "sync",
+		Format:      "json",
+		Network:     "disabled",
+		Timeout:     10,
+		IdleTimeout: 10,
+	}
+
+	err = route3.Validate()
+	if err != nil {
+		t.Fatal("should not have failed, got: ", err)
 	}
 }

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -149,6 +149,11 @@ To define the function execution as `hot function` you set it as one of the foll
 
 - `"http"`
 
+#### network (string)
+
+`network` defines container networking options. Supported options are `default` and `disabled`. Use `disabled` 
+to launch containers without networking.
+
 ### 'Hot function' Only Properties
 
 This properties are only used if the function is in `hot function` mode

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -151,7 +151,7 @@ To define the function execution as `hot function` you set it as one of the foll
 
 #### network (string)
 
-`network` defines container networking options. Supported options are `default` and `disabled`. Use `disabled` 
+`network` defines container networking options. Only supported option is `disabled`. Use `disabled` 
 to launch containers without networking.
 
 ### 'Hot function' Only Properties

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -504,6 +504,12 @@ definitions:
           - json
         description: Payload format sent into function.
         type: string
+      network:
+        enum:
+          - default
+          - disabled
+        description: Container network options.
+        type: string
       config:
         type: object
         description: Route configuration - overrides application configuration

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -505,9 +505,6 @@ definitions:
         description: Payload format sent into function.
         type: string
       network:
-        enum:
-          - default
-          - disabled
         description: Container network options.
         type: string
       config:


### PR DESCRIPTION
Basic "network" option introduction to routes. Initially,
this can be set to "default" or "disabled" to disable container
networking.

In preparation for more advanced future network options.