### PR TITLE
fn: LB agent: reduce 'Too Busy' error logs

### DIFF
--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -52,7 +52,7 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 				placed, err := r.TryExec(tryCtx, call)
 				tryCancel()
 
-				if err != nil {
+				if err != nil && err != models.ErrCallTimeoutServerBusy {
 					logrus.WithError(err).Error("Failed during call placement")
 				}
 				if placed {

--- a/api/runnerpool/naive_placer.go
+++ b/api/runnerpool/naive_placer.go
@@ -46,7 +46,7 @@ func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call Runner
 				placed, err := r.TryExec(tryCtx, call)
 				tryCancel()
 
-				if err != nil {
+				if err != nil && err != models.ErrCallTimeoutServerBusy {
 					logrus.WithError(err).Error("Failed during call placement")
 				}
 				if placed {


### PR DESCRIPTION
With this PR, runner client translates too busy errors
from gRPC session and runner itself into Fn error type.
Placers now ignore this error message to reduce unnecessary
logging.