### PR TITLE
Expose func call as the extensions API

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -898,6 +898,10 @@ func (s *Server) Datastore() models.Datastore {
 	return s.datastore
 }
 
+func (s *Server) Agent() agent.Agent {
+	return s.agent
+}
+
 // returns the unescaped ?cursor and ?perPage values
 // pageParams clamps 0 < ?perPage <= 100 and defaults to 30 if 0
 // ignores parsing errors and falls back to defaults.


### PR DESCRIPTION
The purpose of the PR is to expose an API in the extension manner, so the developers can use this to call the functions inside the extensions, specifically, listeners (note, that existing middleware `CallFunction` can be consumed only within the middleware, but not the listeners). So, given refactoring brings capabilities of the listeners to the same level of the middleware.

There is no impact to existing API.
New method suppose to be (or become) fewer HTTP-aligned.

Please note, that, eventually, this method should become trigger-agnostic and just accept a call for the execution, so any HTTP-(or whatever)-specific configuration should happen outside of this method to give unimaginable freedom of choice.
