### PR TITLE
Fix missing values in context created with common.BackgroundContext

### DIFF
--- a/api_test.sh
+++ b/api_test.sh
@@ -15,7 +15,7 @@ case "$1" in
     "mysql" )
     DB_CONTAINER="func-mysql-test"
     docker rm -fv ${DB_CONTAINER} || echo No prev mysql test db container
-    docker run --name ${DB_CONTAINER} -p 3306:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql
+    docker run --name ${DB_CONTAINER} -p 3306:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql:5.7.22
     MYSQL_HOST=`host ${DB_CONTAINER}`
     MYSQL_PORT=3306
     export FN_DB_URL="mysql://root:root@tcp(${MYSQL_HOST}:${MYSQL_PORT})/funcs"

--- a/system_test.sh
+++ b/system_test.sh
@@ -20,7 +20,7 @@ case "$1" in
     "mysql" )
     DB_CONTAINER="func-mysql-system-test"
     docker rm -fv ${DB_CONTAINER} || echo No prev mysql test db container
-    docker run --name ${DB_CONTAINER} -p 3307:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql
+    docker run --name ${DB_CONTAINER} -p 3307:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql:5.7.22
     MYSQL_HOST=`host ${DB_CONTAINER}`
     MYSQL_PORT=3307
     export FN_DB_URL="mysql://root:root@tcp(${MYSQL_HOST}:${MYSQL_PORT})/funcs"

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ source ./helpers.sh
 remove_containers
 
 docker run --name func-postgres-test -e "POSTGRES_DB=funcs" -e "POSTGRES_PASSWORD=root" -p 5432:5432 -d postgres:9.3-alpine
-docker run --name func-mysql-test -p 3306:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql
+docker run --name func-mysql-test -p 3306:3306 -e MYSQL_DATABASE=funcs -e MYSQL_ROOT_PASSWORD=root -d mysql:5.7.22
 docker run -d -p 9000:9000 --name func-minio-test -e "MINIO_ACCESS_KEY=admin" -e "MINIO_SECRET_KEY=password" minio/minio server /data
 
 MYSQL_HOST=`host func-mysql-test`


### PR DESCRIPTION
Fix missing values in context created with common.BackgroundContext by using delegation to previous context (only for Value()).

Fixes #949 .