### PR TITLE
fn: datastore dial retry should be configurable

### DIFF
--- a/api_test.sh
+++ b/api_test.sh
@@ -51,6 +51,7 @@ esac
 #fi
 #pwd
 #./fn-api-tests.test -test.v  -test.parallel ${2:-1} ./...; cd ../../
+export FN_DS_DB_PING_MAX_RETRIES=60
 cd test/fn-api-tests && FN_API_URL="http://localhost:8080"  FN_DB_URL=${FN_DB_URL} go test -v  -parallel ${2:-1} ./...; cd ../../
 
 remove_containers

--- a/api_test.sh
+++ b/api_test.sh
@@ -19,7 +19,6 @@ case "$1" in
     MYSQL_HOST=`host ${DB_CONTAINER}`
     MYSQL_PORT=3306
     export FN_DB_URL="mysql://root:root@tcp(${MYSQL_HOST}:${MYSQL_PORT})/funcs"
-    wait_for_db ${MYSQL_HOST} ${MYSQL_PORT} 5
     ;;
 
     "postgres" )
@@ -29,7 +28,6 @@ case "$1" in
     POSTGRES_HOST=`host ${DB_CONTAINER}`
     POSTGRES_PORT=5432
     export FN_DB_URL="postgres://postgres:root@${POSTGRES_HOST}:${POSTGRES_PORT}/funcs?sslmode=disable"
-    wait_for_db ${POSTGRES_HOST} ${POSTGRES_PORT} 5
     ;;
 esac
 

--- a/helpers.sh
+++ b/helpers.sh
@@ -25,20 +25,3 @@ function remove_containers {
     docker rm -fv func-mysql-test 2>/dev/null || true
     docker rm -fv func-minio-test 2>/dev/null || true
 }
-
-function wait_for_db {
-  HOST="$1"
-  PORT="$2"
-  TIMEOUT="$3"
-  for i in `seq ${TIMEOUT}` ; do
-    ! nc -w 1 -z "${HOST}" "${PORT}" > /dev/null 2>&1
-    result=$?
-    if [ $result -ne 0 ] ; then
-      echo "DB listening on ${HOST}:${PORT}"
-      return
-    fi
-    sleep 1
-  done
-  echo "Failed to connect to DB on ${HOST}:${PORT}"
-  exit 1
-}

--- a/system_test.sh
+++ b/system_test.sh
@@ -24,7 +24,6 @@ case "$1" in
     MYSQL_HOST=`host ${DB_CONTAINER}`
     MYSQL_PORT=3307
     export FN_DB_URL="mysql://root:root@tcp(${MYSQL_HOST}:${MYSQL_PORT})/funcs"
-    wait_for_db ${MYSQL_HOST} ${MYSQL_PORT} 5
     ;;
 
     "postgres" )
@@ -34,7 +33,6 @@ case "$1" in
     POSTGRES_HOST=`host ${DB_CONTAINER}`
     POSTGRES_PORT=5433
     export FN_DB_URL="postgres://postgres:root@${POSTGRES_HOST}:${POSTGRES_PORT}/funcs?sslmode=disable"
-    wait_for_db ${POSTGRES_HOST} ${POSTGRES_PORT} 5
     ;;
 esac
 

--- a/system_test.sh
+++ b/system_test.sh
@@ -39,7 +39,8 @@ case "$1" in
 esac
 
 # avoid port conflicts with api_test.sh which are run in parallel
-FN_API_URL="http://localhost:8085"
+export FN_API_URL="http://localhost:8085"
+export FN_DS_DB_PING_MAX_RETRIES=60
 cd test/fn-system-tests && FN_DB_URL=${FN_DB_URL} FN_API_URL=${FN_API_URL} go test -v -parallel ${2:-1} ./...; cd ../../
 
 remove_system_containers


### PR DESCRIPTION
Setting this to high (60) in api and system tests.