### PR TITLE
add DELETE to allowed cors methods

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -39,6 +39,8 @@ func optionalCorsWrap(r *gin.Engine) {
 			corsConfig.AllowHeaders = headers
 		}
 
+		corsConfig.AllowMethods = []string{"GET", "POST", "PUT", "HEAD", "DELETE"}
+
 		logrus.Infof("CORS enabled for domains: %s", origins)
 
 		r.Use(cors.New(corsConfig))


### PR DESCRIPTION
Default cors allowed headers is missing DELETE method, this change sets the AllowMethods explicitly, doesn't rely on cors middleware default.

/cc @adoublebarrel @rdallman 