### PR TITLE
fn: agent MaxRequestSize limit

### DIFF
--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -403,6 +403,44 @@ func (l testListener) BeforeCall(context.Context, *models.Call) error {
 	return nil
 }
 
+func TestReqTooLarge(t *testing.T) {
+	app := &models.App{Name: "myapp"}
+	app.SetDefaults()
+
+	cm := &models.Call{
+		AppID:       app.ID,
+		Config:      map[string]string{},
+		Path:        "/",
+		Image:       "fnproject/fn-test-utils",
+		Type:        "sync",
+		Format:      "json",
+		Timeout:     10,
+		IdleTimeout: 20,
+		Memory:      64,
+		CPUs:        models.MilliCPUs(200),
+		Payload:     `{"sleepTime": 0, "isDebug": true, "isCrash": true}`,
+		URL:         "http://127.0.0.1:8080/r/" + app.Name + "/",
+		Method:      "GET",
+	}
+
+	// FromModel doesn't need a datastore, for now...
+	ds := datastore.NewMockInit()
+
+	cfg, err := NewAgentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.MaxRequestSize = 5
+
+	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), WithConfig(cfg))
+	defer a.Close()
+
+	_, err = a.GetCall(FromModel(cm))
+	if err != models.ErrRequestContentTooBig {
+		t.Fatal(err)
+	}
+}
 func TestSubmitError(t *testing.T) {
 	app := &models.App{Name: "myapp"}
 	app.SetDefaults()

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -19,6 +19,7 @@ type AgentConfig struct {
 	CallEndTimeout          time.Duration `json:"call_end_timeout"`
 	MaxCallEndStacking      uint64        `json:"max_call_end_stacking"`
 	MaxResponseSize         uint64        `json:"max_response_size_bytes"`
+	MaxRequestSize          uint64        `json:"max_request_size_bytes"`
 	MaxLogSize              uint64        `json:"max_log_size_bytes"`
 	MaxTotalCPU             uint64        `json:"max_total_cpu_mcpus"`
 	MaxTotalMemory          uint64        `json:"max_total_memory_bytes"`
@@ -41,6 +42,7 @@ const (
 	EnvCallEndTimeout          = "FN_CALL_END_TIMEOUT_MSECS"
 	EnvMaxCallEndStacking      = "FN_MAX_CALL_END_STACKING"
 	EnvMaxResponseSize         = "FN_MAX_RESPONSE_SIZE"
+	EnvMaxRequestSize          = "FN_MAX_REQUEST_SIZE"
 	EnvMaxLogSize              = "FN_MAX_LOG_SIZE_BYTES"
 	EnvMaxTotalCPU             = "FN_MAX_TOTAL_CPU_MCPUS"
 	EnvMaxTotalMemory          = "FN_MAX_TOTAL_MEMORY_BYTES"
@@ -74,6 +76,7 @@ func NewAgentConfig() (*AgentConfig, error) {
 	err = setEnvMsecs(err, EnvAsyncChewPoll, &cfg.AsyncChewPoll, time.Duration(60)*time.Second)
 	err = setEnvMsecs(err, EnvCallEndTimeout, &cfg.CallEndTimeout, time.Duration(10)*time.Minute)
 	err = setEnvUint(err, EnvMaxResponseSize, &cfg.MaxResponseSize)
+	err = setEnvUint(err, EnvMaxRequestSize, &cfg.MaxRequestSize)
 	err = setEnvUint(err, EnvMaxLogSize, &cfg.MaxLogSize)
 	err = setEnvUint(err, EnvMaxTotalCPU, &cfg.MaxTotalCPU)
 	err = setEnvUint(err, EnvMaxTotalMemory, &cfg.MaxTotalMemory)

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -97,6 +97,10 @@ func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
 	if c.req == nil || c.Call == nil {
 		return nil, errors.New("no model or request provided for call")
 	}
+	err := setMaxBodyLimit(&a.cfg, &c)
+	if err != nil {
+		return nil, err
+	}
 
 	c.da = a.da
 	c.ct = a

--- a/api/common/io_utils.go
+++ b/api/common/io_utils.go
@@ -61,9 +61,6 @@ func (g *clampReadCloser) Read(p []byte) (int, error) {
 
 	n, err := g.r.Read(p)
 	g.remaining -= int64(n)
-	if g.remaining <= 0 {
-		err = g.overflowErr
-	}
 	return n, err
 }
 

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -185,6 +185,10 @@ var (
 		code:  http.StatusBadGateway,
 		error: fmt.Errorf("function response too large"),
 	}
+	ErrRequestContentTooBig = err{
+		code:  http.StatusRequestEntityTooLarge,
+		error: fmt.Errorf("Request content too large"),
+	}
 	ErrInvalidAnnotationKey = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Invalid annotation key, annotation keys must be non-empty ascii strings excluding whitespace"),


### PR DESCRIPTION
Currently, LimitRequestBody() exists to install a
http request body size in http/gin server. For production
enviroments, this is expected to be used. However, in agents
we may need to verify/enforce these size limits and to be
able to assert in case of missing limits is valuable.
With this change, operators can define an agent env variable
to limit this in addition to installing Gin/Http handler.

http.MaxBytesReader is superior in some cases as it sets
http headers (Connection: close) to guard against subsequent
requests.

However, NewClampReadCloser() is superior in other cases,
where it can cleanly return an API error for this case alone
(http.MaxBytesReader() does not return a clean error type
for overflow case, which makes it difficult to use it without
peeking into its implementation.)

For lb agent, upcoming changes rely on such limits enabled
and using gin/http handler (http.MaxBytesReader) makes such
checks/safety validations difficult.