### PR TITLE
Fix to make custom headers work in test CallFN function

### DIFF
--- a/test/fn-api-tests/exec_test.go
+++ b/test/fn-api-tests/exec_test.go
@@ -272,11 +272,11 @@ func TestCallResponseHeadersMatch(t *testing.T) {
 	output := &bytes.Buffer{}
 	CallFN(u.String(), content, output, "POST",
 		[]string{
-			"ACCEPT: application/xml",
-			"ACCEPT: application/json; q=0.2",
+			"ACCEPT=application/xml",
+			"ACCEPT=application/json; q=0.2",
 		})
 	res := output.String()
-	if !strings.Contains("application/xml, application/json; q=0.2", res) {
+	if !strings.Contains(res, "application/xml, application/json; q=0.2") {
 		t.Errorf("HEADER_ACCEPT='application/xml, application/json; q=0.2' "+
 			"should be in output, have:%s\n", res)
 	}

--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -207,8 +207,7 @@ func EnvAsHeader(req *http.Request, selectedEnv []string) {
 
 	for _, e := range detectedEnv {
 		kv := strings.Split(e, "=")
-		name := kv[0]
-		req.Header.Set(name, os.Getenv(name))
+		req.Header.Set(kv[0], kv[1])
 	}
 }
 


### PR DESCRIPTION
I noticed the EnvAsHeader function was incorrect, and that the only test that really exercises it was also broken in a way that made it pass when it shouldn't.

The fixed test doesn't pass because the attempt to invoke the function fails with: `Failed to pull image 'denismakogon/os.environ': pull access denied for denismakogon/os.environ, repository does not exist or may require 'docker login'`

@denismakogon, looks like that container isn't publicly readable -- could you make that image publicly accessible somewhere?