### PR TITLE
Call filter by status

### DIFF
--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -863,6 +863,9 @@ func buildFilterCallQuery(filter *models.CallFilter) (string, []interface{}) {
 	}
 	where("app_id=", filter.AppID)
 	where("path=", filter.Path)
+	if filter.Status != "" {
+		where("status=", filter.Status)
+	}
 
 	fmt.Fprintf(&b, ` ORDER BY id DESC`) // TODO assert this is indexed
 	fmt.Fprintf(&b, ` LIMIT ?`)

--- a/api/logs/mock.go
+++ b/api/logs/mock.go
@@ -79,6 +79,7 @@ func (m *mock) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*mode
 
 		if (filter.AppID == "" || c.AppID == filter.AppID) &&
 			(filter.Path == "" || filter.Path == c.Path) &&
+			(filter.Status == "" || filter.Status == c.Status) &&
 			(time.Time(filter.FromTime).IsZero() || time.Time(filter.FromTime).Before(time.Time(c.CreatedAt))) &&
 			(time.Time(filter.ToTime).IsZero() || time.Time(c.CreatedAt).Before(time.Time(filter.ToTime))) &&
 			(filter.Cursor == "" || strings.Compare(filter.Cursor, c.ID) > 0) {

--- a/api/logs/s3/s3.go
+++ b/api/logs/s3/s3.go
@@ -403,8 +403,12 @@ func (s *store) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*mod
 		if !toTime.IsZero() && !time.Time(call.CreatedAt).Before(toTime) {
 			continue
 		}
-
-		calls = append(calls, call)
+		// ensure: append the call object only if status is not an filter.Status
+		// is not an empty string and the call object match filter.Status
+		// todo: maybe there's a way to filter objects by content in S3?
+		if filter.Status == "" || filter.Status == call.Status {
+			calls = append(calls, call)
+		}
 	}
 
 	return calls, nil

--- a/api/logs/testing/test.go
+++ b/api/logs/testing/test.go
@@ -62,6 +62,15 @@ func Test(t *testing.T, fnl models.LogStore) {
 			t.Fatalf("Test GetCalls(ctx, filter): unexpected length `%v`", len(calls))
 		}
 
+		statusFilter := &models.CallFilter{AppID: call.AppID, Path: call.Path, PerPage: 100, Status: "error"}
+		newCalls, err := fnl.GetCalls(ctx, statusFilter)
+		if err != nil {
+			t.Fatalf("Test GetCalls(ctx, filter): unexpected error `%v`", err)
+		}
+		if len(newCalls) == 1 {
+			t.Fatalf("Test GetCalls(ctx, filter): unexpected length `%v` while filtering by status", len(newCalls))
+		}
+
 		c2 := *call
 		c3 := *call
 		now = time.Now().Add(100 * time.Millisecond)

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -145,6 +145,7 @@ type Call struct {
 type CallFilter struct {
 	Path     string // match
 	AppID    string // match
+	Status   string
 	FromTime strfmt.DateTime
 	ToTime   strfmt.DateTime
 	Cursor   string

--- a/api/server/call_list.go
+++ b/api/server/call_list.go
@@ -17,7 +17,7 @@ func (s *Server) handleCallList(c *gin.Context) {
 
 	appID := c.MustGet(api.AppID).(string)
 	// TODO api.CRoute needs to be escaped probably, since it has '/' a lot
-	filter := models.CallFilter{AppID: appID, Path: c.Query("path")}
+	filter := models.CallFilter{AppID: appID, Path: c.Query("path"), Status: c.Query("status")}
 	filter.Cursor, filter.PerPage = pageParams(c, false) // ids are url safe
 
 	filter.FromTime, filter.ToTime, err = timeParams(c)

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: fn
   description: The open source serverless platform.
-  version: "0.2.4"
+  version: "0.2.5"
 # the domain of the service
 host: "127.0.0.1:8080"
 # array of all schemes that your API supports
@@ -455,6 +455,10 @@ paths:
           description: Unix timestamp in seconds, of call.created_at to end the results at, defaults to latest.
           required: false
           type: integer
+          in: query
+        - name: status
+          description: call status filtering option
+          required: false
           in: query
       responses:
         200:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -457,8 +457,9 @@ paths:
           type: integer
           in: query
         - name: status
-          description: call status filtering option
+          description: Call status filtering option.
           required: false
+          type: string
           in: query
       responses:
         200:


### PR DESCRIPTION
    Allow call be filtered by status
    
     - new call(s) filter attribute - status
    
     The simplest way to get the number of calls grouped by one status,
     at this moment we have to do so on client side,
     which makes developers do pagination along with iterative filtering by status.
    
     This patch adds new filtering option supported by both calls API implementations (and mock of course).
