### PR TITLE
Added FN_API_CORS_HEADERS for configuring CORS headers

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -22,12 +22,22 @@ func optionalCorsWrap(r *gin.Engine) {
 	// By default no CORS are allowed unless one
 	// or more Origins are defined by the API_CORS
 	// environment variable.
-	corsStr := getEnv(EnvAPICORS, "")
+	corsStr := getEnv(EnvAPICORSOrigins, "")
 	if len(corsStr) > 0 {
 		origins := strings.Split(strings.Replace(corsStr, " ", "", -1), ",")
 
 		corsConfig := cors.DefaultConfig()
-		corsConfig.AllowOrigins = origins
+		if origins[0] == "*" {
+			corsConfig.AllowAllOrigins = true
+		} else {
+			corsConfig.AllowOrigins = origins
+		}
+
+		corsHeaders := getEnv(EnvAPICORSHeaders, "")
+		if len(corsHeaders) > 0 {
+			headers := strings.Split(strings.Replace(corsHeaders, " ", "", -1), ",")
+			corsConfig.AllowHeaders = headers
+		}
 
 		logrus.Infof("CORS enabled for domains: %s", origins)
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -54,7 +54,8 @@ const (
 	EnvNodeType        = "FN_NODE_TYPE"
 	EnvPort            = "FN_PORT" // be careful, Gin expects this variable to be "port"
 	EnvGRPCPort        = "FN_GRPC_PORT"
-	EnvAPICORS         = "FN_API_CORS"
+	EnvAPICORSOrigins  = "FN_API_CORS_ORIGINS"
+	EnvAPICORSHeaders  = "FN_API_CORS_HEADERS"
 	EnvZipkinURL       = "FN_ZIPKIN_URL"
 	EnvJaegerURL       = "FN_JAEGER_URL"
 	// Certificates to communicate with other FN nodes

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -28,7 +28,8 @@ docker run -e VAR_NAME=VALUE ...
 | `FN_LOG_LEVEL` | Set to DEBUG to enable debugging | INFO |
 | `FN_LOG_DEST` | Set a url to send logs to, instead of stderr. [scheme://][host][:port][/path]; default scheme to udp:// if none given, possible schemes: { udp, tcp, file }
 | `FN_LOG_PREFIX` | If supplying a syslog url in `FN_LOG_DEST`, a prefix to add to each log line
-| `FN_API_CORS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
+| `FN_API_CORS_ORIGINS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
+| `FN_API_CORS_HEADERS` | A comma separated list of Headers to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for. This corresponds to the allowed headers in the `Access-Control-Allow-Headers` header.  | Origin,Content-Length,Content-Type |
 | `FN_FREEZE_IDLE_MSECS` | Set this option to specify the amount of time to wait in milliseconds before pausing/freezing an idle hot container. Set to 0 to freeze idle containers without any delay. Set to negative integer to disable freeze/pause of idle hot containers. | 50 |
  `FN_EJECT_IDLE_MSECS` | Set this option to specify the amount of time in milliseconds to periodically check to terminate an idle hot container if the system is starved for CPU and Memory resources. Set to negative integer to disable this feature. | 1000 |
  `FN_MAX_RESPONSE_SIZE` | Set this option to specify the http body or json response size in bytes from the containers. | 0 (off) |


### PR DESCRIPTION
Fixes https://github.com/fnproject/fn/issues/996

Added `FN_API_CORS_HEADERS` to make allowed CORS headers configurable. 

`FN_API_CORS` variable changed to `FN_API_CORS_ORIGINS` to make it consistent with the new `FN_API_CORS_HEADERS`

/cc @rdallman @adoublebarrel