### PR TITLE
fn: allow specified docker networks in functions

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -137,6 +137,7 @@ func createAgent(da DataAccess) Agent {
 
 	// TODO: Create drivers.New(runnerConfig)
 	driver := docker.NewDocker(drivers.Config{
+		DockerNetworks:  cfg.DockerNetworks,
 		ServerVersion:   cfg.MinDockerVersion,
 		PreForkPoolSize: cfg.PreForkPoolSize,
 		PreForkImage:    cfg.PreForkImage,

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -10,6 +10,7 @@ import (
 
 type AgentConfig struct {
 	MinDockerVersion        string        `json:"min_docker_version"`
+	DockerNetworks          string        `json:"docker_networks"`
 	FreezeIdle              time.Duration `json:"freeze_idle_msecs"`
 	EjectIdle               time.Duration `json:"eject_idle_msecs"`
 	HotPoll                 time.Duration `json:"hot_poll_msecs"`
@@ -31,6 +32,7 @@ type AgentConfig struct {
 }
 
 const (
+	EnvDockerNetworks          = "FN_DOCKER_NETWORKS"
 	EnvFreezeIdle              = "FN_FREEZE_IDLE_MSECS"
 	EnvEjectIdle               = "FN_EJECT_IDLE_MSECS"
 	EnvHotPoll                 = "FN_HOT_POLL_MSECS"
@@ -82,6 +84,7 @@ func NewAgentConfig() (*AgentConfig, error) {
 	err = setEnvStr(err, EnvPreForkCmd, &cfg.PreForkCmd)
 	err = setEnvUint(err, EnvPreForkUseOnce, &cfg.PreForkUseOnce)
 	err = setEnvStr(err, EnvPreForkNetworks, &cfg.PreForkNetworks)
+	err = setEnvStr(err, EnvDockerNetworks, &cfg.DockerNetworks)
 
 	if err != nil {
 		return cfg, err

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -68,6 +68,41 @@ func TestRunnerDocker(t *testing.T) {
 	}
 }
 
+func TestRunnerDockerNetworks(t *testing.T) {
+	dkr := NewDocker(drivers.Config{
+		DockerNetworks: "test1 test2",
+	})
+
+	ctx := context.Background()
+	var output bytes.Buffer
+	var errors bytes.Buffer
+
+	task1 := &taskDockerTest{"test-docker1", bytes.NewBufferString(`{"isDebug": true}`), &output, &errors}
+	task2 := &taskDockerTest{"test-docker2", bytes.NewBufferString(`{"isDebug": true}`), &output, &errors}
+
+	cookie1, err := dkr.Prepare(ctx, task1)
+	if err != nil {
+		t.Fatal("Couldn't prepare task1 test")
+	}
+	defer cookie1.Close(ctx)
+
+	cookie2, err := dkr.Prepare(ctx, task2)
+	if err != nil {
+		t.Fatal("Couldn't prepare task2 test")
+	}
+	defer cookie2.Close(ctx)
+
+	c1 := cookie1.(*cookie)
+	c2 := cookie2.(*cookie)
+
+	if c1.netId != "test1" {
+		t.Fatalf("cookie1 netId should be %s but it is %s", "test1", c1.netId)
+	}
+	if c2.netId != "test2" {
+		t.Fatalf("cookie2 netId should be %s but it is %s", "test2", c2.netId)
+	}
+}
+
 func TestRunnerDockerVersion(t *testing.T) {
 
 	dkr := NewDocker(drivers.Config{

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -190,7 +190,8 @@ const (
 )
 
 type Config struct {
-	Docker string `json:"docker"`
+	Docker         string `json:"docker"`
+	DockerNetworks string `json:"docker_networks"`
 	// TODO CPUShares should likely be on a per container basis
 	CPUShares       int64  `json:"cpu_shares"`
 	ServerVersion   string `json:"server_version"`


### PR DESCRIPTION
If FN_DOCKER_NETWORK is specified with a list of
networks, then agent driver picks the least used
network to place functions on.