### PR TITLE
Experimental Pre-fork Pool: Recycle net ns

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -142,6 +142,7 @@ func createAgent(da DataAccess, withDocker bool) Agent {
 			PreForkImage:    cfg.PreForkImage,
 			PreForkCmd:      cfg.PreForkCmd,
 			PreForkUseOnce:  cfg.PreForkUseOnce,
+			PreForkNetworks: cfg.PreForkNetworks,
 		})
 	} else {
 		driver = mock.New()

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -141,6 +141,7 @@ func createAgent(da DataAccess, withDocker bool) Agent {
 			PreForkPoolSize: cfg.PreForkPoolSize,
 			PreForkImage:    cfg.PreForkImage,
 			PreForkCmd:      cfg.PreForkCmd,
+			PreForkUseOnce:  cfg.PreForkUseOnce,
 		})
 	} else {
 		driver = mock.New()

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -26,6 +26,7 @@ type AgentConfig struct {
 	PreForkImage       string        `json:"pre_fork_image"`
 	PreForkCmd         string        `json:"pre_fork_pool_cmd"`
 	PreForkUseOnce     uint64        `json:"pre_fork_use_once"`
+	PreForkNetworks    string        `json:"pre_fork_networks"`
 }
 
 const (
@@ -45,6 +46,7 @@ const (
 	EnvPreForkImage       = "FN_EXPERIMENTAL_PREFORK_IMAGE"
 	EnvPreForkCmd         = "FN_EXPERIMENTAL_PREFORK_CMD"
 	EnvPreForkUseOnce     = "FN_EXPERIMENTAL_PREFORK_USE_ONCE"
+	EnvPreForkNetworks    = "FN_EXPERIMENTAL_PREFORK_NETWORKS"
 
 	MaxDisabledMsecs = time.Duration(math.MaxInt64)
 )
@@ -77,6 +79,7 @@ func NewAgentConfig() (*AgentConfig, error) {
 	err = setEnvStr(err, EnvPreForkImage, &cfg.PreForkImage)
 	err = setEnvStr(err, EnvPreForkCmd, &cfg.PreForkCmd)
 	err = setEnvUint(err, EnvPreForkUseOnce, &cfg.PreForkUseOnce)
+	err = setEnvStr(err, EnvPreForkNetworks, &cfg.PreForkNetworks)
 
 	if err != nil {
 		return cfg, err

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -25,6 +25,7 @@ type AgentConfig struct {
 	PreForkPoolSize    uint64        `json:"pre_fork_pool_size"`
 	PreForkImage       string        `json:"pre_fork_image"`
 	PreForkCmd         string        `json:"pre_fork_pool_cmd"`
+	PreForkUseOnce     uint64        `json:"pre_fork_use_once"`
 }
 
 const (
@@ -43,6 +44,7 @@ const (
 	EnvPreForkPoolSize    = "FN_EXPERIMENTAL_PREFORK_POOL_SIZE"
 	EnvPreForkImage       = "FN_EXPERIMENTAL_PREFORK_IMAGE"
 	EnvPreForkCmd         = "FN_EXPERIMENTAL_PREFORK_CMD"
+	EnvPreForkUseOnce     = "FN_EXPERIMENTAL_PREFORK_USE_ONCE"
 
 	MaxDisabledMsecs = time.Duration(math.MaxInt64)
 )
@@ -53,6 +55,8 @@ func NewAgentConfig() (*AgentConfig, error) {
 		MinDockerVersion:   "17.10.0-ce",
 		MaxLogSize:         1 * 1024 * 1024,
 		MaxCallEndStacking: 8192,
+		PreForkImage:       "busybox",
+		PreForkCmd:         "tail -f /dev/null",
 	}
 
 	var err error
@@ -70,13 +74,13 @@ func NewAgentConfig() (*AgentConfig, error) {
 	err = setEnvUint(err, EnvMaxFsSize, &cfg.MaxFsSize)
 	err = setEnvUint(err, EnvPreForkPoolSize, &cfg.PreForkPoolSize)
 	err = setEnvUint(err, EnvMaxCallEndStacking, &cfg.MaxCallEndStacking)
+	err = setEnvStr(err, EnvPreForkImage, &cfg.PreForkImage)
+	err = setEnvStr(err, EnvPreForkCmd, &cfg.PreForkCmd)
+	err = setEnvUint(err, EnvPreForkUseOnce, &cfg.PreForkUseOnce)
 
 	if err != nil {
 		return cfg, err
 	}
-
-	cfg.PreForkImage = os.Getenv(EnvPreForkImage)
-	cfg.PreForkCmd = os.Getenv(EnvPreForkCmd)
 
 	if cfg.EjectIdle == time.Duration(0) {
 		return cfg, fmt.Errorf("error %s cannot be zero", EnvEjectIdle)
@@ -87,6 +91,16 @@ func NewAgentConfig() (*AgentConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+func setEnvStr(err error, name string, dst *string) error {
+	if err != nil {
+		return err
+	}
+	if tmp, ok := os.LookupEnv(name); ok {
+		*dst = tmp
+	}
+	return nil
 }
 
 func setEnvUint(err error, name string, dst *uint64) error {

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -141,8 +141,8 @@ func (drv *DockerDriver) tryUsePool(ctx context.Context, container *docker.Creat
 			// We are able to fetch a container from pool. Now, use its
 			// network, ipc and pid namespaces.
 			container.HostConfig.NetworkMode = linker
-			container.HostConfig.IpcMode = linker
-			container.HostConfig.PidMode = linker
+			//container.HostConfig.IpcMode = linker
+			//container.HostConfig.PidMode = linker
 			return id
 		}
 

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -131,6 +131,29 @@ func (drv *DockerDriver) Close() error {
 	return err
 }
 
+func (drv *DockerDriver) tryUsePool(ctx context.Context, container *docker.CreateContainerOptions) string {
+	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "tryUsePool"})
+
+	if drv.pool != nil {
+		id, err := drv.pool.AllocPoolId()
+		if err == nil {
+			linker := fmt.Sprintf("container:%s", id)
+			// We are able to fetch a container from pool. Now, use its
+			// network, ipc and pid namespaces.
+			container.HostConfig.NetworkMode = linker
+			container.HostConfig.IpcMode = linker
+			container.HostConfig.PidMode = linker
+			return id
+		}
+
+		log.WithError(err).Error("Could not fetch pre fork pool container")
+	}
+
+	// hostname and container NetworkMode is not compatible.
+	container.Config.Hostname = drv.hostname
+	return ""
+}
+
 func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask) (drivers.Cookie, error) {
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "Prepare"})
 	var cmd []string
@@ -171,19 +194,7 @@ func (drv *DockerDriver) Prepare(ctx context.Context, task drivers.ContainerTask
 		Context: ctx,
 	}
 
-	poolId := ""
-	if drv.pool != nil {
-		id, err := drv.pool.AllocPoolId()
-		if err != nil {
-			log.WithError(err).Error("Could not fetch pre fork pool container")
-		} else {
-			poolId = id
-			container.HostConfig.NetworkMode = fmt.Sprintf("container:%s", id)
-		}
-	} else {
-		// hostname and container NetworkMode is not compatible.
-		container.Config.Hostname = drv.hostname
-	}
+	poolId := drv.tryUsePool(ctx, &container)
 
 	// Translate milli cpus into CPUQuota & CPUPeriod (see Linux cGroups CFS cgroup v1 documentation)
 	// eg: task.CPUQuota() of 8000 means CPUQuota of 8 * 100000 usecs in 100000 usec period,

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -34,12 +34,16 @@ var (
 	ErrorPoolEmpty = errors.New("docker pre fork pool empty")
 )
 
+type PoolTaskStateType int
+
+const (
+	PoolTaskStateInit  PoolTaskStateType = iota // initializing
+	PoolTaskStateReady                          // ready to be run
+)
+
 const (
 	LimitPerSec = 10
 	LimitBurst  = 20
-
-	DefaultImage = "busybox"
-	DefaultCmd   = "tail -f /dev/null"
 
 	ShutdownTimeout = time.Duration(1) * time.Second
 )
@@ -48,6 +52,7 @@ type poolTask struct {
 	id    string
 	image string
 	cmd   string
+	state PoolTaskStateType
 }
 
 func (c *poolTask) Id() string                                       { return c.id }
@@ -65,13 +70,19 @@ func (c *poolTask) CPUs() uint64                                     { return 0 
 func (c *poolTask) FsSize() uint64                                   { return 0 }
 func (c *poolTask) WriteStat(ctx context.Context, stat drivers.Stat) {}
 
+type dockerPoolItem struct {
+	id     string
+	cancel func()
+}
+
 type dockerPool struct {
-	lock    sync.Mutex
-	inuse   map[string]struct{}
-	free    []string
-	limiter *rate.Limiter
-	cancel  func()
-	wg      sync.WaitGroup // TODO rename
+	lock      sync.Mutex
+	inuse     map[string]dockerPoolItem
+	free      []dockerPoolItem
+	limiter   *rate.Limiter
+	cancel    func()
+	wg        sync.WaitGroup
+	isRecycle bool
 }
 
 type DockerPoolStats struct {
@@ -107,28 +118,25 @@ func NewDockerPool(conf drivers.Config, driver *DockerDriver) DockerPool {
 	log.Error("WARNING: Experimental Prefork Docker Pool Enabled")
 
 	pool := &dockerPool{
-		inuse:   make(map[string]struct{}, conf.PreForkPoolSize),
-		free:    make([]string, 0, conf.PreForkPoolSize),
+		inuse:   make(map[string]dockerPoolItem, conf.PreForkPoolSize),
+		free:    make([]dockerPoolItem, 0, conf.PreForkPoolSize),
 		limiter: rate.NewLimiter(LimitPerSec, LimitBurst),
 		cancel:  cancel,
 	}
 
+	if conf.PreForkUseOnce != 0 {
+		pool.isRecycle = true
+	}
+
+	pool.wg.Add(int(conf.PreForkPoolSize))
 	for i := uint64(0); i < conf.PreForkPoolSize; i++ {
 
 		task := &poolTask{
 			id:    fmt.Sprintf("%d_prefork_%s", i, id.New().String()),
-			image: DefaultImage,
-			cmd:   DefaultCmd,
+			image: conf.PreForkImage,
+			cmd:   conf.PreForkCmd,
 		}
 
-		if conf.PreForkImage != "" {
-			task.image = conf.PreForkImage
-		}
-		if conf.PreForkCmd != "" {
-			task.cmd = conf.PreForkCmd
-		}
-
-		pool.wg.Add(1)
 		go pool.nannyContainer(ctx, driver, task)
 	}
 
@@ -141,10 +149,15 @@ func (pool *dockerPool) Close() error {
 	return nil
 }
 
-func (pool *dockerPool) nannyContainer(ctx context.Context, driver *DockerDriver, task *poolTask) {
-	defer pool.wg.Done()
+func (pool *dockerPool) performInitState(ctx context.Context, driver *DockerDriver, task *poolTask) {
 
-	log := common.Logger(ctx).WithFields(logrus.Fields{"name": task.Id()})
+	log := common.Logger(ctx).WithFields(logrus.Fields{"id": task.Id()})
+
+	err := driver.ensureImage(ctx, task)
+	if err != nil {
+		log.WithError(err).Info("prefork pool image pull failed")
+		return
+	}
 
 	containerOpts := docker.CreateContainerOptions{
 		Name: task.Id(),
@@ -163,7 +176,6 @@ func (pool *dockerPool) nannyContainer(ctx context.Context, driver *DockerDriver
 			LogConfig: docker.LogConfig{
 				Type: "none",
 			},
-			AutoRemove: true,
 		},
 		Context: ctx,
 	}
@@ -175,67 +187,109 @@ func (pool *dockerPool) nannyContainer(ctx context.Context, driver *DockerDriver
 		Context:       ctx,
 	}
 
-	// We spin forever, keeping the pool resident and running at all times.
-	for {
-		err := pool.limiter.Wait(ctx)
-		if err != nil {
-			// should not really happen unless ctx has a deadline or burst is 0.
-			log.WithError(err).Info("prefork pool rate limiter failed")
-			break
-		}
+	// ignore failure here
+	driver.docker.RemoveContainer(removeOpts)
 
-		// Let's try to clean up any left overs
-		err = driver.docker.RemoveContainer(removeOpts)
-		if err != nil {
-			log.WithError(err).Info("prefork pool container remove failed (this is probably OK)")
-		}
-
-		err = driver.ensureImage(ctx, task)
-		if err != nil {
-			log.WithError(err).Info("prefork pool image pull failed")
-			continue
-		}
-
-		_, err = driver.docker.CreateContainer(containerOpts)
-		if err != nil {
-			log.WithError(err).Info("prefork pool container create failed")
-			continue
-		}
-
-		err = driver.docker.StartContainerWithContext(task.Id(), nil, ctx)
-		if err != nil {
-			log.WithError(err).Info("prefork pool container start failed")
-			continue
-		}
-
-		log.Debug("prefork pool container ready")
-
-		// IMPORTANT: container is now up and running. Register it to make it
-		// available for function containers.
-		pool.register(task.Id())
-
-		// We are optimistic here where provided image and command really blocks
-		// and runs forever.
-		exitCode, err := driver.docker.WaitContainerWithContext(task.Id(), ctx)
-
-		// IMPORTANT: We have exited. This window is potentially very destructive, as any new
-		// function containers created during this window will fail. We must immediately
-		// proceed to unregister ourself to avoid further issues.
-		pool.unregister(task.Id())
-
-		log.WithError(err).Infof("prefork pool container exited exit_code=%d", exitCode)
+	_, err = driver.docker.CreateContainer(containerOpts)
+	if err != nil {
+		log.WithError(err).Info("prefork pool container create failed")
+		return
 	}
 
-	// final exit cleanup
+	task.state = PoolTaskStateReady
+}
+
+func (pool *dockerPool) performReadyState(ctx context.Context, driver *DockerDriver, task *poolTask) {
+
+	log := common.Logger(ctx).WithFields(logrus.Fields{"id": task.Id()})
+
+	killOpts := docker.KillContainerOptions{
+		ID:      task.Id(),
+		Context: ctx,
+	}
+
+	defer func() {
+		err := driver.docker.KillContainer(killOpts)
+		if err != nil {
+			log.WithError(err).Info("prefork pool container kill failed")
+			task.state = PoolTaskStateInit
+		}
+	}()
+
+	err := driver.docker.StartContainerWithContext(task.Id(), nil, ctx)
+	if err != nil {
+		log.WithError(err).Info("prefork pool container start failed")
+		task.state = PoolTaskStateInit
+		return
+	}
+
+	log.Debug("prefork pool container ready")
+
+	// IMPORTANT: container is now up and running. Register it to make it
+	// available for function containers.
+	ctx, cancel := context.WithCancel(ctx)
+
+	pool.register(task.Id(), cancel)
+	exitCode, err := driver.docker.WaitContainerWithContext(task.Id(), ctx)
+	pool.unregister(task.Id())
+
+	if ctx.Err() == nil {
+		log.WithError(err).Infof("prefork pool container exited exit_code=%d", exitCode)
+		task.state = PoolTaskStateInit
+	}
+}
+
+func (pool *dockerPool) performTeardown(ctx context.Context, driver *DockerDriver, task *poolTask) {
+
 	ctx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)
 	defer cancel()
-	removeOpts.Context = ctx
+
+	removeOpts := docker.RemoveContainerOptions{
+		ID:            task.Id(),
+		Force:         true,
+		RemoveVolumes: true,
+		Context:       ctx,
+	}
+
 	driver.docker.RemoveContainer(removeOpts)
 }
 
-func (pool *dockerPool) register(id string) {
+func (pool *dockerPool) nannyContainer(ctx context.Context, driver *DockerDriver, task *poolTask) {
+	defer pool.performTeardown(ctx, driver, task)
+	defer pool.wg.Done()
+
+	log := common.Logger(ctx).WithFields(logrus.Fields{"id": task.Id()})
+
+	// We spin forever, keeping the pool resident and running at all times.
+	for ctx.Err() == nil {
+
+		if task.state != PoolTaskStateReady {
+			err := pool.limiter.Wait(ctx)
+			if err != nil {
+				// should not really happen unless ctx has a deadline or burst is 0.
+				log.WithError(err).Info("prefork pool rate limiter failed")
+				break
+			}
+		}
+
+		if task.state != PoolTaskStateReady {
+			pool.performInitState(ctx, driver, task)
+		}
+
+		if task.state == PoolTaskStateReady {
+			pool.performReadyState(ctx, driver, task)
+		}
+	}
+}
+
+func (pool *dockerPool) register(id string, cancel func()) {
+	item := dockerPoolItem{
+		id:     id,
+		cancel: cancel,
+	}
+
 	pool.lock.Lock()
-	pool.free = append(pool.free, id)
+	pool.free = append(pool.free, item)
 	pool.lock.Unlock()
 }
 
@@ -247,7 +301,7 @@ func (pool *dockerPool) unregister(id string) {
 		delete(pool.inuse, id)
 	} else {
 		for i := 0; i < len(pool.free); i += 1 {
-			if pool.free[i] == id {
+			if pool.free[i].id == id {
 				pool.free = append(pool.free[:i], pool.free[i+1:]...)
 				break
 			}
@@ -268,18 +322,26 @@ func (pool *dockerPool) AllocPoolId() (string, error) {
 
 	id := pool.free[len(pool.free)-1]
 	pool.free = pool.free[:len(pool.free)-1]
-	pool.inuse[id] = struct{}{}
+	pool.inuse[id.id] = id
 
-	return id, nil
+	return id.id, nil
 }
 
 func (pool *dockerPool) FreePoolId(id string) {
+
+	isRecycle := pool.isRecycle
+
 	pool.lock.Lock()
 
-	_, ok := pool.inuse[id]
+	item, ok := pool.inuse[id]
 	if ok {
+		if item.cancel != nil && isRecycle {
+			item.cancel()
+		}
 		delete(pool.inuse, id)
-		pool.free = append(pool.free, id)
+		if !isRecycle {
+			pool.free = append(pool.free, item)
+		}
 	}
 
 	pool.lock.Unlock()

--- a/api/agent/drivers/docker/docker_pool_test.go
+++ b/api/agent/drivers/docker/docker_pool_test.go
@@ -8,13 +8,21 @@ import (
 	"github.com/fnproject/fn/api/agent/drivers"
 )
 
+func getDefaultCfg() *drivers.Config {
+	cfg := &drivers.Config{
+		PreForkImage: "busybox",
+		PreForkCmd:   "tail -f /dev/null",
+	}
+	return cfg
+}
+
 func TestRunnerDockerPool(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("prefork only supported on Linux")
 		return
 	}
 
-	cfg := &drivers.Config{}
+	cfg := getDefaultCfg()
 
 	// shouldn't spin up a pool since cfg is empty
 	drv := NewDocker(*cfg)
@@ -95,7 +103,7 @@ func TestRunnerDockerPoolFaulty(t *testing.T) {
 		return
 	}
 
-	cfg := &drivers.Config{}
+	cfg := getDefaultCfg()
 
 	// shouldn't spin up a pool since cfg is empty
 	drv := NewDocker(*cfg)

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -197,6 +197,7 @@ type Config struct {
 	PreForkPoolSize uint64 `json:"pre_fork_pool_size"`
 	PreForkImage    string `json:"pre_fork_image"`
 	PreForkCmd      string `json:"pre_fork_cmd"`
+	PreForkUseOnce  uint64 `json:"pre_fork_use_once"`
 }
 
 func average(samples []Stat) (Stat, bool) {

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -198,6 +198,7 @@ type Config struct {
 	PreForkImage    string `json:"pre_fork_image"`
 	PreForkCmd      string `json:"pre_fork_cmd"`
 	PreForkUseOnce  uint64 `json:"pre_fork_use_once"`
+	PreForkNetworks string `json:"pre_fork_networks"`
 }
 
 func average(samples []Stat) (Stat, bool) {


### PR DESCRIPTION
*) Rework the control loop for the containers, where now we have two states: initializing and ready. This allows us to avoid expensive & unnecessary operations for backfill/recycle phases.
*) A recycle option which discards each pool item after use.
*) Network list option to provide a list of docker bridges to spread the pool into. Each docker bridge has a linux limitation of 1023 containers, so using this list, we can exceed that limit easily.

TODO: Recycle performs poorly in cold-containers as it runs out of pool items over time. This causes churn and increases system load significantly. Need to run/tune this recycle mode for hot containers and re-evaluate.