### PR TITLE
add user syslog writers to app

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"log/syslog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -669,8 +671,21 @@ func (s *hotSlot) exec(ctx context.Context, call *call) error {
 	// buffering overflows (json to a string, http to a buffer, etc)
 	stdoutWrite := common.NewClampWriter(stdoutWritePipe, s.maxRespSize, models.ErrFunctionResponseTooBig)
 
+	// get our own syslogger with THIS call id (cheap), using the container's already open syslog conns (expensive)
+	// TODO? we can basically just do this whether there are conns or not, this is relatively cheap (despite appearances)
+	buf1 := bufPool.Get().(*bytes.Buffer)
+	buf2 := bufPool.Get().(*bytes.Buffer)
+	defer bufPool.Put(buf1)
+	defer bufPool.Put(buf2)
+
+	sw := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_ERR, s.container.syslogConns, buf1)
+	var syslog io.WriteCloser = &nopCloser{sw}
+	syslog = newLineWriterWithBuffer(buf2, syslog)
+	defer syslog.Close()                            // close syslogger from here, but NOT the call log stderr OR conns
+	stderr := multiWriteCloser{call.stderr, syslog} // use multiWriteCloser for its error ignoring properties
+
 	proto := protocol.New(protocol.Protocol(call.Format), stdinWrite, stdoutRead)
-	swapBack := s.container.swap(stdinRead, stdoutWrite, call.stderr, &call.Stats)
+	swapBack := s.container.swap(stdinRead, stdoutWrite, stderr, &call.Stats)
 	defer swapBack() // NOTE: it's important this runs before the pipes are closed.
 
 	errApp := make(chan error, 1)
@@ -757,7 +772,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 	state.UpdateState(ctx, ContainerStateStart, call.slots)
 	defer state.UpdateState(ctx, ContainerStateDone, call.slots)
 
-	container, closer := NewHotContainer(call, &a.cfg)
+	container, closer := NewHotContainer(ctx, call, &a.cfg)
 	defer closer()
 
 	logger := logrus.WithFields(logrus.Fields{"id": container.id, "app_id": call.AppID, "route": call.Path, "image": call.Image, "memory": call.Memory, "cpus": call.CPUs, "format": call.Format, "idle_timeout": call.IdleTimeout})
@@ -923,17 +938,17 @@ type container struct {
 	fsSize  uint64
 	timeout time.Duration // cold only (superfluous, but in case)
 
-	stdin  io.Reader
-	stdout io.Writer
-	stderr io.Writer
+	stdin       io.Reader
+	stdout      io.Writer
+	stderr      io.Writer
+	syslogConns io.WriteCloser
 
-	// lock protects the stats swapping
-	statsMu sync.Mutex
-	stats   *drivers.Stats
+	// swapMu protects the stats swapping
+	swapMu sync.Mutex
+	stats  *drivers.Stats
 }
 
-func NewHotContainer(call *call, cfg *AgentConfig) (*container, func()) {
-
+func NewHotContainer(ctx context.Context, call *call, cfg *AgentConfig) (*container, func()) {
 	// if freezer is enabled, be consistent with freezer behavior and
 	// block stdout and stderr between calls.
 	isBlockIdleIO := MaxDisabledMsecs != cfg.FreezeIdle
@@ -944,34 +959,73 @@ func NewHotContainer(call *call, cfg *AgentConfig) (*container, func()) {
 	stderr := common.NewGhostWriter()
 	stdout := common.NewGhostWriter()
 
+	// these are only the conns, this doesn't write the syslog format (since it will change between calls)
+	syslogConns, err := syslogConns(ctx, call.SyslogURL)
+	if err != nil {
+		// TODO we could write this to between stderr but between stderr doesn't go to user either. kill me.
+		logrus.WithError(err).WithFields(logrus.Fields{"app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}).Error("error dialing syslog urls")
+	}
+
+	// for use if no freezer (or we ever make up our minds)
+	var bufs []*bytes.Buffer
+
 	// when not processing a request, do we block IO?
 	if !isBlockIdleIO {
 		// IMPORTANT: we are not operating on a TTY allocated container. This means, stderr and stdout are multiplexed
 		// from the same stream internally via docker using a multiplexing protocol. Therefore, stderr/stdout *BOTH*
 		// have to be read or *BOTH* blocked consistently. In other words, we cannot block one and continue
 		// reading from the other one without risking head-of-line blocking.
-		stderr.Swap(newLineWriter(&logWriter{
-			logrus.WithFields(logrus.Fields{"tag": "stderr", "app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}),
-		}))
-		stdout.Swap(newLineWriter(&logWriter{
+
+		// wrap the syslog and debug loggers in the same (respective) line writer
+		// syslog complete chain for this (from top):
+		// stderr -> line writer -> syslog -> []conns
+
+		// TODO(reed): I guess this is worth it
+		// TODO(reed): there's a bug here where the between writers could have
+		// bytes in there, get swapped for real stdout/stderr, come back and write
+		// bytes in and the bytes are [really] stale. I played with fixing this
+		// and mostly came to the conclusion that life is meaningless.
+		buf1 := bufPool.Get().(*bytes.Buffer)
+		buf2 := bufPool.Get().(*bytes.Buffer)
+		buf3 := bufPool.Get().(*bytes.Buffer)
+		buf4 := bufPool.Get().(*bytes.Buffer)
+		bufs = []*bytes.Buffer{buf1, buf2, buf3, buf4}
+
+		// stdout = LOG_INFO, stderr = LOG_ERR -- ONLY for the between writers, normal stdout is a response
+		so := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_INFO, syslogConns, buf1)
+		se := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_ERR, syslogConns, buf2)
+
+		// use multiWriteCloser since it ignores errors (io.MultiWriter does not)
+		soc := multiWriteCloser{&nopCloser{so}, &nopCloser{&logWriter{
 			logrus.WithFields(logrus.Fields{"tag": "stdout", "app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}),
-		}))
+		}}}
+		sec := multiWriteCloser{&nopCloser{se}, &nopCloser{&logWriter{
+			logrus.WithFields(logrus.Fields{"tag": "stderr", "app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}),
+		}}}
+
+		stdout.Swap(newLineWriterWithBuffer(buf4, soc))
+		stderr.Swap(newLineWriterWithBuffer(buf3, sec))
 	}
 
 	return &container{
-			id:     id, // XXX we could just let docker generate ids...
-			image:  call.Image,
-			env:    map[string]string(call.Config),
-			memory: call.Memory,
-			cpus:   uint64(call.CPUs),
-			fsSize: cfg.MaxFsSize,
-			stdin:  stdin,
-			stdout: stdout,
-			stderr: stderr,
+			id:          id, // XXX we could just let docker generate ids...
+			image:       call.Image,
+			env:         map[string]string(call.Config),
+			memory:      call.Memory,
+			cpus:        uint64(call.CPUs),
+			fsSize:      cfg.MaxFsSize,
+			stdin:       stdin,
+			stdout:      stdout,
+			stderr:      stderr,
+			syslogConns: syslogConns,
 		}, func() {
 			stdin.Close()
 			stderr.Close()
 			stdout.Close()
+			for _, b := range bufs {
+				bufPool.Put(b)
+			}
+			syslogConns.Close()
 		}
 }
 
@@ -981,18 +1035,18 @@ func (c *container) swap(stdin io.Reader, stdout, stderr io.Writer, cs *drivers.
 	ostdout := c.stdout.(common.GhostWriter).Swap(stdout)
 	ostderr := c.stderr.(common.GhostWriter).Swap(stderr)
 
-	c.statsMu.Lock()
+	c.swapMu.Lock()
 	ocs := c.stats
 	c.stats = cs
-	c.statsMu.Unlock()
+	c.swapMu.Unlock()
 
 	return func() {
 		c.stdin.(common.GhostReader).Swap(ostdin)
 		c.stdout.(common.GhostWriter).Swap(ostdout)
 		c.stderr.(common.GhostWriter).Swap(ostderr)
-		c.statsMu.Lock()
+		c.swapMu.Lock()
 		c.stats = ocs
-		c.statsMu.Unlock()
+		c.swapMu.Unlock()
 	}
 }
 
@@ -1016,11 +1070,11 @@ func (c *container) WriteStat(ctx context.Context, stat drivers.Stat) {
 		stats.Record(ctx, stats.FindMeasure("docker_stats_"+key).(*stats.Int64Measure).M(int64(value)))
 	}
 
-	c.statsMu.Lock()
+	c.swapMu.Lock()
 	if c.stats != nil {
 		*(c.stats) = append(*(c.stats), stat)
 	}
-	c.statsMu.Unlock()
+	c.swapMu.Unlock()
 }
 
 func init() {

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -336,8 +336,8 @@ func TestAsyncCallHeaders(t *testing.T) {
 func TestLoggerIsStringerAndWorks(t *testing.T) {
 	// TODO test limit writer, logrus writer, etc etc
 
-	loggyloo := logrus.WithFields(logrus.Fields{"yodawg": true})
-	logger := setupLogger(loggyloo, 1*1024*1024)
+	var call models.Call
+	logger := setupLogger(context.Background(), 1*1024*1024, &call)
 
 	if _, ok := logger.(fmt.Stringer); !ok {
 		// NOTE: if you are reading, maybe what you've done is ok, but be aware we were relying on this for optimization...
@@ -360,8 +360,8 @@ func TestLoggerIsStringerAndWorks(t *testing.T) {
 
 func TestLoggerTooBig(t *testing.T) {
 
-	loggyloo := logrus.WithFields(logrus.Fields{"yodawg": true})
-	logger := setupLogger(loggyloo, 10)
+	var call models.Call
+	logger := setupLogger(context.Background(), 10, &call)
 
 	str := fmt.Sprintf("0 line\n1 l\n-----max log size 10 bytes exceeded, truncating log-----\n")
 

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -287,6 +287,8 @@ func getSlotQueueKey(call *call) string {
 
 	hash.Write(unsafeBytes(call.AppID))
 	hash.Write(unsafeBytes("\x00"))
+	hash.Write(unsafeBytes(call.SyslogURL))
+	hash.Write(unsafeBytes("\x00"))
 	hash.Write(unsafeBytes(call.Path))
 	hash.Write(unsafeBytes("\x00"))
 	hash.Write(unsafeBytes(call.Image))

--- a/api/agent/syslog.go
+++ b/api/agent/syslog.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/syslog"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fnproject/fn/api/common"
+)
+
+// syslogConns may return a non-nil io.WriteCloser and an error simultaneously,
+// the error containing any errors from connecting to any of the syslog URLs, and the
+// io.WriteCloser writing to any syslogURLs that were successfully connected to.
+// the returned io.WriteCloser is a Writer to each conn, it should be wrapped in another
+// writer that writes syslog formatted messages (by line).
+func syslogConns(ctx context.Context, syslogURLs string) (io.WriteCloser, error) {
+	if len(syslogURLs) == 0 {
+		return nullReadWriter{}, nil
+	}
+
+	// gather all the conns, re-use the line we make in the syslogWriter
+	// to write the same bytes to each of the conns.
+	var conns []io.WriteCloser
+	var errs []error
+
+	sinks := strings.Split(syslogURLs, ",")
+	for _, s := range sinks {
+		conn, err := dialSyslog(ctx, strings.TrimSpace(s))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to setup remote syslog connection to %v: %v", s, err))
+			continue
+		}
+
+		conns = append(conns, conn)
+	}
+
+	// do this before checking length of conns
+	var err error
+	if len(errs) > 0 {
+		for _, e := range errs {
+			err = fmt.Errorf("%v%v, ", err, e)
+		}
+	}
+
+	if len(conns) == 0 {
+		return nullReadWriter{}, err
+	}
+
+	return multiWriteCloser(conns), err
+}
+
+func dialSyslog(ctx context.Context, syslogURL string) (io.WriteCloser, error) {
+	url, err := url.Parse(syslogURL)
+	if err != nil {
+		return nil, err
+	}
+
+	common.Logger(ctx).WithField("syslog_url", url).Debug("dialing syslog url")
+
+	var dialer net.Dialer
+	deadline, ok := ctx.Deadline()
+	if ok {
+		dialer.Deadline = deadline
+	}
+
+	// slice off 'xxx://' and dial it
+	switch url.Scheme {
+	case "udp", "tcp":
+		return dialer.Dial(url.Scheme, syslogURL[6:])
+	case "tls":
+		return tls.DialWithDialer(&dialer, "tcp", syslogURL[6:], nil)
+	default:
+		return nil, fmt.Errorf("Unsupported scheme, please use {tcp|udp|tls}: %s: ", url.Scheme)
+	}
+}
+
+// syslogWriter prepends a syslog format with call-specific details
+// for each data segment provided in Write(). This doesn't use
+// log/syslog pkg because we do not need pid for every line (expensive),
+// and we have a format that is easier to read than hiding in preamble.
+// this writes logfmt formatted syslog with values for call, function, and
+// app, it is up to the user to use logfmt from their functions to get a
+// fully formatted line out.
+// TODO not pressing, but we could support json & other formats, too, upon request.
+type syslogWriter struct {
+	pres  []byte
+	post  []byte
+	b     *bytes.Buffer
+	clock func() time.Time
+
+	// the syslog conns (presumably)
+	io.Writer
+}
+
+const severityMask = 0x07
+const facilityMask = 0xf8
+
+func newSyslogWriter(call, function, app string, severity syslog.Priority, wc io.Writer, buf *bytes.Buffer) *syslogWriter {
+	// Facility = LOG_USER
+	pr := (syslog.LOG_USER & facilityMask) | (severity & severityMask)
+
+	// <priority>VERSION ISOTIMESTAMP HOSTNAME APPLICATION PID      MESSAGEID STRUCTURED-DATA MSG
+	//
+	// and for us:
+	// <22>2             ISOTIMESTAMP fn       appID       funcName callID    -               MSG
+	// ex:
+	//<11>2 2018-02-31T07:42:21Z Fn - - - -  call_id=123 func_name=rdallman/yodawg app_id=123 loggo hereo
+
+	// TODO we could use json for structured data and do that whole thing. up to whoever.
+	return &syslogWriter{
+		pres:   []byte(fmt.Sprintf(`<%d>2`, pr)),
+		post:   []byte(fmt.Sprintf(`fn - - - - call_id=%s func_name=%s app_id=%s `, call, function, app)),
+		b:      buf,
+		Writer: wc,
+		clock:  time.Now,
+	}
+}
+
+func (sw *syslogWriter) Write(p []byte) (int, error) {
+	// re-use buffer to write in timestamp hodge podge and reduce writes to
+	// the conn by buffering a whole line here before writing to conn.
+
+	buf := sw.b
+	buf.Reset()
+	buf.Write(sw.pres)
+	buf.WriteString(" ")
+	buf.WriteString(sw.clock().UTC().Format(time.RFC3339))
+	buf.WriteString(" ")
+	buf.Write(sw.post)
+	buf.Write(p)
+	n, err := io.Copy(sw.Writer, buf)
+	return int(n), err
+}

--- a/api/agent/syslog.go
+++ b/api/agent/syslog.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/fnproject/fn/api/common"
+	"go.opencensus.io/trace"
 )
 
 // syslogConns may return a non-nil io.WriteCloser and an error simultaneously,
@@ -21,6 +22,10 @@ import (
 // the returned io.WriteCloser is a Writer to each conn, it should be wrapped in another
 // writer that writes syslog formatted messages (by line).
 func syslogConns(ctx context.Context, syslogURLs string) (io.WriteCloser, error) {
+	// TODO(reed): we should likely add a trace per conn, need to plumb tagging better
+	ctx, span := trace.StartSpan(ctx, "syslog_conns")
+	defer span.End()
+
 	if len(syslogURLs) == 0 {
 		return nullReadWriter{}, nil
 	}

--- a/api/agent/syslog_test.go
+++ b/api/agent/syslog_test.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"bytes"
+	"log/syslog"
+	"testing"
+	"time"
+)
+
+func TestSyslogFormat(t *testing.T) {
+	var b1 bytes.Buffer
+	var b2 bytes.Buffer
+
+	call := "12345"
+	fn := "yo/dawg"
+	app := "sup"
+	now := time.Date(1982, 6, 25, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	writer := newSyslogWriter(call, fn, app, syslog.LOG_ERR, &nopCloser{&b1}, &b2)
+	writer.clock = clock
+	writer.Write([]byte("yo"))
+
+	gold := `<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/dawg app_id=sup yo`
+
+	if b1.String() != gold {
+		t.Fatal("syslog was not what we expected: ", b1.String())
+	}
+}

--- a/api/datastore/sql/migrations/13_add_syslogurl_app.go
+++ b/api/datastore/sql/migrations/13_add_syslogurl_app.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up13(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE apps ADD syslog_url TEXT;")
+
+	return err
+}
+
+func down13(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE apps DROP COLUMN syslog_url;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(13),
+		UpFunc:      up13,
+		DownFunc:    down13,
+	})
+}

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -125,6 +125,9 @@ type Call struct {
 	// Headers are headers from the request that created this call
 	Headers http.Header `json:"headers,omitempty" db:"-"`
 
+	// SyslogURL is a syslog URL to send all logs to.
+	SyslogURL string `json:"syslog_url,omitempty" db:"-"`
+
 	// Time when call completed, whether it was successul or failed. Always in UTC.
 	CompletedAt strfmt.DateTime `json:"completed_at,omitempty" db:"completed_at"`
 
@@ -140,6 +143,7 @@ type Call struct {
 	// Error is the reason why the call failed, it is only non-empty if
 	// status is equal to "error".
 	Error string `json:"error,omitempty" db:"error"`
+
 	// App this call belongs to.
 	AppID string `json:"app_id" db:"app_id"`
 }

--- a/docs/operating/logging.md
+++ b/docs/operating/logging.md
@@ -24,9 +24,30 @@ Note the easily searchable `call_id=x` format.
 call_id=477949e2-922c-5da9-8633-0b2887b79f6e
 ```
 
-## Metrics
+## Remote syslog for functions
 
-Metrics are emitted via the logs.
+You may add a syslog url to any function application and all functions that
+exist under that application will ship all of their logs to it. You may
+provide a comma separated list, if desired. Currently, we support `tcp`,
+`udp`, and `tls`, and this will not work if behind a proxy [yet?] (this is my
+life now). This feature only works for 'hot' functions.
 
-See [Metrics](metrics.md) doc for more information.
+An example syslog url is:
 
+```
+tls://logs.papertrailapp.com:1
+```
+
+We log in a syslog format, with some variables added in logfmt format. If you
+find logfmt format offensive, please open an issue and we will consider adding
+more formats (or open a PR that does it, with tests, and you will receive 1
+free cookie along with the feature you want). The logs from the functions
+themselves are not formatted, only our pre-amble, thus, if you'd like a fully
+logfmt line, you must use a logfmt logger to log from your function.
+
+* All log lines are sent as level error w/ the current time and `fn` as hostname.
+* call_id, func_name, and app_id will prefix every log line.
+
+```
+<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/yo app_id=54321 this is your log line
+```

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -559,6 +559,9 @@ definitions:
         description: Application annotations - this is a map of annotations attached to this app, keys must not exceed 128 bytes and must consist of non-whitespace printable ascii characters, and the seralized representation of individual values must not exeed 512 bytes
         additionalProperties:
           type: object
+      syslog_url:
+        type: string
+        description: A comma separated list of syslog urls to send all function logs to. supports tls, udp or tcp. e.g. tls://logs.papertrailapp.com:1
       created_at:
         type: string
         format: date-time


### PR DESCRIPTION
users may specify a syslog url[s] on apps now and all functions under that app
will spew their logs out to it. the docs have more information around details
there, please review those (swagger and operating/logging.md), tried to
implement to spec in some parts and improve others, open to feedback on
format though, lots of liberty there.

design decision wise, I am looking to the future and ignoring cold containers.
the overhead of the connections there will not be worth it, so this feature
only works for hot functions, since we're killing cold anyway (even if a user
can just straight up exit a hot container).

syslog connections will be opened against a container when it starts up, and
then the call id that is logged gets swapped out for each call that goes
through the container, this cuts down on the cost of opening/closing
connections significantly. there are buffers to accumulate logs until we get a
`\n` to actually write a syslog line, and a buffer to save some bytes when
we're writing the syslog formatting as well. underneath writers re-use the
line writer in certain scenarios (swapper). we could likely improve the ease
of setting this up, but opening the syslog conns against a container seems
worth it, and is a different path than the other func loggers that we create
when we make a call object. the Close() stuff is a little tricky, not sure how
to make it easier and have the ^ benefits, open to idears.

this does add another vector of 'limits' to consider for more strict service
operators. one being how many syslog urls can a user add to an app (infinite,
atm) and the other being on the order of number of containers per host we
could run out of connections in certain scenarios. there may be some utility
in having multiple syslog sinks to send to, it could help with debugging at
times to send to another destination or if a user is a client w/ someone and
both want the function logs, e.g. (have used this for that in the past,
specifically).

this also doesn't work behind a proxy, which is something i'm open to fixing,
but afaict will require a 3rd party dependency (we can pretty much steal what
docker does). this is mostly of utility for those of us that work behind a
proxy all the time, not really for end users.

there are some unit tests. integration tests for this don't sound very fun to
maintain. I did test against papertrail with each protocol and it works (and
even times out if you're behind a proxy!).

closes #337