### PR TITLE
Admin server for paths which are not part of API

### DIFF
--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -15,13 +15,14 @@ import (
 
 func testRouterAsync(ds models.Datastore, mq models.MessageQueue, rnr agent.Agent) *gin.Engine {
 	ctx := context.Background()
-
+	engine := gin.New()
 	s := &Server{
-		agent:     rnr,
-		Router:    gin.New(),
-		datastore: ds,
-		mq:        mq,
-		nodeType:  ServerTypeFull,
+		agent:       rnr,
+		Router:      engine,
+		AdminRouter: engine,
+		datastore:   ds,
+		mq:          mq,
+		nodeType:    ServerTypeFull,
 	}
 
 	r := s.Router

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -100,7 +100,7 @@ func (s ServerNodeType) String() string {
 
 type Server struct {
 	// TODO this one maybe we have `AddRoute` in extensions?
-	Router *gin.Engine
+	Router      *gin.Engine
 	AdminRouter *gin.Engine
 
 	webListenPort   int
@@ -500,12 +500,12 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 	log := common.Logger(ctx)
 	engine := gin.New()
 	s := &Server{
-		Router: engine,
+		Router:      engine,
 		AdminRouter: engine,
 		// Add default ports
-		webListenPort:  DefaultPort,
+		webListenPort:   DefaultPort,
 		adminListenPort: DefaultPort,
-		grpcListenPort: DefaultGRPCPort,
+		grpcListenPort:  DefaultGRPCPort,
 		// Almost everything else is configured through opts (see NewFromEnv for ex.) or below
 	}
 
@@ -818,7 +818,6 @@ func (s *Server) startGears(ctx context.Context, cancel context.CancelFunc) {
 		}()
 	}
 
-
 	// listening for signals or listener errors or cancellations on all registered contexts.
 	s.extraCtxs = append(s.extraCtxs, ctx)
 	cases := make([]reflect.SelectCase, len(s.extraCtxs))
@@ -856,7 +855,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	// now for extensible middleware
 	engine.Use(s.rootMiddlewareWrapper())
 
-	admin.GET("/", handlePing)
+	engine.GET("/", handlePing)
 	admin.GET("/version", handleVersion)
 
 	// TODO: move under v1 ?

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -189,6 +189,9 @@ func pwd() string {
 
 func WithWebPort(port int) ServerOption {
 	return func(ctx context.Context, s *Server) error {
+		if s.adminListenPort == s.webListenPort {
+			s.adminListenPort = port
+		}
 		s.webListenPort = port
 		return nil
 	}


### PR DESCRIPTION
This change adds method `WithAdminServer` to fn server which enables to have the following paths available on server running on different port than the API server:

- /version
- /metrics
- /debug

This is useful when you want to keep these for 'internal' usage only, not to be exposed by the API.

The default behavior is backward compatible, that means all paths available on the API server only (no admin server running).

/cc @rdallman @treeder @vshiva @zootalures 