### PR TITLE
Try to instantiate from HTTP request in favour Event

### DIFF
--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -100,6 +100,7 @@ func (a *agent) asyncRun(ctx context.Context, model *models.Call) {
 	defer span.End()
 
 	call, err := a.GetCall(
+		ctx,
 		FromModel(model),
 		WithContext(ctx), // NOTE: order is important
 	)

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -124,9 +124,9 @@ func (a *lbAgent) GetAppByID(ctx context.Context, appID string) (*models.App, er
 
 // GetCall delegates to the wrapped agent but disables the capacity check as
 // this agent isn't actually running the call.
-func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
+func (a *lbAgent) GetCall(ctx context.Context, opts ...CallOpt) (Call, error) {
 	opts = append(opts, WithoutPreemptiveCapacityCheck())
-	return a.delegatedAgent.GetCall(opts...)
+	return a.delegatedAgent.GetCall(ctx, opts...)
 }
 
 func (a *lbAgent) Close() error {
@@ -166,8 +166,8 @@ func (a *lbAgent) Submit(callI Call) error {
 
 	call := callI.(*call)
 
-	ctx, cancel := context.WithDeadline(call.req.Context(), call.execDeadline)
-	call.req = call.req.WithContext(ctx)
+	ctx, cancel := context.WithDeadline(call.event.Context(), call.execDeadline)
+	call.event = call.event.WithContext(ctx)
 	defer cancel()
 
 	ctx, span := trace.StartSpan(ctx, "agent_submit")

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -118,7 +118,7 @@ func (r *mockRunner) Address() string {
 
 type mockRunnerCall struct {
 	slotDeadline time.Time
-	r            *http.Request
+	event        *models.EventRequest
 	rw           http.ResponseWriter
 	stdErr       io.ReadWriteCloser
 	model        *models.Call
@@ -128,8 +128,8 @@ func (c *mockRunnerCall) SlotDeadline() time.Time {
 	return c.slotDeadline
 }
 
-func (c *mockRunnerCall) Request() *http.Request {
-	return c.r
+func (c *mockRunnerCall) EventRequest() *models.EventRequest {
+	return c.event
 }
 func (c *mockRunnerCall) ResponseWriter() http.ResponseWriter {
 	return c.rw

--- a/api/agent/protocol/http.go
+++ b/api/agent/protocol/http.go
@@ -27,7 +27,7 @@ func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) e
 	ctx, span := trace.StartSpan(ctx, "dispatch_http")
 	defer span.End()
 
-	req := ci.Request()
+	req := ci.Event().OriginalRequest
 
 	req.RequestURI = ci.RequestURL() // force set to this, for req.Write to use (TODO? still?)
 
@@ -46,7 +46,7 @@ func (h *HTTPProtocol) Dispatch(ctx context.Context, ci CallInfo, w io.Writer) e
 	}
 
 	_, span = trace.StartSpan(ctx, "dispatch_http_read_response")
-	resp, err := http.ReadResponse(bufio.NewReader(h.out), ci.Request())
+	resp, err := http.ReadResponse(bufio.NewReader(h.out), req)
 	span.End()
 	if err != nil {
 		return models.NewAPIError(http.StatusBadGateway, fmt.Errorf("invalid http response from function err: %v", err))

--- a/api/agent/protocol/json_test.go
+++ b/api/agent/protocol/json_test.go
@@ -46,8 +46,10 @@ func setupRequest(data interface{}) *callInfoImpl {
 	// fixup URL in models.Call
 	call.URL = req.URL.String()
 
-	ci := &callInfoImpl{call, req}
-	return ci
+	event := &models.EventRequest{}
+	event.FromHTTPRequest(req)
+
+	return &callInfoImpl{call, event}
 }
 
 func TestJSONProtocolwriteJSONInputRequestBasicFields(t *testing.T) {
@@ -158,9 +160,9 @@ func TestJSONProtocolwriteJSONInputRequestWithoutData(t *testing.T) {
 		t.Errorf("Request body assertion mismatch: expected: %s, got %s",
 			"<empty-string>", incomingReq.Body)
 	}
-	if !models.Headers(ci.req.Header).Equals(models.Headers(incomingReq.Protocol.Headers)) {
+	if !models.Headers(ci.event.Header()).Equals(models.Headers(incomingReq.Protocol.Headers)) {
 		t.Errorf("Request headers assertion mismatch: expected: %s, got %s",
-			ci.req.Header, incomingReq.Protocol.Headers)
+			ci.event.Header(), incomingReq.Protocol.Headers)
 	}
 	if incomingReq.Protocol.Type != ci.ProtocolType() {
 		t.Errorf("Call protocol type assertion mismatch: expected: %s, got %s",

--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -258,8 +258,8 @@ func (pr *pureRunner) GetAppByID(ctx context.Context, appID string) (*models.App
 	return pr.a.GetAppByID(ctx, appID)
 }
 
-func (pr *pureRunner) GetCall(opts ...CallOpt) (Call, error) {
-	return pr.a.GetCall(opts...)
+func (pr *pureRunner) GetCall(ctx context.Context, opts ...CallOpt) (Call, error) {
+	return pr.a.GetCall(ctx, opts...)
 }
 
 func (pr *pureRunner) Submit(Call) error {
@@ -396,11 +396,11 @@ func (pr *pureRunner) handleTryCall(ctx context.Context, tc *runner.TryCall, sta
 	var w http.ResponseWriter
 	w = state
 	inR, inW := io.Pipe()
-	agent_call, err := pr.a.GetCall(FromModelAndInput(&c, inR), WithWriter(w))
+	agentCall, err := pr.a.GetCall(ctx, FromModelAndInput(&c, inR), WithWriter(w))
 	if err != nil {
 		return func() { pr.capacity.ReleaseCapacity(c.Memory) }, err
 	}
-	state.c = agent_call.(*call)
+	state.c = agentCall.(*call)
 	state.input = inW
 	state.allocatedTime = strfmt.DateTime(time.Now())
 

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -135,7 +135,7 @@ func (r *gRPCRunner) TryExec(ctx context.Context, call pool.RunnerCall) (bool, e
 }
 
 func sendToRunner(call pool.RunnerCall, protocolClient pb.RunnerProtocol_EngageClient) error {
-	bodyReader := call.Request().Body
+	bodyReader := call.EventRequest().Body()
 	writeBufferSize := 10 * 1024 // 10KB
 	writeBuffer := make([]byte, writeBufferSize)
 	for {

--- a/api/models/event.go
+++ b/api/models/event.go
@@ -1,0 +1,101 @@
+package models
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+func reqURL(req *http.Request) string {
+	if req.URL.Scheme == "" {
+		if req.TLS == nil {
+			req.URL.Scheme = "http"
+		} else {
+			req.URL.Scheme = "https"
+		}
+	}
+	if req.URL.Host == "" {
+		req.URL.Host = req.Host
+	}
+	return req.URL.String()
+}
+
+type EventRequest struct {
+	ctx         context.Context
+	contentType string
+	header      http.Header
+	body        io.Reader
+	requestPath string
+	method      string
+	eventType   string
+
+	// required by HTTP protocol
+	// we can't do a copy of the request because it will turn
+	// the event into yet another HTTP request-like struct,
+	// so just keeping the reference to that
+	OriginalRequest *http.Request
+}
+
+func (e *EventRequest) FromHTTPRequest(req *http.Request) {
+	e.ctx = req.Context()
+	e.header = req.Header
+	e.body = req.Body
+	e.requestPath = reqURL(req)
+	e.method = req.Method
+
+	e.eventType = "http"
+	e.OriginalRequest = req
+	e.contentType = req.Header.Get("Content-Type")
+}
+
+func (e *EventRequest) Context() context.Context {
+	return e.ctx
+}
+
+func (e *EventRequest) WithContext(ctx context.Context) *EventRequest {
+	e.ctx = ctx
+	return e
+}
+
+func (e *EventRequest) Header() http.Header {
+	return e.header
+}
+
+func (e *EventRequest) WithHeader(h http.Header) {
+	e.header = h
+}
+
+func (e *EventRequest) Body() io.Reader {
+	return e.body
+}
+
+func (e *EventRequest) WithBody(b io.Reader) {
+	e.body = b
+}
+
+func (e *EventRequest) WithRequestURL(u string) {
+	e.requestPath = u
+}
+
+func (e *EventRequest) RequestURL() string {
+	return e.requestPath
+}
+
+func (e *EventRequest) Method() string {
+	return e.method
+}
+
+func (e *EventRequest) WithMethod(m string) {
+	e.method = m
+}
+
+func (e *EventRequest) Type() string {
+	return e.eventType
+}
+
+func (e *EventRequest) ContentType() string {
+	if e.contentType == "" {
+		e.contentType = e.header.Get("Content-Type")
+	}
+	return e.contentType
+}

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -41,7 +41,7 @@ type Runner interface {
 // processed by a RunnerPool
 type RunnerCall interface {
 	SlotDeadline() time.Time
-	Request() *http.Request
+	EventRequest() *models.EventRequest
 	ResponseWriter() http.ResponseWriter
 	StdErr() io.ReadWriteCloser
 	Model() *models.Call

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -73,9 +73,13 @@ func (s *Server) serve(c *gin.Context, app *models.App, path string) error {
 	// GetCall can mod headers, assign an id, look up the route/app (cached),
 	// strip params, etc.
 
+	event := &models.EventRequest{}
+	event.FromHTTPRequest(c.Request)
+
 	call, err := s.agent.GetCall(
+		event.Context(),
 		agent.WithWriter(&writer), // XXX (reed): order matters [for now]
-		agent.FromRequest(app, path, c.Request),
+		agent.FromEventRequest(app, path, event),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
 - this PR makes Agent work with the Event object that is (unfortunately) derived from the `http.Request`
 - it does make code look more HTTP-agnostic
 - step forward to multiple triggers
 - allows API Listeners to submit non-HTTP-specific events (call the function).