### PR TITLE
fn: handleCallEnd and submit improvements

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -238,37 +238,67 @@ func (a *agent) submit(ctx context.Context, call *call) error {
 
 	slot, err := a.getSlot(ctx, call)
 	if err != nil {
-		handleStatsDequeue(ctx, err)
-		return transformTimeout(err, true)
+		return a.handleCallEnd(ctx, call, slot, err, false)
 	}
-	defer slot.Close(ctx) // notify our slot is free once we're done
 
 	err = call.Start(ctx)
 	if err != nil {
-		handleStatsDequeue(ctx, err)
-		return transformTimeout(err, true)
+		return a.handleCallEnd(ctx, call, slot, err, false)
 	}
 
 	statsDequeueAndStart(ctx)
 
 	// pass this error (nil or otherwise) to end directly, to store status, etc
 	err = slot.exec(ctx, call)
-	handleStatsEnd(ctx, err)
-	a.handleCallEnd(ctx, call, err)
-	return transformTimeout(err, false)
+	return a.handleCallEnd(ctx, call, slot, err, true)
 }
 
-func (a *agent) handleCallEnd(ctx context.Context, call *call, err error) {
-	a.wg.Add(1)
-	atomic.AddInt64(&a.callEndCount, 1)
-	go func() {
-		ctx = common.BackgroundContext(ctx)
-		ctx, cancel := context.WithTimeout(ctx, a.cfg.CallEndTimeout)
-		call.End(ctx, err)
-		cancel()
-		atomic.AddInt64(&a.callEndCount, -1)
-		a.wg.Done()
-	}()
+func (a *agent) handleCallEnd(ctx context.Context, call *call, slot Slot, err error, isCommitted bool) error {
+
+	// For hot-containers, slot close is a simple channel close... No need
+	// to handle it async. Execute it here ASAP
+	if slot != nil && protocol.IsStreamable(protocol.Protocol(call.Format)) {
+		slot.Close(ctx)
+		slot = nil
+	}
+
+	// This means call has succeeded, in order to reduce latency here
+	// we perform most of these tasks in go-routine asynchronously.
+	if isCommitted {
+		a.wg.Add(1)
+		atomic.AddInt64(&a.callEndCount, 1)
+		go func() {
+			ctx = common.BackgroundContext(ctx)
+			if slot != nil {
+				slot.Close(ctx) // (no timeout)
+			}
+			ctx, cancel := context.WithTimeout(ctx, a.cfg.CallEndTimeout)
+			call.End(ctx, err)
+			cancel()
+			atomic.AddInt64(&a.callEndCount, -1)
+			a.wg.Done()
+		}()
+
+		handleStatsEnd(ctx, err)
+		return transformTimeout(err, false)
+	}
+
+	// The call did not succeed. And it is retriable. We close the slot
+	// ASAP in the background if we haven't already done so (cold-container case),
+	// in order to keep latency down.
+	if slot != nil {
+		a.wg.Add(1)
+		atomic.AddInt64(&a.callEndCount, 1)
+		go func() {
+			ctx = common.BackgroundContext(ctx)
+			slot.Close(ctx) // (no timeout)
+			atomic.AddInt64(&a.callEndCount, -1)
+			a.wg.Done()
+		}()
+	}
+
+	handleStatsDequeue(ctx, err)
+	return transformTimeout(err, true)
 }
 
 func transformTimeout(e error, isRetriable bool) error {
@@ -522,10 +552,6 @@ func (s *coldSlot) exec(ctx context.Context, call *call) error {
 
 func (s *coldSlot) Close(ctx context.Context) error {
 	if s.cookie != nil {
-		// call this from here so that in exec we don't have to eat container
-		// removal latency
-		// NOTE ensure container removal, no ctx timeout
-		ctx = common.BackgroundContext(ctx)
 		s.cookie.Close(ctx)
 	}
 	if s.tok != nil {

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -448,14 +448,6 @@ func TestSubmitError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error but got none")
 	}
-
-	if cm.Status != "error" {
-		t.Fatal("expected status to be set to 'error' but was", cm.Status)
-	}
-
-	if cm.Error == "" {
-		t.Fatal("expected error string to be set on call")
-	}
 }
 
 // this implements io.Reader, but importantly, is not a strings.Reader or

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -57,7 +57,9 @@ func (sp *naivePlacer) PlaceCall(rp pool.RunnerPool, ctx context.Context, call p
 			// backoff
 			select {
 			case <-ctx.Done():
+				return models.ErrCallTimeoutServerBusy
 			case <-timeout:
+				return models.ErrCallTimeoutServerBusy
 			case <-time.After(minDuration(retryWaitInterval, remaining)):
 			}
 		}

--- a/test/fn-api-tests/exec_test.go
+++ b/test/fn-api-tests/exec_test.go
@@ -314,11 +314,19 @@ func TestCanWriteLogs(t *testing.T) {
 	}
 
 	// TODO this test is redundant we have 3 tests for this?
-	_, err := s.Client.Operations.GetAppsAppCallsCallLog(cfg)
-	if err != nil {
-		t.Error(err.Error())
-	}
+	retryErr := APICallWithRetry(t, 10, time.Second*2, func() (err error) {
+		_, err = s.Client.Operations.GetAppsAppCallsCallLog(cfg)
+		return err
+	})
 
+	if retryErr != nil {
+		t.Error(retryErr.Error())
+	} else {
+		_, err := s.Client.Operations.GetAppsAppCallsCallLog(cfg)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
 }
 
 func TestOversizedLog(t *testing.T) {
@@ -353,10 +361,18 @@ func TestOversizedLog(t *testing.T) {
 		Context: s.Context,
 	}
 
-	logObj, err := s.Client.Operations.GetAppsAppCallsCallLog(cfg)
-	if err != nil {
-		t.Error(err.Error())
+	retryErr := APICallWithRetry(t, 10, time.Second*2, func() (err error) {
+		_, err = s.Client.Operations.GetAppsAppCallsCallLog(cfg)
+		return err
+	})
+
+	if retryErr != nil {
+		t.Error(retryErr.Error())
 	} else {
+		logObj, err := s.Client.Operations.GetAppsAppCallsCallLog(cfg)
+		if err != nil {
+			t.Error(err.Error())
+		}
 		log := logObj.Payload.Log.Log
 		if len(log) >= size {
 			t.Errorf("Log entry suppose to be truncated up to expected size %v, got %v",


### PR DESCRIPTION
*) This simplifies submit() function but moves the burden
of retriable-versus-committed request handling and slot.Close()
responsibility to handleCallEnd().
*) handleCallEnd() related test fixes.