### PR TITLE
Change port for local registry

### DIFF
--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -327,7 +327,7 @@ func TestRouteRunnerExecution(t *testing.T) {
 	rHdr := map[string][]string{"X-Function": {"Test"}}
 	rImg := "fnproject/fn-test-utils"
 	rImgBs1 := "fnproject/imagethatdoesnotexist"
-	rImgBs2 := "localhost:5000/fnproject/imagethatdoesnotexist"
+	rImgBs2 := "localhost:5050/fnproject/imagethatdoesnotexist"
 
 	app := &models.App{Name: "myapp"}
 	app.SetDefaults()


### PR DESCRIPTION
   In one of the tests we want a failure due to a 500 error returned by a
    not existing local registry, the fake server address is set to localhost:5000
    In a typical local env is quite likely to have a local registry running
    at localhost:5000 and that will make the
    test to return a 4xx error instead of the expected 500, this change
    just set a not standard port for the fake local registry to reduce the
    chances to clash with an existing running one.