### PR TITLE
loosen perms on bolt mq

### DIFF
--- a/api/mqs/bolt.go
+++ b/api/mqs/bolt.go
@@ -60,7 +60,7 @@ func NewBoltMQ(url *url.URL) (*BoltDbMQ, error) {
 		log.WithError(err).Errorln("Could not create data directory for mq")
 		return nil, err
 	}
-	db, err := bolt.Open(url.Path, 0655, &bolt.Options{Timeout: 1 * time.Second})
+	db, err := bolt.Open(url.Path, 0666, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		log.WithError(err).Errorln("Could not open BoltDB file for MQ")
 		return nil, err


### PR DESCRIPTION
the bolt mq file should only be used for local dev and isn't necessarily
sensitive, don't think 0655 restriction was necessary and the data isn't
likely all that sensitive anyway.

see https://github.com/fnproject/fn/issues/404#issuecomment-377570626

closes #779