### PR TITLE
Expose route and app models to RunnerCall for extensions (alternative 2)

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -101,6 +101,7 @@ func FromRequest(appName, path string, req *http.Request) CallOpt {
 			Memory:      route.Memory,
 			CPUs:        route.CPUs,
 			Config:      buildConfig(app, route),
+			Annotations: buildAnnotations(app, route),
 			Headers:     req.Header,
 			CreatedAt:   strfmt.DateTime(time.Now()),
 			URL:         reqURL(req),
@@ -133,6 +134,17 @@ func buildConfig(app *models.App, route *models.Route) models.Config {
 		conf["FN_CPUS"] = CPUs
 	}
 	return conf
+}
+
+func buildAnnotations(app *models.App, route *models.Route) models.Annotations {
+	ann := make(models.Annotations)
+	for k, v := range app.Annotations {
+		ann[k] = v
+	}
+	for k, v := range route.Annotations {
+		ann[k] = v
+	}
+	return ann
 }
 
 func reqURL(req *http.Request) string {

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -126,6 +126,9 @@ type Call struct {
 	// Config is the set of configuration variables for the call
 	Config Config `json:"config,omitempty" db:"-"`
 
+	// Annotations is the set of annotations for the app/route of the call.
+	Annotations Annotations `json:"annotations,omitempty" db:"-"`
+
 	// Headers are headers from the request that created this call
 	Headers http.Header `json:"headers,omitempty" db:"-"`
 


### PR DESCRIPTION
Another alternative to #878 (and #879)

This allows us to merge the Annotations from app and route (which are the useful information which is missing in Call) into the models.Call. The field is ephemeral like Config so it should not be persisted and should not cause issues.