### PR TITLE
Provide GetApp and GetRoute in agent.DataAccess with original http.Request for multitenancy

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -51,12 +51,12 @@ type Params []Param
 
 func FromRequest(appName, path string, req *http.Request) CallOpt {
 	return func(a *agent, c *call) error {
-		app, err := a.da.GetApp(req.Context(), appName)
+		app, err := a.da.GetApp(req, appName)
 		if err != nil {
 			return err
 		}
 
-		route, err := a.da.GetRoute(req.Context(), appName, path)
+		route, err := a.da.GetRoute(req, appName, path)
 		if err != nil {
 			return err
 		}

--- a/api/agent/data_access.go
+++ b/api/agent/data_access.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/fnproject/fn/api/common"
@@ -17,10 +18,10 @@ import (
 // mediation through an API node).
 type DataAccess interface {
 	// GetApp abstracts querying the datastore for an app.
-	GetApp(ctx context.Context, appName string) (*models.App, error)
+	GetApp(req *http.Request, appName string) (*models.App, error)
 
 	// GetRoute abstracts querying the datastore for a route within an app.
-	GetRoute(ctx context.Context, appName string, routePath string) (*models.Route, error)
+	GetRoute(req *http.Request, appName string, routePath string) (*models.Route, error)
 
 	// Enqueue will add a Call to the queue (ultimately forwards to mq.Push).
 	Enqueue(ctx context.Context, mCall *models.Call) error
@@ -62,7 +63,7 @@ func appCacheKey(appname string) string {
 	return "a:" + appname
 }
 
-func (da *CachedDataAccess) GetApp(ctx context.Context, appName string) (*models.App, error) {
+func (da *CachedDataAccess) GetApp(req *http.Request, appName string) (*models.App, error) {
 	key := appCacheKey(appName)
 	app, ok := da.cache.Get(key)
 	if ok {
@@ -71,7 +72,7 @@ func (da *CachedDataAccess) GetApp(ctx context.Context, appName string) (*models
 
 	resp, err := da.singleflight.Do(key,
 		func() (interface{}, error) {
-			return da.DataAccess.GetApp(ctx, appName)
+			return da.DataAccess.GetApp(req, appName)
 		})
 
 	if err != nil {
@@ -82,7 +83,7 @@ func (da *CachedDataAccess) GetApp(ctx context.Context, appName string) (*models
 	return app.(*models.App), nil
 }
 
-func (da *CachedDataAccess) GetRoute(ctx context.Context, appName string, routePath string) (*models.Route, error) {
+func (da *CachedDataAccess) GetRoute(req *http.Request, appName string, routePath string) (*models.Route, error) {
 	key := routeCacheKey(appName, routePath)
 	r, ok := da.cache.Get(key)
 	if ok {
@@ -91,7 +92,7 @@ func (da *CachedDataAccess) GetRoute(ctx context.Context, appName string, routeP
 
 	resp, err := da.singleflight.Do(key,
 		func() (interface{}, error) {
-			return da.DataAccess.GetRoute(ctx, appName, routePath)
+			return da.DataAccess.GetRoute(req, appName, routePath)
 		})
 
 	if err != nil {
@@ -117,12 +118,12 @@ func NewDirectDataAccess(ds models.Datastore, ls models.LogStore, mq models.Mess
 	return da
 }
 
-func (da *directDataAccess) GetApp(ctx context.Context, appName string) (*models.App, error) {
-	return da.ds.GetApp(ctx, appName)
+func (da *directDataAccess) GetApp(req *http.Request, appName string) (*models.App, error) {
+	return da.ds.GetApp(req.Context(), appName)
 }
 
-func (da *directDataAccess) GetRoute(ctx context.Context, appName string, routePath string) (*models.Route, error) {
-	return da.ds.GetRoute(ctx, appName, routePath)
+func (da *directDataAccess) GetRoute(req *http.Request, appName string, routePath string) (*models.Route, error) {
+	return da.ds.GetRoute(req.Context(), appName, routePath)
 }
 
 func (da *directDataAccess) Enqueue(ctx context.Context, mCall *models.Call) error {

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -118,8 +118,8 @@ func (cl *client) Finish(ctx context.Context, c *models.Call, r io.Reader, async
 	return err
 }
 
-func (cl *client) GetApp(ctx context.Context, appName string) (*models.App, error) {
-	ctx, span := trace.StartSpan(ctx, "hybrid_client_get_app")
+func (cl *client) GetApp(req *http.Request, appName string) (*models.App, error) {
+	ctx, span := trace.StartSpan(req.Context(), "hybrid_client_get_app")
 	defer span.End()
 
 	var a struct {
@@ -129,8 +129,8 @@ func (cl *client) GetApp(ctx context.Context, appName string) (*models.App, erro
 	return &a.A, err
 }
 
-func (cl *client) GetRoute(ctx context.Context, appName, route string) (*models.Route, error) {
-	ctx, span := trace.StartSpan(ctx, "hybrid_client_get_route")
+func (cl *client) GetRoute(req *http.Request, appName, route string) (*models.Route, error) {
+	ctx, span := trace.StartSpan(req.Context(), "hybrid_client_get_route")
 	defer span.End()
 
 	// TODO trim prefix is pretty odd here eh?

--- a/api/agent/hybrid/nop.go
+++ b/api/agent/hybrid/nop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/models"
@@ -41,14 +42,14 @@ func (cl *nopDataStore) Finish(ctx context.Context, c *models.Call, r io.Reader,
 	return nil // It's ok to call this method, and it does no operations
 }
 
-func (cl *nopDataStore) GetApp(ctx context.Context, appName string) (*models.App, error) {
-	ctx, span := trace.StartSpan(ctx, "nop_datastore_get_app")
+func (cl *nopDataStore) GetApp(req *http.Request, appName string) (*models.App, error) {
+	_, span := trace.StartSpan(req.Context(), "nop_datastore_get_app")
 	defer span.End()
 	return nil, errors.New("Should not call GetApp on a NOP data store")
 }
 
-func (cl *nopDataStore) GetRoute(ctx context.Context, appName, route string) (*models.Route, error) {
-	ctx, span := trace.StartSpan(ctx, "nop_datastore_get_route")
+func (cl *nopDataStore) GetRoute(req *http.Request, appName, route string) (*models.Route, error) {
+	_, span := trace.StartSpan(req.Context(), "nop_datastore_get_route")
 	defer span.End()
 	return nil, errors.New("Should not call GetRoute on a NOP data store")
 }


### PR DESCRIPTION
This PR modifies the `agent.DataAccess` interface to provide full access to original `http.Request` when resolving apps and routes:
```
GetApp(ctx context.Context, appName string) (*models.App, error)
GetRoute(ctx context.Context, appName string, routePath string) (*models.Route, error)
```

This change is required in multi-tenant scenarios where it is not sufficient to know the app and route names to resolve the respective models. By providing access to the underlying `http.Request`, apps/routes can be disambiguated based on the contents of the HTTP request, including HTTP headers, Host or URL path.