### PR TITLE
Make sure to rebuild protobuf files during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dep:
 dep-up:
 	dep ensure
 
-build:
+build: api/agent/grpc/runner.pb.go
 	go build -o fnserver
 
 install:
@@ -82,11 +82,8 @@ test-build-arm:
 	GOARCH=arm GOARM=7 $(MAKE) build
 	GOARCH=arm64 $(MAKE) build
 
-protos: api/agent/grpc/runner.pb.go poolmanager/grpc/poolmanager.pb.go
-
 %.pb.go: %.proto
-	protoc  --proto_path=$(@D) --proto_path=./vendor \
-    --go_out=plugins=grpc:$(@D) $<
+	protoc --proto_path=$(@D) --proto_path=./vendor --go_out=plugins=grpc:$(@D) $<
 
 run: build
 	GIN_MODE=debug ./fnserver


### PR DESCRIPTION
I noticed that the Makefile rule to build protobuf files was listing a
non-existent file and that the protobuf files were not getting rebuilt
during builds.