### PR TITLE
Implement graceful shutdown of agent.DataAccess

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -84,6 +84,7 @@ type Agent interface {
 	Submit(Call) error
 
 	// Close will wait for any outstanding calls to complete and then exit.
+	// Closing the agent will invoke Close on the underlying DataAccess.
 	// Close is not safe to be called from multiple threads.
 	io.Closer
 
@@ -209,6 +210,12 @@ func (a *agent) Close() error {
 		}
 	})
 
+	// shutdown any db/queue resources
+	// associated with DataAccess
+	daErr := a.da.Close()
+	if daErr != nil {
+		return daErr
+	}
 	return err
 }
 

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -248,3 +248,7 @@ func (cl *client) once(ctx context.Context, request, result interface{}, method 
 func (cl *client) url(args ...string) string {
 	return cl.base + strings.Join(args, "/")
 }
+
+func (cl *client) Close() error {
+	return nil
+}

--- a/api/agent/hybrid/nop.go
+++ b/api/agent/hybrid/nop.go
@@ -58,3 +58,7 @@ func (cl *nopDataStore) GetRoute(ctx context.Context, appName, route string) (*m
 	defer span.End()
 	return nil, errors.New("Should not call GetRoute on a NOP data store")
 }
+
+func (cl *nopDataStore) Close() error {
+	return nil
+}

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -116,3 +116,8 @@ func (m *metricds) GetLog(ctx context.Context, appName, callID string) (io.Reade
 
 // instant & no context ;)
 func (m *metricds) GetDatabase() *sqlx.DB { return m.ds.GetDatabase() }
+
+// Close calls Close on the underlying Datastore
+func (m *metricds) Close() error {
+	return m.ds.Close()
+}

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -198,3 +198,7 @@ func (m *mock) batchDeleteRoutes(ctx context.Context, appID string) error {
 func (m *mock) GetDatabase() *sqlx.DB {
 	return nil
 }
+
+func (m *mock) Close() error {
+	return nil
+}

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -910,3 +910,8 @@ func buildFilterCallQuery(filter *models.CallFilter) (string, []interface{}) {
 func (ds *sqlStore) GetDatabase() *sqlx.DB {
 	return ds.db
 }
+
+// Close closes the database, releasing any open resources.
+func (ds *sqlStore) Close() error {
+	return ds.db.Close()
+}

--- a/api/datastore/sql/sql_test.go
+++ b/api/datastore/sql/sql_test.go
@@ -127,4 +127,23 @@ func TestDatastore(t *testing.T) {
 
 		both(u)
 	}
+
+}
+
+func TestClose(t *testing.T) {
+	ctx := context.Background()
+	defer os.RemoveAll("sqlite_test_dir")
+	u, err := url.Parse("sqlite3://sqlite_test_dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll("sqlite_test_dir")
+	ds, err := newDS(ctx, u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Close(); err != nil {
+		t.Fatalf("Failed to close datastore: %v", err)
+	}
 }

--- a/api/logs/mock.go
+++ b/api/logs/mock.go
@@ -89,3 +89,7 @@ func (m *mock) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*mode
 
 	return calls, nil
 }
+
+func (m *mock) Close() error {
+	return nil
+}

--- a/api/logs/s3/s3.go
+++ b/api/logs/s3/s3.go
@@ -460,3 +460,7 @@ func init() {
 		}
 	}
 }
+
+func (s *store) Close() error {
+	return nil
+}

--- a/api/models/logs.go
+++ b/api/models/logs.go
@@ -30,4 +30,8 @@ type LogStore interface {
 	// GetCalls returns a list of calls that satisfy the given CallFilter. If no
 	// calls exist, an empty list and a nil error are returned.
 	GetCalls(ctx context.Context, filter *CallFilter) ([]*Call, error)
+
+	// Close will close any underlying connections as needed.
+	// Close is not safe to be called from multiple threads.
+	io.Closer
 }

--- a/api/models/mq.go
+++ b/api/models/mq.go
@@ -1,6 +1,9 @@
 package models
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // Message Queue is used to impose a total ordering on jobs that it will
 // execute in order. calls are added to the queue via the Push() interface. The
@@ -49,4 +52,8 @@ type MessageQueue interface {
 	// the job does not have an outstanding reservation, error. If a job did not
 	// exist, succeed.
 	Delete(context.Context, *Call) error
+
+	// Close will close any underlying connections as needed.
+	// Close is not safe to be called from multiple threads.
+	io.Closer
 }

--- a/api/mqs/bolt.go
+++ b/api/mqs/bolt.go
@@ -347,3 +347,10 @@ func (mq *BoltDbMQ) Delete(ctx context.Context, job *models.Call) error {
 		return nil
 	})
 }
+
+// Close shuts down the bolt db connection and
+// stops the goroutine associated with the ticker
+func (mq *BoltDbMQ) Close() error {
+	mq.ticker.Stop()
+	return mq.db.Close()
+}

--- a/api/mqs/memory.go
+++ b/api/mqs/memory.go
@@ -192,3 +192,9 @@ func (mq *MemoryMQ) Delete(ctx context.Context, job *models.Call) error {
 	log.Debugln("Deleted")
 	return nil
 }
+
+// Close stops the associated goroutines by stopping the ticker
+func (mq *MemoryMQ) Close() error {
+	mq.Ticker.Stop()
+	return nil
+}

--- a/api/mqs/mock.go
+++ b/api/mqs/mock.go
@@ -24,3 +24,7 @@ func (mock *Mock) Reserve(context.Context) (*models.Call, error) {
 func (mock *Mock) Delete(context.Context, *models.Call) error {
 	return nil
 }
+
+func (mock *Mock) Close() error {
+	return nil
+}

--- a/api/mqs/new.go
+++ b/api/mqs/new.go
@@ -60,3 +60,8 @@ func (m *metricMQ) Delete(ctx context.Context, t *models.Call) error {
 	defer span.End()
 	return m.mq.Delete(ctx, t)
 }
+
+// Close closes the underlying message queue
+func (m *metricMQ) Close() error {
+	return m.mq.Close()
+}

--- a/api/mqs/redis.go
+++ b/api/mqs/redis.go
@@ -307,3 +307,10 @@ func (mq *RedisMQ) Delete(ctx context.Context, job *models.Call) error {
 	_, err = conn.Do("HDEL", "timeout", resID)
 	return err
 }
+
+// Close shuts down the redis connection pool and
+// stops the goroutine associated with the ticker
+func (mq *RedisMQ) Close() error {
+	mq.ticker.Stop()
+	return mq.pool.Close()
+}

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -446,7 +446,7 @@ func (mock *errorMQ) Push(context.Context, *models.Call) (*models.Call, error) {
 func (mock *errorMQ) Reserve(context.Context) (*models.Call, error)            { return nil, mock }
 func (mock *errorMQ) Delete(context.Context, *models.Call) error               { return mock }
 func (mock *errorMQ) Code() int                                                { return mock.code }
-
+func (mock *errorMQ) Close() error                                             { return nil }
 func TestFailedEnqueue(t *testing.T) {
 	buf := setLogBuffer()
 	app := &models.App{Name: "myapp", Config: models.Config{}}


### PR DESCRIPTION
As part of an agent's graceful shutdown, we should also flush and close any resources associated with its underlying _DataAccess_ implementation. This includes adding the ability to close the underlying Datastore, Logstore and MessageQueue, which are extended to implement _io.Closer_. 
