### PR TITLE
try out the pipe yes trick

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker login -u $DOCKER_USER -p $DOCKER_PASS | y
               git config --global user.email "ci@fnproject.com"
               git config --global user.name "CI"
               git branch --set-upstream-to=origin/${CIRCLE_BRANCH} ${CIRCLE_BRANCH}


### PR DESCRIPTION
build is broken on master from docker 18.04 to do releases (branch builds still work)

```
#!/bin/bash -eo pipefail
if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
  docker login -u $DOCKER_USER -p $DOCKER_PASS
  git config --global user.email "ci@fnproject.com"
  git config --global user.name "CI"
  git branch --set-upstream-to=origin/${CIRCLE_BRANCH} ${CIRCLE_BRANCH}
  if [[ -n "$DIND_NEEDED" ]]; then
    make release-dind
  fi
  if [[ -n "$FN_NEEDED" ]]; then
    make release-fnserver
  fi
fi

WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/circleci/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Are you sure you want to proceed? [y/N] User refused unencrypted credentials storage.
Exited with code 1
```

this might be quick and dirty fix. we should probably upgrade to an encrypted password i guess.