### PR TITLE
unmatched api handler reported as 'invalid' in api metrics

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -88,7 +88,7 @@ func apiMetricsWrap(s *Server) {
 			}
 			start := time.Now()
 			// get the handler url, example: /v1/apps/:app
-			url := ""
+			url := "invalid"
 			for _, r := range routes {
 				if r.Handler == c.HandlerName() {
 					url = r.Path


### PR DESCRIPTION
If the there is an api request with url that doesn't match any route, the url end up being as empty string, which causes opencensus to report:

 level=error msg="opencensus prometheus exporter err" error="inconsistent label cardinality"

This fix causes such a case to report the metric with url as 'invalid' -- this is convenient because we don't want to report the original url as it would increase the metrics cardinality.

/cc @rdallman @skinowski 