### PR TITLE
Bugfix/grpc consume eof

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -285,8 +285,8 @@ func (c *call) SlotDeadline() time.Time {
 	return c.slotDeadline
 }
 
-func (c *call) Request() *http.Request {
-	return c.req
+func (c *call) RequestBody() io.ReadCloser {
+	return c.req.Body
 }
 
 func (c *call) ResponseWriter() http.ResponseWriter {

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -135,9 +135,11 @@ func (c *mockRunnerCall) RequestBody() io.ReadCloser {
 func (c *mockRunnerCall) ResponseWriter() http.ResponseWriter {
 	return c.rw
 }
+
 func (c *mockRunnerCall) StdErr() io.ReadWriteCloser {
 	return c.stdErr
 }
+
 func (c *mockRunnerCall) Model() *models.Call {
 	return c.model
 }

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -128,9 +128,10 @@ func (c *mockRunnerCall) SlotDeadline() time.Time {
 	return c.slotDeadline
 }
 
-func (c *mockRunnerCall) Request() *http.Request {
-	return c.r
+func (c *mockRunnerCall) RequestBody() io.ReadCloser {
+	return c.r.Body
 }
+
 func (c *mockRunnerCall) ResponseWriter() http.ResponseWriter {
 	return c.rw
 }

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -199,7 +199,11 @@ func receiveFromRunner(protocolClient pb.RunnerProtocol_EngageClient, c pool.Run
 			if body.Finished.Success {
 				logrus.Infof("Call finished successfully: %v", body.Finished.Details)
 			} else {
-				logrus.Infof("Call finish unsuccessfully:: %v", body.Finished.Details)
+				logrus.Infof("Call finished unsuccessfully: %v", body.Finished.Details)
+			}
+			// There should be an EOF following the last packet
+			if _, err := protocolClient.Recv(); err != io.EOF {
+				logrus.Errorf("Did not receive expected EOF from runner stream: %v", err)
 			}
 			close(done)
 			return

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -135,7 +135,7 @@ func (r *gRPCRunner) TryExec(ctx context.Context, call pool.RunnerCall) (bool, e
 }
 
 func sendToRunner(call pool.RunnerCall, protocolClient pb.RunnerProtocol_EngageClient) error {
-	bodyReader := call.Request().Body
+	bodyReader := call.RequestBody()
 	writeBufferSize := 10 * 1024 // 10KB
 	writeBuffer := make([]byte, writeBufferSize)
 	for {

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -203,7 +203,8 @@ func receiveFromRunner(protocolClient pb.RunnerProtocol_EngageClient, c pool.Run
 			}
 			// There should be an EOF following the last packet
 			if _, err := protocolClient.Recv(); err != io.EOF {
-				logrus.Errorf("Did not receive expected EOF from runner stream: %v", err)
+				logrus.WithError(err).Error("Did not receive expected EOF from runner stream")
+				done <- err
 			}
 			close(done)
 			return

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -42,7 +42,7 @@ type Runner interface {
 // processed by a RunnerPool
 type RunnerCall interface {
 	SlotDeadline() time.Time
-	Request() *http.Request
+	RequestBody() io.ReadCloser
 	ResponseWriter() http.ResponseWriter
 	StdErr() io.ReadWriteCloser
 	Model() *models.Call


### PR DESCRIPTION
The GRPC stream will terminate with an io.EOF; ensure that we consume this in the client code.

Whilst we're at it, the RunnerCall interface strictly only requires a ReadCloser rather than the full httpRequest - the remainder of that request has been extracted into a model.Call at the point this is used.

These changes (a) make the grpc client code correct, and (b) refactor the Runner interface slightly in order that it can be reused from a command-line client.