### PR TITLE
Api metrics

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -80,47 +80,46 @@ func traceWrap(c *gin.Context) {
 
 func apiMetricsWrap(s *Server) {
 
-	// don't do anything if the exporter is not set
-	if s.promExporter == nil {
-		return
+	measure := func(routes gin.RoutesInfo) func(*gin.Context) {
+		return func(c *gin.Context) {
+			start := time.Now()
+			// get the handler url, example: /v1/apps/:app
+			url := ""
+			for _, r := range routes {
+				if r.Handler == c.HandlerName() {
+					url = r.Path
+					break
+				}
+			}
+
+			ctx, err := tag.New(c.Request.Context(),
+				tag.Upsert(pathKey, url),
+				tag.Upsert(methodKey, c.Request.Method),
+			)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			stats.Record(ctx, apiRequestCount.M(1))
+			c.Next()
+
+			status := strconv.Itoa(c.Writer.Status())
+			ctx, err = tag.New(ctx,
+				tag.Upsert(statusKey, status),
+			)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			stats.Record(ctx, apiLatency.M(float64(time.Since(start))/float64(time.Millisecond)))
+		}
 	}
 
 	r := s.Router
-	r.Use(func(c *gin.Context) {
-		// ignore metrics path
-		if c.Request.URL.String() == "/metrics" {
-			c.Next()
-			return
-		}
-		start := time.Now()
-		// get the handler url, example: /apps/:id
-		url := ""
-		for _, r := range r.Routes() {
-			if r.Handler == c.HandlerName() {
-				url = r.Path
-				break
-			}
-		}
+	r.Use(measure(r.Routes()))
+	if s.webListenPort != s.adminListenPort {
+		a := s.AdminRouter
+		a.Use(measure(a.Routes()))
+	}
 
-		ctx, err := tag.New(c.Request.Context(),
-			tag.Upsert(pathKey, url),
-			tag.Upsert(methodKey, c.Request.Method),
-		)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		stats.Record(ctx, apiRequestCount.M(1))
-		c.Next()
-
-		status := strconv.Itoa(c.Writer.Status())
-		ctx, err = tag.New(ctx,
-			tag.Upsert(statusKey, status),
-		)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		stats.Record(ctx, apiLatency.M(float64(time.Since(start))/float64(time.Millisecond)))
-	})
 }
 
 func panicWrap(c *gin.Context) {

--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -80,8 +80,12 @@ func traceWrap(c *gin.Context) {
 
 func apiMetricsWrap(s *Server) {
 
-	measure := func(routes gin.RoutesInfo) func(*gin.Context) {
+	measure := func(engine *gin.Engine) func(*gin.Context) {
+		var routes gin.RoutesInfo
 		return func(c *gin.Context) {
+			if routes == nil {
+				routes = engine.Routes()
+			}
 			start := time.Now()
 			// get the handler url, example: /v1/apps/:app
 			url := ""
@@ -114,10 +118,10 @@ func apiMetricsWrap(s *Server) {
 	}
 
 	r := s.Router
-	r.Use(measure(r.Routes()))
+	r.Use(measure(r))
 	if s.webListenPort != s.adminListenPort {
 		a := s.AdminRouter
-		a.Use(measure(a.Routes()))
+		a.Use(measure(a))
 	}
 
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -537,6 +537,7 @@ func New(ctx context.Context, opts ...ServerOption) *Server {
 	setMachineID()
 	s.Router.Use(loggerWrap, traceWrap, panicWrap) // TODO should be opts
 	optionalCorsWrap(s.Router)                     // TODO should be an opt
+	apiMetricsWrap(s)
 	s.bindHandlers(ctx)
 
 	s.appListeners = new(appListeners)
@@ -572,6 +573,7 @@ func WithPrometheus() ServerOption {
 		}
 		s.promExporter = exporter
 		view.RegisterExporter(exporter)
+		registerViews()
 		return nil
 	}
 }

--- a/api/server/stats.go
+++ b/api/server/stats.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	apiRequestCount = stats.Int64("api/request_count", "Number of API requests", stats.UnitDimensionless)
+	apiLatency      = stats.Float64("api/latency", "API latency", stats.UnitMilliseconds)
+)
+
+var (
+	pathKey   = makeKey("path")
+	methodKey = makeKey("method")
+	statusKey = makeKey("status")
+)
+
+var (
+	defaultLatencyDistribution = view.Distribution(0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+var (
+	apiRequestCountView = &view.View{
+		Name:        "api/request_count",
+		Description: "Count of API requests started",
+		Measure:     apiRequestCount,
+		TagKeys:     []tag.Key{pathKey, methodKey},
+		Aggregation: view.Count(),
+	}
+
+	apiResponseCountView = &view.View{
+		Name:        "api/response_count",
+		Description: "API response count",
+		TagKeys:     []tag.Key{pathKey, methodKey, statusKey},
+		Measure:     apiLatency,
+		Aggregation: view.Count(),
+	}
+
+	apiLatencyView = &view.View{
+		Name:        "api/latency",
+		Description: "Latency distribution of API requests",
+		Measure:     apiLatency,
+		TagKeys:     []tag.Key{pathKey, methodKey, statusKey},
+		Aggregation: defaultLatencyDistribution,
+	}
+)
+
+func registerViews() {
+	err := view.Register(
+		apiRequestCountView,
+		apiResponseCountView,
+		apiLatencyView,
+	)
+	if err != nil {
+		logrus.WithError(err).Fatal("cannot register view")
+	}
+}
+
+func makeKey(name string) tag.Key {
+	key, err := tag.NewKey(name)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	return key
+}

--- a/api/server/stats.go
+++ b/api/server/stats.go
@@ -23,7 +23,7 @@ var (
 )
 
 var (
-	apiRequestCountView = &view.View{
+	ApiRequestCountView = &view.View{
 		Name:        "api/request_count",
 		Description: "Count of API requests started",
 		Measure:     apiRequestCount,
@@ -31,7 +31,7 @@ var (
 		Aggregation: view.Count(),
 	}
 
-	apiResponseCountView = &view.View{
+	ApiResponseCountView = &view.View{
 		Name:        "api/response_count",
 		Description: "API response count",
 		TagKeys:     []tag.Key{pathKey, methodKey, statusKey},
@@ -39,7 +39,7 @@ var (
 		Aggregation: view.Count(),
 	}
 
-	apiLatencyView = &view.View{
+	ApiLatencyView = &view.View{
 		Name:        "api/latency",
 		Description: "Latency distribution of API requests",
 		Measure:     apiLatency,
@@ -50,9 +50,9 @@ var (
 
 func registerViews() {
 	err := view.Register(
-		apiRequestCountView,
-		apiResponseCountView,
-		apiLatencyView,
+		ApiRequestCountView,
+		ApiResponseCountView,
+		ApiLatencyView,
 	)
 	if err != nil {
 		logrus.WithError(err).Fatal("cannot register view")


### PR DESCRIPTION
This change adds support for capturing metrics over all api endpoints.

3 new metrics views available:

`api/request_count` - Count of API requests started, supporting tags: `path`,`mathod`
`api/response_count` - API response count, supporting tags: `path`,`method`,`status`
`api/latency` - Latency distribution of API requests, supporting tags: `path`,`method`,`status`

Metrics definition is inspired by opencensus' http plugin: `https://github.com/census-instrumentation/opencensus-go/blob/master/plugin/ochttp/stats.go`

This is implemented using gin middleware, which uses the handler path, not the actual request path to keep the number of measure metrics smaller. (eg. use `/v1/apps/:app` instead of `/v1/apps/myrealapp`).
