### PR TITLE
dep: lock opencensus to commit

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -509,7 +509,6 @@
   version = "v1.1"
 
 [[projects]]
-  branch = "master"
   name = "go.opencensus.io"
   packages = [
     "exporter/jaeger",
@@ -659,6 +658,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "476e0b453b4947a75639db11c7a092d3157be8e665eb7a7a2633422f737f5369"
+  inputs-digest = "1da8f3b4885673e5d2b431cf72e0a089da506c4ec6da226d6faaa25aeeff958c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,4 +72,4 @@ ignored = ["github.com/fnproject/fn/cli"]
 
 [[constraint]]
   name = "go.opencensus.io"
-  branch = "master"
+  revision = "f1af72ab88d638dcc20ea6ecf83c98b59b092559"


### PR DESCRIPTION
0.4.0 is too low, no prometheus registry specification.
0.6.0 jaeger is broken. filing ticket w/ them.

closes #886