### PR TITLE
Fix docker login syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              printenv DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               git config --global user.email "ci@fnproject.com"
               git config --global user.name "CI"
               git branch --set-upstream-to=origin/${CIRCLE_BRANCH} ${CIRCLE_BRANCH}


### PR DESCRIPTION
With docker 18.04 the behaviour of a documented interface has changed from 18.03 -
to wit, you need to use a specific noninteractive mode of `docker login` to avoid
being prompted about insecure credential storage.