### PR TITLE
Expose route and app models to RunnerCall for extensions to use it

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -106,6 +106,8 @@ func FromRequest(appName, path string, req *http.Request) CallOpt {
 			URL:         reqURL(req),
 			Method:      req.Method,
 		}
+		c.app = app
+		c.route = route
 
 		c.req = req
 		return nil
@@ -260,6 +262,9 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 type call struct {
 	*models.Call
 
+	app   *models.App
+	route *models.Route
+
 	da             DataAccess
 	w              io.Writer
 	req            *http.Request
@@ -291,6 +296,10 @@ func (c *call) StdErr() io.ReadWriteCloser {
 }
 
 func (c *call) Model() *models.Call { return c.Call }
+
+func (c *call) App() *models.App { return c.app }
+
+func (c *call) Route() *models.Route { return c.route }
 
 func (c *call) Start(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "agent_call_start")

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -122,6 +122,8 @@ type mockRunnerCall struct {
 	rw           http.ResponseWriter
 	stdErr       io.ReadWriteCloser
 	model        *models.Call
+	app          *models.App
+	route        *models.Route
 }
 
 func (c *mockRunnerCall) SlotDeadline() time.Time {
@@ -139,6 +141,12 @@ func (c *mockRunnerCall) StdErr() io.ReadWriteCloser {
 }
 func (c *mockRunnerCall) Model() *models.Call {
 	return c.model
+}
+func (c *mockRunnerCall) App() *models.App {
+	return c.app
+}
+func (c *mockRunnerCall) Route() *models.Route {
+	return c.route
 }
 
 func setupMockRunnerPool(expectedRunners []string, execSleep time.Duration, maxCalls int32) *mockRunnerPool {

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -45,4 +45,6 @@ type RunnerCall interface {
 	ResponseWriter() http.ResponseWriter
 	StdErr() io.ReadWriteCloser
 	Model() *models.Call
+	App() *models.App
+	Route() *models.Route
 }


### PR DESCRIPTION
This is an alternative to #878 

The internal `agent.call` is not persisted to the db, so we should be able to add route and app models to it without any significant cost. Therefore this just extends the current abstraction rather than using a different way to pass data.