### PR TITLE
fn: read-only root fs becomes default

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -170,7 +170,7 @@ func createAgent(da DataAccess, options ...AgentOption) Agent {
 		PreForkUseOnce:       a.cfg.PreForkUseOnce,
 		PreForkNetworks:      a.cfg.PreForkNetworks,
 		MaxTmpFsInodes:       a.cfg.MaxTmpFsInodes,
-		EnableReadOnlyRootFs: a.cfg.EnableReadOnlyRootFs,
+		EnableReadOnlyRootFs: !a.cfg.DisableReadOnlyRootFs,
 	})
 
 	a.da = da

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -666,7 +666,6 @@ func TestTmpFsSize(t *testing.T) {
 	}
 
 	cfg.MaxTmpFsInodes = 1024
-	cfg.EnableReadOnlyRootFs = true
 
 	a := New(NewDirectDataAccess(ds, ds, new(mqs.Mock)), WithConfig(cfg))
 	defer checkClose(t, a)

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -31,7 +31,7 @@ type AgentConfig struct {
 	PreForkNetworks         string        `json:"pre_fork_networks"`
 	EnableNBResourceTracker bool          `json:"enable_nb_resource_tracker"`
 	MaxTmpFsInodes          uint64        `json:"max_tmpfs_inodes"`
-	EnableReadOnlyRootFs    bool          `json:"enable_readonly_rootfs"`
+	DisableReadOnlyRootFs   bool          `json:"disable_readonly_rootfs"`
 }
 
 const (
@@ -56,14 +56,13 @@ const (
 	EnvPreForkNetworks         = "FN_EXPERIMENTAL_PREFORK_NETWORKS"
 	EnvEnableNBResourceTracker = "FN_ENABLE_NB_RESOURCE_TRACKER"
 	EnvMaxTmpFsInodes          = "FN_MAX_TMPFS_INODES"
-	EnvEnableReadOnlyRootFs    = "FN_ENABLE_READONLY_ROOTFS"
+	EnvDisableReadOnlyRootFs   = "FN_DISABLE_READONLY_ROOTFS"
 
 	MaxDisabledMsecs = time.Duration(math.MaxInt64)
 
 	// defaults
 
-	DefaultHotPoll     = 200 * time.Millisecond
-	DefaultNBIOHotPoll = 20 * time.Millisecond
+	DefaultHotPoll = 200 * time.Millisecond
 )
 
 func NewAgentConfig() (*AgentConfig, error) {
@@ -106,9 +105,8 @@ func NewAgentConfig() (*AgentConfig, error) {
 	if _, ok := os.LookupEnv(EnvEnableNBResourceTracker); ok {
 		cfg.EnableNBResourceTracker = true
 	}
-
-	if _, ok := os.LookupEnv(EnvEnableReadOnlyRootFs); ok {
-		cfg.EnableReadOnlyRootFs = true
+	if _, ok := os.LookupEnv(EnvDisableReadOnlyRootFs); ok {
+		cfg.DisableReadOnlyRootFs = true
 	}
 
 	if cfg.EjectIdle == time.Duration(0) {

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -39,6 +39,7 @@ docker run -e VAR_NAME=VALUE ...
 | `DOCKER_CERT_PATH` | Set this option to specify where CA cert placeholder. | ~/.docker/cert.pem |
 | `FN_MAX_FS_SIZE_MB` | Set this option in MB to pass a `size` option to Docker storage driver. This limits the file system size for all containers on the system. See [Docker storage driver options per container](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container) documentation for details. | None |
 | `FN_DOCKER_NETWORKS` | Set this option with a list of docker networks for function containers to use. If unset, default docker network is used. | None |
+| `FN_DISABLE_READONLY_ROOTFS` | Set this option to enable writable root filesystem. By default root filesystem is mounted read-only. | None |
 
 ## Starting without Docker in Docker
 


### PR DESCRIPTION
This change sets root filesystem as read-only by default.
This behavior can be disabled via setting the
    FN_DISABLE_READONLY_ROOTFS
environment variable.