### PR TITLE
Last middleware should use the request passed by preceding middleware.

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -93,7 +93,7 @@ func (s *Server) runMiddleware(c *gin.Context, ms []fnext.Middleware) {
 			c.Abort()
 			return
 		}
-		c.Request = c.Request.WithContext(ctx)
+		c.Request = r.WithContext(ctx)
 		c.Next()
 	})
 


### PR DESCRIPTION
When we chain middlewares, the last middleware does not use the request passed by the preceding middleware. If the preceding middleware read httpRequest.Body and set a new io.ReadCloser to httpRequest.Body, the last middleware will not see this.

This change is useful when some middleware reads httpRequest.Body to
perform some logic, and assigns a new ReadCloser to httpRequest.Body
(as body can be read only once). One example is authentication middleware that needs to read the body to validate signature.