### PR TITLE
Wrap custom datastore with metrics and validator

### DIFF
--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -18,7 +18,11 @@ func New(ctx context.Context, dbURL string) (models.Datastore, error) {
 		return nil, err
 	}
 
-	return datastoreutil.MetricDS(datastoreutil.NewValidator(ds)), nil
+	return Wrap(ds), nil
+}
+
+func Wrap(ds models.Datastore) (models.Datastore) {
+	return datastoreutil.MetricDS(datastoreutil.NewValidator(ds))
 }
 
 func newds(ctx context.Context, dbURL string) (models.Datastore, error) {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -325,7 +325,7 @@ func WithNodeCertAuthority(ca string) ServerOption {
 
 func WithDatastore(ds models.Datastore) ServerOption {
 	return func(ctx context.Context, s *Server) error {
-		s.datastore = ds
+		s.datastore = datastore.Wrap(ds)
 		return nil
 	}
 }


### PR DESCRIPTION
When the server is configured using `WithDatastore` function fn doesn't use the validator/metric emitter from api/datastore/internal/datastoreutil.

This change makes validator and metrics emitter mandatory for custom datastore implementation by introducing new function `Wrap` to datastore, which is then called from `WithDatastore` function.

/cc @rdallman @zootalures @adoublebarrel @jan-g 