### PR TITLE
fn: lb_agent_test tweak

### DIFF
--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -201,7 +201,7 @@ func TestSpilloverToSecondRunner(t *testing.T) {
 
 func TestEnforceSlotTimeout(t *testing.T) {
 	placer := pool.NewNaivePlacer()
-	rp := setupMockRunnerPool([]string{"171.19.0.1", "171.19.0.2"}, 10*time.Millisecond, 2)
+	rp := setupMockRunnerPool([]string{"171.19.0.1", "171.19.0.2"}, 10*time.Millisecond, 1)
 
 	parallelCalls := 5
 	var wg sync.WaitGroup


### PR DESCRIPTION
Time.Sleep() blocking fixes in placers (naive and ch) improves
some of the timing in processing, therefore reducing the max
calls settings in mock runner pool.