### PR TITLE
support runner TLS certificates with specified certificate Common Names

### DIFF
--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -26,14 +26,14 @@ type mockRunner struct {
 
 type mockRunnerPool struct {
 	runners   []pool.Runner
-	generator insecureRunnerFactory
+	generator pool.MTLSRunnerFactory
 	pki       *pool.PKIData
 }
 
-func newMockRunnerPool(rf insecureRunnerFactory, runnerAddrs []string) *mockRunnerPool {
+func newMockRunnerPool(rf pool.MTLSRunnerFactory, runnerAddrs []string) *mockRunnerPool {
 	var runners []pool.Runner
 	for _, addr := range runnerAddrs {
-		r, err := rf(addr)
+		r, err := rf(addr, "", nil)
 		if err != nil {
 			continue
 		}
@@ -55,8 +55,8 @@ func (rp *mockRunnerPool) Shutdown(context.Context) error {
 	return nil
 }
 
-func NewMockRunnerFactory(sleep time.Duration, maxCalls int32) insecureRunnerFactory {
-	return func(addr string) (pool.Runner, error) {
+func NewMockRunnerFactory(sleep time.Duration, maxCalls int32) pool.MTLSRunnerFactory {
+	return func(addr, cn string, pki *pool.PKIData) (pool.Runner, error) {
 		return &mockRunner{
 			sleep:    sleep,
 			maxCalls: maxCalls,
@@ -65,8 +65,8 @@ func NewMockRunnerFactory(sleep time.Duration, maxCalls int32) insecureRunnerFac
 	}
 }
 
-func FaultyRunnerFactory() insecureRunnerFactory {
-	return func(addr string) (pool.Runner, error) {
+func FaultyRunnerFactory() pool.MTLSRunnerFactory {
+	return func(addr, cn string, pki *pool.PKIData) (pool.Runner, error) {
 		return &mockRunner{
 			addr: addr,
 		}, errors.New("Creation of new runner failed")

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -16,11 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// the comm
-	RunnerCertificateCommonName = "runner.fn.fnproject.github.com"
-)
-
 type gRPCRunner struct {
 	// Need a WaitGroup of TryExec in flight
 	wg      sync.WaitGroup

--- a/api/agent/static_pool.go
+++ b/api/agent/static_pool.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	staticPoolShutdownTimeout = 5 * time.Second
-	defaultRunnerPoolCN       = "runner.fn.fnproject.github.com"
 )
 
 // manages a single set of runners ignoring lb groups
@@ -23,15 +22,15 @@ type staticRunnerPool struct {
 	runners   []pool.Runner
 }
 
-func DefaultStaticRunnerPool(runnerAddresses []string, pki *pool.PKIData) pool.RunnerPool {
-	return NewStaticRunnerPool(runnerAddresses, pki, defaultRunnerPoolCN, SecureGRPCRunnerFactory)
+func DefaultStaticRunnerPool(runnerAddresses []string) pool.RunnerPool {
+	return NewStaticRunnerPool(runnerAddresses, nil, "", SecureGRPCRunnerFactory)
 }
 
 func NewStaticRunnerPool(runnerAddresses []string, pki *pool.PKIData, runnerCN string, runnerFactory pool.MTLSRunnerFactory) pool.RunnerPool {
 	logrus.WithField("runners", runnerAddresses).Info("Starting static runner pool")
 	var runners []pool.Runner
 	for _, addr := range runnerAddresses {
-		r, err := runnerFactory(addr, defaultRunnerPoolCN, pki)
+		r, err := runnerFactory(addr, runnerCN, pki)
 		if err != nil {
 			logrus.WithField("runner_addr", addr).Warn("Invalid runner")
 			continue

--- a/api/agent/static_pool_test.go
+++ b/api/agent/static_pool_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func setupStaticPool(runners []string) pool.RunnerPool {
-	return newStaticRunnerPool(runners, mockRunnerFactory)
+	return NewStaticRunnerPool(runners, nil, "", mockRunnerFactory)
 }
 
 type mockStaticRunner struct {
@@ -27,7 +27,7 @@ func (r *mockStaticRunner) Address() string {
 	return r.address
 }
 
-func mockRunnerFactory(addr string) (pool.Runner, error) {
+func mockRunnerFactory(addr, cn string, pki *pool.PKIData) (pool.Runner, error) {
 	return &mockStaticRunner{address: addr}, nil
 }
 

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -21,6 +21,7 @@ type RunnerPool interface {
 	Shutdown(context.Context) error
 }
 
+// PKIData encapsulates TLS certificate data
 type PKIData struct {
 	Ca   string
 	Key  string
@@ -28,7 +29,7 @@ type PKIData struct {
 }
 
 // MTLSRunnerFactory represents a factory method for constructing runners using mTLS
-type MTLSRunnerFactory func(addr string, pki *PKIData) (Runner, error)
+type MTLSRunnerFactory func(addr, certCommonName string, pki *PKIData) (Runner, error)
 
 // Runner is the interface to invoke the execution of a function call on a specific runner
 type Runner interface {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -19,8 +19,6 @@ import (
 	"syscall"
 	"unicode"
 
-	"github.com/fnproject/fn/api/runnerpool"
-
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/agent/hybrid"
 	"github.com/fnproject/fn/api/common"
@@ -356,17 +354,7 @@ func (s *Server) defaultRunnerPool() (pool.RunnerPool, error) {
 	if runnerAddresses == "" {
 		return nil, errors.New("Must provide FN_RUNNER_ADDRESSES  when running in default load-balanced mode!")
 	}
-
-	var pki *runnerpool.PKIData
-	if s.cert != "" && s.certKey != "" && s.certAuthority != "" {
-		pki = &runnerpool.PKIData{
-			Ca:   s.certAuthority,
-			Key:  s.certKey,
-			Cert: s.cert,
-		}
-	}
-
-	return agent.DefaultStaticRunnerPool(strings.Split(runnerAddresses, ","), pki), nil
+	return agent.DefaultStaticRunnerPool(strings.Split(runnerAddresses, ",")), nil
 }
 
 func (s *Server) defaultPlacer() pool.Placer {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"unicode"
 
+	"github.com/fnproject/fn/api/runnerpool"
+
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/agent/hybrid"
 	"github.com/fnproject/fn/api/common"
@@ -354,7 +356,17 @@ func (s *Server) defaultRunnerPool() (pool.RunnerPool, error) {
 	if runnerAddresses == "" {
 		return nil, errors.New("Must provide FN_RUNNER_ADDRESSES  when running in default load-balanced mode!")
 	}
-	return agent.DefaultStaticRunnerPool(strings.Split(runnerAddresses, ",")), nil
+
+	var pki *runnerpool.PKIData
+	if s.cert != "" && s.certKey != "" && s.certAuthority != "" {
+		pki = &runnerpool.PKIData{
+			Ca:   s.certAuthority,
+			Key:  s.certKey,
+			Cert: s.cert,
+		}
+	}
+
+	return agent.DefaultStaticRunnerPool(strings.Split(runnerAddresses, ","), pki), nil
 }
 
 func (s *Server) defaultPlacer() pool.Placer {


### PR DESCRIPTION
In order to support TLS certificates with different Common Names, we need to extend the grpc utilities and the way we create runners.