### PR TITLE
Create an Annotation map of the right size to avoid resizing

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -137,7 +137,7 @@ func buildConfig(app *models.App, route *models.Route) models.Config {
 }
 
 func buildAnnotations(app *models.App, route *models.Route) models.Annotations {
-	ann := make(models.Annotations)
+	ann := make(models.Annotations, len(app.Annotations)+len(route.Annotations))
 	for k, v := range app.Annotations {
 		ann[k] = v
 	}


### PR DESCRIPTION
Incorporates @treeder's optimization from #880 