### PR TITLE
fn: cleanup of unused/global constants in lb agent

### DIFF
--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -18,16 +18,6 @@ import (
 	"github.com/fnproject/fn/fnext"
 )
 
-const (
-	runnerReconnectInterval = 5 * time.Second
-	// sleep time to attempt placement across all runners before retrying
-	retryWaitInterval = 10 * time.Millisecond
-	// sleep time when scaling from 0 to 1 runners
-	noCapacityWaitInterval = 1 * time.Second
-	// amount of time to wait to place a request on a runner
-	placementTimeout = 15 * time.Second
-)
-
 type lbAgent struct {
 	cfg           AgentConfig
 	da            DataAccess

--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"time"
 
-	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 
 	"github.com/dchest/siphash"
 	"github.com/sirupsen/logrus"
 )
 
-type chPlacer struct{}
+type chPlacer struct {
+	rrInterval time.Duration
+}
 
 func NewCHPlacer() Placer {
 	logrus.Info("Creating new CH runnerpool placer")
-	return &chPlacer{}
+	return &chPlacer{
+		rrInterval: 10 * time.Millisecond,
+	}
 }
 
 // This borrows the CH placement algorithm from the original FNLB.
@@ -62,18 +65,13 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 			}
 		}
 
-		remaining := call.LbDeadline().Sub(time.Now())
-		if remaining <= 0 {
-			return models.ErrCallTimeoutServerBusy
-		}
-
 		// backoff
 		select {
 		case <-ctx.Done():
 			return models.ErrCallTimeoutServerBusy
 		case <-timeout:
 			return models.ErrCallTimeoutServerBusy
-		case <-time.After(common.MinDuration(retryWaitInterval, remaining)):
+		case <-time.After(p.rrInterval):
 		}
 	}
 }


### PR DESCRIPTION
Moved retry interval as placer member variable for time-being.