### PR TITLE
fn: user friendly timeout handling changes

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -276,9 +276,9 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 	}
 
 	if c.Type == models.TypeAsync {
-		// *) for async, slotDealine is also c.Call.timeout". This is because we would like to
+		// *) for async, slotDeadline is also c.Call.timeout. This is because we would like to
 		// allocate enough time for docker-pull, slot-wait, docker-start, etc.
-		// and also carve c.Call.Timeout inside the container.
+		// and also make sure we have c.Call.Timeout inside the container as well..
 		// *) for sync, there's no slotDeadline, the timeout is controlled by http-client
 		// context (or runner gRPC context)
 		c.slotDeadline = time.Now().Add(time.Duration(c.Call.Timeout) * time.Second)

--- a/api/agent/protocol/factory.go
+++ b/api/agent/protocol/factory.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/fnproject/fn/api/models"
 	"github.com/go-openapi/strfmt"
@@ -79,16 +78,8 @@ func (ci callInfoImpl) Input() io.Reader {
 func (ci callInfoImpl) Deadline() strfmt.DateTime {
 	deadline, ok := ci.req.Context().Deadline()
 	if !ok {
-		// In theory deadline must have been set here, but if it wasn't then
-		// at this point it is already too late to raise an error. Set it to
-		// something meaningful.
-		// This assumes StartedAt was set to something other than the default.
-		// If that isn't set either, then how many things have gone wrong?
-		if ci.call.StartedAt == strfmt.NewDateTime() {
-			// We just panic if StartedAt is the default (i.e. not set)
-			panic("No context deadline and zero-value StartedAt - this should never happen")
-		}
-		deadline = ((time.Time)(ci.call.StartedAt)).Add(time.Duration(ci.call.Timeout) * time.Second)
+		// In theory deadline must have been set here
+		panic("No context deadline is set in protocol, should never happen")
 	}
 	return strfmt.DateTime(deadline)
 }

--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -67,8 +67,7 @@ type callHandle struct {
 	c          *call // the agent's version of call
 
 	// Timings, for metrics:
-	receivedTime  strfmt.DateTime // When was the call received?
-	allocatedTime strfmt.DateTime // When did we finish allocating capacity?
+	receivedTime strfmt.DateTime // When was the call received?
 
 	// For implementing http.ResponseWriter:
 	headers http.Header
@@ -530,7 +529,7 @@ func (pr *pureRunner) handleTryCall(tc *runner.TryCall, state *callHandle) error
 		return err
 	}
 
-	agent_call, err := pr.a.GetCall(FromModelAndInput(&c, state.pipeToFnR), WithWriter(state))
+	agent_call, err := pr.a.GetCall(FromModelAndInput(&c, state.pipeToFnR), WithWriter(state), WithContext(state.ctx))
 	if err != nil {
 		state.enqueueCallResponse(err)
 		return err
@@ -545,7 +544,6 @@ func (pr *pureRunner) handleTryCall(tc *runner.TryCall, state *callHandle) error
 		}
 		state.c.slotHashId = string(hashId[:])
 	}
-	state.allocatedTime = strfmt.DateTime(time.Now())
 	pr.spawnSubmit(state)
 
 	return nil

--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -31,7 +31,7 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 	// The key is just the path in this case
 	key := call.Model().Path
 	sum64 := siphash.Hash(0, 0x4c617279426f6174, []byte(key))
-	timeout := time.After(call.LbDeadline().Sub(time.Now()))
+
 	for {
 		runners, err := rp.Runners(call)
 		if err != nil {
@@ -42,8 +42,6 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 
 				select {
 				case <-ctx.Done():
-					return models.ErrCallTimeoutServerBusy
-				case <-timeout:
 					return models.ErrCallTimeoutServerBusy
 				default:
 				}
@@ -68,8 +66,6 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 		// backoff
 		select {
 		case <-ctx.Done():
-			return models.ErrCallTimeoutServerBusy
-		case <-timeout:
 			return models.ErrCallTimeoutServerBusy
 		case <-time.After(p.rrInterval):
 		}

--- a/api/runnerpool/naive_placer.go
+++ b/api/runnerpool/naive_placer.go
@@ -25,7 +25,6 @@ func NewNaivePlacer() Placer {
 }
 
 func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall) error {
-	timeout := time.After(call.LbDeadline().Sub(time.Now()))
 
 	for {
 		runners, err := rp.Runners(call)
@@ -36,8 +35,6 @@ func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call Runner
 
 				select {
 				case <-ctx.Done():
-					return models.ErrCallTimeoutServerBusy
-				case <-timeout:
 					return models.ErrCallTimeoutServerBusy
 				default:
 				}
@@ -61,8 +58,6 @@ func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call Runner
 		// backoff
 		select {
 		case <-ctx.Done():
-			return models.ErrCallTimeoutServerBusy
-		case <-timeout:
 			return models.ErrCallTimeoutServerBusy
 		case <-time.After(sp.rrInterval):
 		}

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/fnproject/fn/api/models"
 )
@@ -42,7 +41,6 @@ type Runner interface {
 // processed by a RunnerPool
 type RunnerCall interface {
 	SlotHashId() string
-	LbDeadline() time.Time
 	RequestBody() io.ReadCloser
 	ResponseWriter() http.ResponseWriter
 	StdErr() io.ReadWriteCloser

--- a/test/fn-api-tests/calls_test.go
+++ b/test/fn-api-tests/calls_test.go
@@ -60,7 +60,7 @@ func TestGetExactCall(t *testing.T) {
 	}
 	u.Path = path.Join(u.Path, "r", s.AppName, s.RoutePath)
 
-	callID := CallAsync(t, u, &bytes.Buffer{})
+	callID := CallAsync(t, s.Context, u, &bytes.Buffer{})
 
 	cfg := &call.GetAppsAppCallsCallParams{
 		Call:    callID,

--- a/test/fn-api-tests/formats_test.go
+++ b/test/fn-api-tests/formats_test.go
@@ -41,7 +41,7 @@ func TestFnJSONFormats(t *testing.T) {
 	})
 	content := bytes.NewBuffer(b)
 	output := &bytes.Buffer{}
-	resp, err := CallFN(u.String(), content, output, "POST", []string{})
+	resp, err := CallFN(s.Context, u.String(), content, output, "POST", []string{})
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}

--- a/test/fn-api-tests/utils.go
+++ b/test/fn-api-tests/utils.go
@@ -136,6 +136,8 @@ func (s *TestHarness) Cleanup() {
 	for app, _ := range s.createdApps {
 		safeDeleteApp(ctx, s.Client, app)
 	}
+
+	s.Cancel()
 }
 
 func EnvAsHeader(req *http.Request, selectedEnv []string) {
@@ -151,7 +153,7 @@ func EnvAsHeader(req *http.Request, selectedEnv []string) {
 	}
 }
 
-func CallFN(u string, content io.Reader, output io.Writer, method string, env []string) (*http.Response, error) {
+func CallFN(ctx context.Context, u string, content io.Reader, output io.Writer, method string, env []string) (*http.Response, error) {
 	if method == "" {
 		if content == nil {
 			method = "GET"
@@ -164,8 +166,8 @@ func CallFN(u string, content io.Reader, output io.Writer, method string, env []
 	if err != nil {
 		return nil, fmt.Errorf("error running route: %s", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
 
 	if len(env) > 0 {
 		EnvAsHeader(req, env)


### PR DESCRIPTION
Timeout setting in routes now means "maximum amount
of time a function can run in a container".

Total wait time for a given http request is now expected
to be handled by the client. As long as the client waits,
the LB, runner or agents will search for resources to
schedule it.