### PR TITLE
fn: update minimum docker version required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The fastest way to experience Fn is to follow the quickstart below, or you can j
 
 ### Pre-requisites
 
-* Docker 17.06 or later installed and running
+* Docker 17.10.0-ce or later installed and running
 * A Docker Hub account ([Docker Hub](https://hub.docker.com/)) (or other Docker-compliant registry)
 * Log Docker into your Docker Hub account: `docker login`
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -46,7 +46,7 @@ const (
 func NewAgentConfig() (*AgentConfig, error) {
 
 	cfg := &AgentConfig{
-		MinDockerVersion: "17.06.0-ce",
+		MinDockerVersion: "17.10.0-ce",
 		MaxLogSize:       1 * 1024 * 1024,
 	}
 


### PR DESCRIPTION
Oracle Linux 7.4 backported versions still having issues
with freezing/terminating containers. 17.10.0-ce seems like
a resonable lowest common denominator.