### PR TITLE
fn: docker compose fixups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 version: '3'
+networks:
+  fn-network:
+    name: fn-network
 services:
   logstore:
     hostname: logstore
     image: minio/minio
+    networks:
+      - fn-network
     ports:
       - "9091:9000"
     environment:
@@ -14,6 +19,8 @@ services:
   db:
     image: "mysql:5.7.22"
     restart: always
+    networks:
+      - fn-network
     ports:
       - "3306:3306"
     environment:
@@ -24,6 +31,8 @@ services:
   mq:
     image: "redis"
     restart: always
+    networks:
+      - fn-network
     ports:
       - "6379:6379"
   fnserver:
@@ -33,6 +42,8 @@ services:
       - db
       - logstore
     build: .
+    networks:
+      - fn-network
     ports:
       - "8080:8080"
     links:
@@ -43,12 +54,14 @@ services:
       FN_DB_URL: "mysql://root:root@tcp(db:3306)/funcs"
       FN_MQ_URL: "redis://mq:6379/"
       FN_LOGSTORE_URL: "s3://admin:password@logstore:9000/us-east-1/fnlogs"
-      FN_DOCKER_NETWORKS: "fn_default"
+      FN_DOCKER_NETWORKS: "fn-network"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   grafana:
     image: grafana/grafana
     restart: always
+    networks:
+      - fn-network
     ports:
       - "3000:3000"
     links:
@@ -62,6 +75,8 @@ services:
     restart: always
     depends_on:
       - fnserver
+    networks:
+      - fn-network
     ports:
       - "9090:9090"
     links:
@@ -73,6 +88,8 @@ services:
       - fnserver
     image: fnproject/ui
     restart: always
+    networks:
+      - fn-network
     ports:
       - "4000:4000"
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./data/logstore:/data
     command: server /data
   db:
-    image: "mysql"
+    image: "mysql:5.7.22"
     restart: always
     ports:
       - "3306:3306"
@@ -43,6 +43,7 @@ services:
       FN_DB_URL: "mysql://root:root@tcp(db:3306)/funcs"
       FN_MQ_URL: "redis://mq:6379/"
       FN_LOGSTORE_URL: "s3://admin:password@logstore:9000/us-east-1/fnlogs"
+      FN_DOCKER_NETWORKS: "fn_default"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   grafana:


### PR DESCRIPTION
1) fnserver dind requires privileged mode
2) mysql should be in sync with test.sh/api_test.sh mysql version to avoid errors such as
    msg="couldn't ping db" error="this authentication plugin is not supported" url="root:root@tcp(db:3306)/funcs

TODO: fix/investigate why fnserver fails on latest mysql.