### PR TITLE
Returning Agent on exported func for pureRunner

### DIFF
--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -554,15 +554,15 @@ func (pr *pureRunner) Start() error {
 	return err
 }
 
-func UnsecuredPureRunner(cancel context.CancelFunc, addr string, da DataAccess) (*pureRunner, error) {
+func UnsecuredPureRunner(cancel context.CancelFunc, addr string, da DataAccess) (Agent, error) {
 	return NewPureRunner(cancel, addr, da, "", "", "", nil)
 }
 
-func DefaultPureRunner(cancel context.CancelFunc, addr string, da DataAccess, cert string, key string, ca string) (*pureRunner, error) {
+func DefaultPureRunner(cancel context.CancelFunc, addr string, da DataAccess, cert string, key string, ca string) (Agent, error) {
 	return NewPureRunner(cancel, addr, da, cert, key, ca, nil)
 }
 
-func NewPureRunner(cancel context.CancelFunc, addr string, da DataAccess, cert string, key string, ca string, gate CapacityGate) (*pureRunner, error) {
+func NewPureRunner(cancel context.CancelFunc, addr string, da DataAccess, cert string, key string, ca string, gate CapacityGate) (Agent, error) {
 	a := createAgent(da, true)
 	var pr *pureRunner
 	var err error


### PR DESCRIPTION
pureRunner is a not exported struct and it was set as a return value for
few exported methods, in this change we return Agent which is the
interface implemented by pureRunner to avoid to leak an unexported type.