### PR TITLE
add functions CRUD api & model

### DIFF
--- a/api/const.go
+++ b/api/const.go
@@ -6,6 +6,7 @@ const (
 	AppID string = "app_id"
 	Path  string = "path"
 	Call  string = "call"
+	Func  string = "func"
 	// Short forms for API URLs
 	CApp   string = "app"
 	CRoute string = "route"

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -83,6 +83,30 @@ func (m *metricds) RemoveRoute(ctx context.Context, appID string, routePath stri
 	return m.ds.RemoveRoute(ctx, appID, routePath)
 }
 
+func (m *metricds) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, error) {
+	ctx, span := trace.StartSpan(ctx, "ds_put_func")
+	defer span.End()
+	return m.ds.PutFunc(ctx, fn)
+}
+
+func (m *metricds) GetFuncs(ctx context.Context, filter *models.FuncFilter) ([]*models.Func, error) {
+	ctx, span := trace.StartSpan(ctx, "ds_get_funcs")
+	defer span.End()
+	return m.ds.GetFuncs(ctx, filter)
+}
+
+func (m *metricds) GetFunc(ctx context.Context, funcName string) (*models.Func, error) {
+	ctx, span := trace.StartSpan(ctx, "ds_get_func")
+	defer span.End()
+	return m.ds.GetFunc(ctx, funcName)
+}
+
+func (m *metricds) RemoveFunc(ctx context.Context, funcName string) error {
+	ctx, span := trace.StartSpan(ctx, "ds_remove_func")
+	defer span.End()
+	return m.ds.RemoveFunc(ctx, funcName)
+}
+
 // instant & no context ;)
 func (m *metricds) GetDatabase() *sqlx.DB { return m.ds.GetDatabase() }
 

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -83,10 +83,10 @@ func (m *metricds) RemoveRoute(ctx context.Context, appID string, routePath stri
 	return m.ds.RemoveRoute(ctx, appID, routePath)
 }
 
-func (m *metricds) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, error) {
+func (m *metricds) PutFunc(ctx context.Context, fname string, fn *models.Func) (*models.Func, error) {
 	ctx, span := trace.StartSpan(ctx, "ds_put_func")
 	defer span.End()
-	return m.ds.PutFunc(ctx, fn)
+	return m.ds.PutFunc(ctx, fname, fn)
 }
 
 func (m *metricds) GetFuncs(ctx context.Context, filter *models.FuncFilter) ([]*models.Func, error) {

--- a/api/datastore/internal/datastoreutil/validator.go
+++ b/api/datastore/internal/datastoreutil/validator.go
@@ -132,6 +132,30 @@ func (v *validator) RemoveRoute(ctx context.Context, appID string, routePath str
 	return v.Datastore.RemoveRoute(ctx, appID, routePath)
 }
 
+func (v *validator) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, error) {
+	if fn == nil {
+		return nil, models.ErrDatastoreEmptyFunc
+	}
+	if fn.Name == "" {
+		return nil, models.ErrDatastoreEmptyFuncName
+	}
+	return v.Datastore.PutFunc(ctx, fn)
+}
+
+func (v *validator) GetFunc(ctx context.Context, funcName string) (*models.Func, error) {
+	if funcName == "" {
+		return nil, models.ErrDatastoreEmptyFuncName
+	}
+	return v.Datastore.GetFunc(ctx, funcName)
+}
+
+func (v *validator) RemoveFunc(ctx context.Context, funcName string) error {
+	if funcName == "" {
+		return models.ErrDatastoreEmptyFuncName
+	}
+	return v.Datastore.RemoveFunc(ctx, funcName)
+}
+
 // GetDatabase returns the underlying sqlx database implementation
 func (v *validator) GetDatabase() *sqlx.DB {
 	return v.Datastore.GetDatabase()

--- a/api/datastore/internal/datastoreutil/validator.go
+++ b/api/datastore/internal/datastoreutil/validator.go
@@ -132,14 +132,14 @@ func (v *validator) RemoveRoute(ctx context.Context, appID string, routePath str
 	return v.Datastore.RemoveRoute(ctx, appID, routePath)
 }
 
-func (v *validator) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, error) {
+func (v *validator) PutFunc(ctx context.Context, fname string, fn *models.Func) (*models.Func, error) {
 	if fn == nil {
 		return nil, models.ErrDatastoreEmptyFunc
 	}
-	if fn.Name == "" {
+	if fname == "" || fn.Name == "" {
 		return nil, models.ErrDatastoreEmptyFuncName
 	}
-	return v.Datastore.PutFunc(ctx, fn)
+	return v.Datastore.PutFunc(ctx, fname, fn)
 }
 
 func (v *validator) GetFunc(ctx context.Context, funcName string) (*models.Func, error) {

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -197,10 +197,10 @@ func (m *mock) batchDeleteRoutes(ctx context.Context, appID string) error {
 	return nil
 }
 
-func (m *mock) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, error) {
+func (m *mock) PutFunc(ctx context.Context, fname string, fn *models.Func) (*models.Func, error) {
 	// update if exists
 	for _, f := range m.Funcs {
-		if f.Name == fn.Name {
+		if f.Name == fname {
 			copy := f.Clone()
 			copy.Update(fn)
 			err := copy.Validate()
@@ -224,7 +224,7 @@ func (m *mock) PutFunc(ctx context.Context, fn *models.Func) (*models.Func, erro
 type sortF []*models.Func
 
 func (s sortF) Len() int           { return len(s) }
-func (s sortF) Less(i, j int) bool { return strings.Compare(s[i].ID, s[j].ID) < 0 }
+func (s sortF) Less(i, j int) bool { return strings.Compare(s[i].Name, s[j].Name) < 0 }
 func (s sortF) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 func (m *mock) GetFuncs(ctx context.Context, filter *models.FuncFilter) ([]*models.Func, error) {
@@ -238,7 +238,7 @@ func (m *mock) GetFuncs(ctx context.Context, filter *models.FuncFilter) ([]*mode
 			break
 		}
 
-		if strings.Compare(filter.Cursor, f.ID) < 0 {
+		if strings.Compare(filter.Cursor, f.Name) < 0 {
 			funcs = append(funcs, f)
 		}
 	}

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -59,6 +59,24 @@ type Datastore interface {
 	// ErrDatastoreEmptyRoutePath when routePath is empty. Returns ErrRoutesNotFound when no route exists.
 	RemoveRoute(ctx context.Context, appID, routePath string) error
 
+	// PutFunc inserts a new function if one does not exist, applying any defaults necessary, or
+	// updates a function that exists under the same name. Returns ErrDatastoreEmptyFunc if func is nil,
+	// ErrDatastoreEmptyFuncName is func.Name is empty.
+	// TODO(reed): should we allow rename if id provided?
+	PutFunc(ctx context.Context, fn *Func) (*Func, error)
+
+	// GetFuncs returns a list of funcs, applying any additional filters provided.
+	GetFuncs(ctx context.Context, filter *FuncFilter) ([]*Func, error)
+
+	// GetFunc returns a function by name. Returns ErrDatastoreEmptyFuncName if funcName is empty.
+	// Returns ErrFuncsNotFound if a func is not found.
+	// TODO(reed): figure out addressable by id or name biz. iff 1 query, name works.
+	GetFunc(ctx context.Context, funcName string) (*Func, error)
+
+	// RemoveFunc removes a function. Returns ErrDatastoreEmptyFuncName if funcName is empty.
+	// Returns ErrFuncsNotFound if a func is not found.
+	RemoveFunc(ctx context.Context, funcName string) error
+
 	// GetDatabase returns the underlying sqlx database implementation
 	GetDatabase() *sqlx.DB
 

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -63,7 +63,7 @@ type Datastore interface {
 	// updates a function that exists under the same name. Returns ErrDatastoreEmptyFunc if func is nil,
 	// ErrDatastoreEmptyFuncName is func.Name is empty.
 	// TODO(reed): should we allow rename if id provided?
-	PutFunc(ctx context.Context, fn *Func) (*Func, error)
+	PutFunc(ctx context.Context, fname string, fn *Func) (*Func, error)
 
 	// GetFuncs returns a list of funcs, applying any additional filters provided.
 	GetFuncs(ctx context.Context, filter *FuncFilter) ([]*Func, error)

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -76,6 +76,18 @@ var (
 		code:  http.StatusBadRequest,
 		error: errors.New("Missing call ID"),
 	}
+	ErrDatastoreEmptyFunc = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Missing func"),
+	}
+	ErrDatastoreEmptyFuncName = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Missing func name"),
+	}
+	ErrFuncsMissingNew = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Missing function body"),
+	}
 	ErrInvalidPayload = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Invalid payload"),
@@ -155,6 +167,34 @@ var (
 	ErrRoutesInvalidMemory = err{
 		code:  http.StatusBadRequest,
 		error: fmt.Errorf("memory value is out of range. It should be between 0 and %d", RouteMaxMemory),
+	}
+	ErrFuncsInvalidName = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Func name must be an RFC 3986 compliant path string"),
+	}
+	ErrFuncsMissingImage = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Missing func image"),
+	}
+	ErrFuncsInvalidFormat = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Invalid func format"),
+	}
+	ErrInvalidTimeout = err{
+		code:  http.StatusBadRequest,
+		error: fmt.Errorf("timeout value is out of range, must be between 0 and %d", MaxTimeout),
+	}
+	ErrInvalidIdleTimeout = err{
+		code:  http.StatusBadRequest,
+		error: fmt.Errorf("idle_timeout value is out of range, must be between 0 and %d", MaxIdleTimeout),
+	}
+	ErrInvalidMemory = err{
+		code:  http.StatusBadRequest,
+		error: fmt.Errorf("memory value is out of range. It should be between 0 and %d", RouteMaxMemory),
+	}
+	ErrFuncsNotFound = err{
+		code:  http.StatusNotFound,
+		error: errors.New("Func not found"),
 	}
 	ErrCallNotFound = err{
 		code:  http.StatusNotFound,

--- a/api/models/func.go
+++ b/api/models/func.go
@@ -1,0 +1,224 @@
+package models
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/fnproject/fn/api/id"
+	"github.com/go-openapi/strfmt"
+)
+
+var (
+	// these are vars so that they can be configured. these apply
+	// across function & trigger (resource config)
+
+	MaxMemory      uint64 = 8 * 1024 // 8GB
+	MaxTimeout     int32  = 300      // 5m
+	MaxIdleTimeout int32  = 3600     // 1h
+)
+
+// FuncWrapper makes jason purrty for a Func.
+type FuncWrapper struct {
+	Func *Func `json:"func"`
+}
+
+// Func contains information about a function configuration.
+type Func struct {
+	// ID is the generated resource id.
+	ID string `json:"id" db:"id"`
+	// Name is a user provided name for this func.
+	Name string `json:"name" db:"name"`
+	// Image is the fully qualified container registry address to execute.
+	// examples: hub.docker.io/me/myfunc, me/myfunc, me/func:0.0.1
+	Image string `json:"image" db:"image"`
+	// ResourceConfig specifies resource constraints.
+	ResourceConfig // embed (TODO or not?)
+	// Config is the configuration passed to a function at execution time.
+	Config Config `json:"config" db:"config"`
+	// Annotations allow additional configuration of a function, these are not passed to the function.
+	Annotations Annotations `json:"annotations,omitempty" db:"annotations"`
+	// CreatedAt is the UTC timestamp when this function was created.
+	CreatedAt strfmt.DateTime `json:"created_at,omitempty" db:"created_at"`
+	// UpdatedAt is the UTC timestamp of the last time this func was modified.
+	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" db:"updated_at"`
+
+	// TODO wish to kill but not yet ?
+	// Format is the container protocol the function will accept,
+	// may be one of: json | http | cloudevent | default
+	Format string `json:"format" db:"format"`
+}
+
+// ResourceConfig specified resource constraints imposed on a function execution.
+type ResourceConfig struct {
+	// Memory is the amount of memory allotted, in MB.
+	Memory uint64 `json:"memory,omitempty" db:"memory"`
+	// CPUs is the max usable CPU cores for this route. Value in MilliCPUs,
+	// (eg. 500m) or as floating-point (eg. 0.5)
+	// TODO this is a good chance to fix this. let's pick one?
+	CPUs MilliCPUs `json:"cpus,omitempty" db:"cpus"`
+	// Timeout is the max execution time for a function, in seconds.
+	// TODO this should probably be milliseconds?
+	Timeout int32 `json:"timeout,omitempty" db:"timeout"`
+	// IdleTimeout is the
+	// TODO this should probably be milliseconds
+	IdleTimeout int32 `json:"idle_timeout,omitempty" db:"idle_timeout"`
+}
+
+// SetDefaults sets zeroed field to defaults.
+func (f *Func) SetDefaults() {
+	if f.ID == "" {
+		f.ID = id.New().String()
+	}
+
+	if f.Memory == 0 {
+		f.Memory = DefaultMemory
+	}
+
+	if f.Format == "" {
+		f.Format = FormatDefault
+	}
+
+	if f.Config == nil {
+		// keeps the json from being nil
+		f.Config = map[string]string{}
+	}
+
+	if f.Timeout == 0 {
+		f.Timeout = DefaultTimeout
+	}
+
+	if f.IdleTimeout == 0 {
+		f.IdleTimeout = DefaultIdleTimeout
+	}
+
+	if time.Time(f.CreatedAt).IsZero() {
+		f.CreatedAt = strfmt.DateTime(time.Now())
+	}
+
+	if time.Time(f.UpdatedAt).IsZero() {
+		f.UpdatedAt = strfmt.DateTime(time.Now())
+	}
+}
+
+// Validate validates all field values, returning the first error, if any.
+func (f *Func) Validate() error {
+	if url.PathEscape(f.Name) != f.Name {
+		return ErrFuncsInvalidName
+	}
+
+	if f.Image == "" {
+		return ErrFuncsMissingImage
+	}
+
+	switch f.Format {
+	case FormatDefault, FormatHTTP, FormatJSON, FormatCloudEvent:
+	default:
+		return ErrFuncsInvalidFormat
+	}
+
+	if f.Timeout <= 0 || f.Timeout > MaxTimeout {
+		return ErrInvalidTimeout
+	}
+
+	if f.IdleTimeout <= 0 || f.IdleTimeout > MaxIdleTimeout {
+		return ErrInvalidIdleTimeout
+	}
+
+	if f.Memory < 1 || f.Memory > MaxMemory {
+		return ErrInvalidMemory
+	}
+
+	return f.Annotations.Validate()
+}
+
+func (f *Func) Clone() *Func {
+	clone := new(Func)
+	*clone = *f // shallow copy
+
+	// now deep copy the maps
+	if f.Config != nil {
+		clone.Config = make(Config, len(f.Config))
+		for k, v := range f.Config {
+			clone.Config[k] = v
+		}
+	}
+	if f.Annotations != nil {
+		clone.Annotations = make(Annotations, len(f.Annotations))
+		for k, v := range f.Annotations {
+			// TODO technically, we need to deep copy the bytes
+			clone.Annotations[k] = v
+		}
+	}
+	return clone
+}
+
+func (f1 *Func) Equals(f2 *Func) bool {
+	// start off equal, check equivalence of each field.
+	// the RHS of && won't eval if eq==false so config/headers checking is lazy
+
+	eq := true
+	eq = eq && f1.Image == f2.Image
+	eq = eq && f1.Memory == f2.Memory
+	eq = eq && f1.CPUs == f2.CPUs
+	eq = eq && f1.Format == f2.Format
+	eq = eq && f1.Timeout == f2.Timeout
+	eq = eq && f1.IdleTimeout == f2.IdleTimeout
+	eq = eq && f1.Config.Equals(f2.Config)
+	eq = eq && f1.Annotations.Equals(f2.Annotations)
+	// NOTE: datastore tests are not very fun to write with timestamp checks,
+	// and these are not values the user may set so we kind of don't care.
+	//eq = eq && time.Time(f1.CreatedAt).Equal(time.Time(f2.CreatedAt))
+	//eq = eq && time.Time(f2.UpdatedAt).Equal(time.Time(f2.UpdatedAt))
+	return eq
+}
+
+// Update updates fields in f with non-zero field values from new, and sets
+// updated_at if any of the fields change. 0-length slice Header values, and
+// empty-string Config values trigger removal of map entry.
+func (f *Func) Update(patch *Func) {
+	original := f.Clone()
+
+	if patch.Image != "" {
+		f.Image = patch.Image
+	}
+	if patch.Memory != 0 {
+		f.Memory = patch.Memory
+	}
+	if patch.CPUs != 0 {
+		f.CPUs = patch.CPUs
+	}
+	if patch.Timeout != 0 {
+		f.Timeout = patch.Timeout
+	}
+	if patch.IdleTimeout != 0 {
+		f.IdleTimeout = patch.IdleTimeout
+	}
+	if patch.Format != "" {
+		f.Format = patch.Format
+	}
+	if patch.Config != nil {
+		if f.Config == nil {
+			f.Config = make(Config)
+		}
+		for k, v := range patch.Config {
+			if v == "" {
+				delete(f.Config, k)
+			} else {
+				f.Config[k] = v
+			}
+		}
+	}
+
+	f.Annotations = f.Annotations.MergeChange(patch.Annotations)
+
+	if !f.Equals(original) {
+		f.UpdatedAt = strfmt.DateTime(time.Now())
+	}
+}
+
+type FuncFilter struct {
+	Image string // this is exact match
+
+	Cursor  string
+	PerPage int
+}

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -17,7 +17,6 @@ const (
 
 	MaxSyncTimeout  = 120  // 2 minutes
 	MaxAsyncTimeout = 3600 // 1 hour
-	MaxIdleTimeout  = MaxAsyncTimeout
 )
 
 var RouteMaxMemory = uint64(8 * 1024)

--- a/api/server/funcs_delete.go
+++ b/api/server/funcs_delete.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/fnproject/fn/api"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleFuncsDelete(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	fn := c.Param(api.Func)
+	err := s.datastore.RemoveFunc(ctx, fn)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Successfully deleted func"})
+}

--- a/api/server/funcs_get.go
+++ b/api/server/funcs_get.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/fnproject/fn/api"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleFuncsGet(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	fn := c.Param(api.Func)
+	f, err := s.datastore.GetFunc(ctx, fn)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, funcResponse{"Successfully loaded func", f})
+}

--- a/api/server/funcs_list.go
+++ b/api/server/funcs_list.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/fnproject/fn/api/models"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleFuncsList(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var filter models.FuncFilter
+	filter.Cursor, filter.PerPage = pageParams(c, false)
+
+	funcs, err := s.datastore.GetFuncs(ctx, &filter)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	var nextCursor string
+	if len(funcs) > 0 && len(funcs) == filter.PerPage {
+		nextCursor = funcs[len(funcs)-1].ID
+	}
+
+	c.JSON(http.StatusOK, funcsResponse{
+		Message:    "Successfully listed applications",
+		NextCursor: nextCursor,
+		Funcs:      funcs,
+	})
+}

--- a/api/server/funcs_list.go
+++ b/api/server/funcs_list.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"net/http"
 
 	"github.com/fnproject/fn/api/models"
@@ -11,7 +12,7 @@ func (s *Server) handleFuncsList(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var filter models.FuncFilter
-	filter.Cursor, filter.PerPage = pageParams(c, false)
+	filter.Cursor, filter.PerPage = pageParams(c, true)
 
 	funcs, err := s.datastore.GetFuncs(ctx, &filter)
 	if err != nil {
@@ -21,7 +22,8 @@ func (s *Server) handleFuncsList(c *gin.Context) {
 
 	var nextCursor string
 	if len(funcs) > 0 && len(funcs) == filter.PerPage {
-		nextCursor = funcs[len(funcs)-1].ID
+		last := []byte(funcs[len(funcs)-1].Name)
+		nextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
 	c.JSON(http.StatusOK, funcsResponse{

--- a/api/server/funcs_put.go
+++ b/api/server/funcs_put.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/fnproject/fn/api"
+	"github.com/fnproject/fn/api/models"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleFuncsPut(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var wfunc models.FuncWrapper
+	err := c.BindJSON(&wfunc)
+	if err != nil {
+		if !models.IsAPIError(err) {
+			// TODO this error message sucks
+			err = models.ErrInvalidJSON
+		}
+		handleErrorResponse(c, err)
+		return
+	}
+	if wfunc.Func == nil {
+		handleErrorResponse(c, models.ErrFuncsMissingNew)
+		return
+	}
+
+	fn := c.Param(api.Func)
+	// TODO: what about name changes? PutFunc(ctx, name, func) ?
+	wfunc.Func.Name = fn
+
+	f, err := s.datastore.PutFunc(ctx, wfunc.Func)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, funcResponse{"Successfully put func", f})
+}

--- a/api/server/funcs_put.go
+++ b/api/server/funcs_put.go
@@ -26,11 +26,13 @@ func (s *Server) handleFuncsPut(c *gin.Context) {
 		return
 	}
 
-	fn := c.Param(api.Func)
-	// TODO: what about name changes? PutFunc(ctx, name, func) ?
-	wfunc.Func.Name = fn
+	// help them fill name if they aren't trying to change it
+	fname := c.Param(api.Func)
+	if wfunc.Func.Name == "" {
+		wfunc.Func.Name = fname
+	}
 
-	f, err := s.datastore.PutFunc(ctx, wfunc.Func)
+	f, err := s.datastore.PutFunc(ctx, fname, wfunc.Func)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return

--- a/api/server/funcs_test.go
+++ b/api/server/funcs_test.go
@@ -1,0 +1,297 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fnproject/fn/api/datastore"
+	"github.com/fnproject/fn/api/id"
+	"github.com/fnproject/fn/api/logs"
+	"github.com/fnproject/fn/api/models"
+	"github.com/fnproject/fn/api/mqs"
+)
+
+type funcTestCase struct {
+	ds            models.Datastore
+	logDB         models.LogStore
+	method        string
+	path          string
+	body          string
+	expectedCode  int
+	expectedError error
+}
+
+func (test *funcTestCase) run(t *testing.T, i int, buf *bytes.Buffer) {
+	rnr, cancel := testRunner(t)
+	srv := testServer(test.ds, &mqs.Mock{}, test.logDB, rnr, ServerTypeFull)
+
+	body := bytes.NewBuffer([]byte(test.body))
+	_, rec := routerRequest(t, srv.Router, test.method, test.path, body)
+
+	if rec.Code != test.expectedCode {
+		t.Log(buf.String())
+		t.Log(rec.Body.String())
+		t.Errorf("Test %d: Expected status code to be %d but was %d",
+			i, test.expectedCode, rec.Code)
+	}
+
+	if test.expectedError != nil {
+		resp := getErrorResponse(t, rec)
+		if resp.Error == nil {
+			t.Log(buf.String())
+			t.Errorf("Test %d: Expected error message to have `%s`, but it was nil",
+				i, test.expectedError)
+		} else if resp.Error.Message != test.expectedError.Error() {
+			t.Log(buf.String())
+			t.Errorf("Test %d: Expected error message to have `%s`, but it was `%s`",
+				i, test.expectedError, resp.Error.Message)
+		}
+	}
+
+	if test.expectedCode == http.StatusOK {
+		var fwrap models.FuncWrapper
+		err := json.NewDecoder(rec.Body).Decode(&fwrap)
+		if err != nil {
+			t.Log(buf.String())
+			t.Errorf("Test %d: error decoding body for 'ok' json, it was a lie: %v", i, err)
+		}
+
+		fn := fwrap.Func
+		if test.method == http.MethodPut {
+			// IsZero() doesn't really work, this ensures it's not unset as long as we're not in 1970
+			if time.Time(fn.CreatedAt).Before(time.Now().Add(-1 * time.Hour)) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: expected created_at to be set on func, it wasn't: %s", i, fn.CreatedAt)
+			}
+			if time.Time(fn.UpdatedAt).Before(time.Now().Add(-1 * time.Hour)) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: expected updated_at to be set on func, it wasn't: %s", i, fn.UpdatedAt)
+			}
+			if fn.ID == "" {
+				t.Log(buf.String())
+				t.Errorf("Test %d: expected id to be non-empty, it was empty: %v", i, fn)
+			}
+		}
+	}
+
+	cancel()
+	buf.Reset()
+}
+
+func TestFuncPut(t *testing.T) {
+	buf := setLogBuffer()
+
+	ds := datastore.NewMockInit()
+	ls := logs.NewMock()
+	for i, test := range []funcTestCase{
+		// errors
+		{ds, ls, http.MethodPut, "/v1/funcs/a", ``, http.StatusBadRequest, models.ErrInvalidJSON},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ }`, http.StatusBadRequest, models.ErrFuncsMissingNew},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "image": "yo" }`, http.StatusBadRequest, models.ErrFuncsMissingNew},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { } }`, http.StatusBadRequest, models.ErrFuncsMissingImage},
+		{ds, ls, http.MethodPut, "/v1/funcs/ ", `{ "func": { "image": "fnproject/fn-test-utils" } }`, http.StatusBadRequest, models.ErrFuncsInvalidName},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { "image": "fnproject/fn-test-utils", "format": "wazzup" } }`, http.StatusBadRequest, models.ErrFuncsInvalidFormat},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { "image": "fnproject/fn-test-utils", "cpus": "-100" } }`, http.StatusBadRequest, models.ErrInvalidCPUs},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { "image": "fnproject/fn-test-utils", "timeout": 3601 } }`, http.StatusBadRequest, models.ErrInvalidTimeout},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { "image": "fnproject/fn-test-utils", "idle_timeout": 3601 } }`, http.StatusBadRequest, models.ErrInvalidIdleTimeout},
+		{ds, ls, http.MethodPut, "/v1/funcs/a", `{ "func": { "image": "fnproject/fn-test-utils", "memory": 100000000000000 } }`, http.StatusBadRequest, models.ErrInvalidMemory},
+
+		// success create & update
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "image": "fnproject/fn-test-utils" } }`, http.StatusOK, nil},
+
+		// TODO(reed): discuss on #988 do we want to allow partial modifications still?
+		// partial updates should work
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "image": "fnproject/test" } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "format": "http" } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "cpus": "100m" } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "cpus": "0.2" } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "memory": 1000 } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "timeout": 10 } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "idle_timeout": 10 } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "config": {"k":"v"} } }`, http.StatusOK, nil},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "annotations": {"k":"v"} } }`, http.StatusOK, nil},
+
+		// test that partial update fails w/ same errors as create
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "format": "wazzup" } }`, http.StatusBadRequest, models.ErrFuncsInvalidFormat},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "cpus": "-100" } }`, http.StatusBadRequest, models.ErrInvalidCPUs},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "timeout": 3601 } }`, http.StatusBadRequest, models.ErrInvalidTimeout},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "idle_timeout": 3601 } }`, http.StatusBadRequest, models.ErrInvalidIdleTimeout},
+		{ds, ls, http.MethodPut, "/v1/funcs/myfunc", `{ "func": { "memory": 100000000000000 } }`, http.StatusBadRequest, models.ErrInvalidMemory},
+	} {
+		test.run(t, i, buf)
+	}
+}
+
+func TestFuncDelete(t *testing.T) {
+	buf := setLogBuffer()
+
+	funcs := []*models.Func{{Name: "myfunc"}}
+	commonDS := datastore.NewMockInit(funcs)
+
+	for i, test := range []struct {
+		ds            models.Datastore
+		logDB         models.LogStore
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{commonDS, logs.NewMock(), "/v1/funcs/missing", "", http.StatusNotFound, models.ErrFuncsNotFound},
+		{commonDS, logs.NewMock(), "/v1/funcs/myfunc", "", http.StatusOK, nil},
+	} {
+		rnr, cancel := testRunner(t)
+		srv := testServer(test.ds, &mqs.Mock{}, test.logDB, rnr, ServerTypeFull)
+		_, rec := routerRequest(t, srv.Router, "DELETE", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Log(rec.Body.String())
+			t.Errorf("Test %d: Expected status code to be %d but was %d",
+				i, test.expectedCode, rec.Code)
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Error.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`",
+					i, test.expectedError.Error())
+			}
+		}
+		cancel()
+	}
+}
+
+func TestFuncList(t *testing.T) {
+	buf := setLogBuffer()
+
+	rnr, cancel := testRunner(t)
+	defer cancel()
+
+	// ids are sortable, need to test cursoring works as expected
+	r1b := id.New().String()
+	r2b := id.New().String()
+	r3b := id.New().String()
+
+	ds := datastore.NewMockInit(
+		[]*models.Func{
+			{
+				ID:    r1b,
+				Name:  "myfunc",
+				Image: "fnproject/fn-test-utils",
+			},
+			{
+				ID:    r2b,
+				Name:  "myfunc1",
+				Image: "fnproject/fn-test-utils",
+			},
+			{
+				ID:    r3b,
+				Name:  "myfunc2",
+				Image: "fnproject/yo",
+			},
+		},
+	)
+	fnl := logs.NewMock()
+
+	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path string
+		body string
+
+		expectedCode  int
+		expectedError error
+		expectedLen   int
+		nextCursor    string
+	}{
+		{"/v1/funcs", "", http.StatusOK, nil, 3, ""},
+		{"/v1/funcs?per_page=1", "", http.StatusOK, nil, 1, r1b},
+		{"/v1/funcs?per_page=1&cursor=" + r1b, "", http.StatusOK, nil, 1, r2b},
+		{"/v1/funcs?per_page=1&cursor=" + r2b, "", http.StatusOK, nil, 1, r3b},
+		{"/v1/funcs?per_page=100&cursor=" + r2b, "", http.StatusOK, nil, 1, ""}, // cursor is empty if per_page > len(results)
+		{"/v1/funcs?per_page=1&cursor=" + r3b, "", http.StatusOK, nil, 0, ""},   // cursor could point to empty page
+	} {
+		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Errorf("Test %d: Expected status code to be %d but was %d",
+				i, test.expectedCode, rec.Code)
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Error.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`",
+					i, test.expectedError.Error())
+			}
+		} else {
+			// normal path
+
+			var resp funcsResponse
+			err := json.NewDecoder(rec.Body).Decode(&resp)
+			if err != nil {
+				t.Errorf("Test %d: Expected response body to be a valid json object. err: %v", i, err)
+			}
+			if len(resp.Funcs) != test.expectedLen {
+				t.Errorf("Test %d: Expected funcs length to be %d, but got %d", i, test.expectedLen, len(resp.Funcs))
+			}
+			if resp.NextCursor != test.nextCursor {
+				t.Errorf("Test %d: Expected next_cursor to be %s, but got %s", i, test.nextCursor, resp.NextCursor)
+			}
+		}
+	}
+}
+
+func TestFuncGet(t *testing.T) {
+	buf := setLogBuffer()
+
+	rnr, cancel := testRunner(t)
+	defer cancel()
+
+	ds := datastore.NewMockInit([]*models.Func{
+		{
+			Name:  "myfunc",
+			Image: "fnproject/fn-test-utils",
+		},
+	})
+	fnl := logs.NewMock()
+
+	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{"/v1/funcs/missing", "", http.StatusNotFound, models.ErrFuncsNotFound},
+		{"/v1/funcs/myfunc", "", http.StatusOK, nil},
+	} {
+		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Errorf("Test %d: Expected status code to be %d but was %d",
+				i, test.expectedCode, rec.Code)
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Error.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`",
+					i, test.expectedError.Error())
+			}
+		}
+	}
+}

--- a/api/server/funcs_test.go
+++ b/api/server/funcs_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -174,25 +175,29 @@ func TestFuncList(t *testing.T) {
 	defer cancel()
 
 	// ids are sortable, need to test cursoring works as expected
-	r1b := id.New().String()
-	r2b := id.New().String()
-	r3b := id.New().String()
+	r1n := "myfunc"
+	r2n := "myfunc1"
+	r3n := "myfunc2"
+
+	r1b := base64.RawURLEncoding.EncodeToString([]byte(r1n))
+	r2b := base64.RawURLEncoding.EncodeToString([]byte(r2n))
+	r3b := base64.RawURLEncoding.EncodeToString([]byte(r3n))
 
 	ds := datastore.NewMockInit(
 		[]*models.Func{
 			{
-				ID:    r1b,
-				Name:  "myfunc",
+				ID:    id.New().String(),
+				Name:  r1n,
 				Image: "fnproject/fn-test-utils",
 			},
 			{
-				ID:    r2b,
-				Name:  "myfunc1",
+				ID:    id.New().String(),
+				Name:  r2n,
 				Image: "fnproject/fn-test-utils",
 			},
 			{
-				ID:    r3b,
-				Name:  "myfunc2",
+				ID:    id.New().String(),
+				Name:  r3n,
 				Image: "fnproject/yo",
 			},
 		},
@@ -220,6 +225,7 @@ func TestFuncList(t *testing.T) {
 		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
 
 		if rec.Code != test.expectedCode {
+			t.Log(test.path, test.nextCursor)
 			t.Log(buf.String())
 			t.Errorf("Test %d: Expected status code to be %d but was %d",
 				i, test.expectedCode, rec.Code)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -884,6 +884,11 @@ func (s *Server) bindHandlers(ctx context.Context) {
 			v1.GET("/apps", s.handleAppList)
 			v1.POST("/apps", s.handleAppCreate)
 
+			v1.GET("/funcs", s.handleFuncsList)
+			v1.GET("/funcs/:func", s.handleFuncsGet)
+			v1.PUT("/funcs/:func", s.handleFuncsPut)
+			v1.DELETE("/funcs/:func", s.handleFuncsDelete)
+
 			{
 				apps := v1.Group("/apps/:app")
 				apps.Use(appNameCheck)
@@ -894,13 +899,20 @@ func (s *Server) bindHandlers(ctx context.Context) {
 					withAppCheck.GET("", s.handleAppGetByName)
 					withAppCheck.PATCH("", s.handleAppUpdate)
 					withAppCheck.DELETE("", s.handleAppDelete)
+
 					withAppCheck.GET("/routes", s.handleRouteList)
 					withAppCheck.GET("/routes/:route", s.handleRouteGetAPI)
 					withAppCheck.PATCH("/routes/*route", s.handleRoutesPatch)
 					withAppCheck.DELETE("/routes/*route", s.handleRouteDelete)
+
 					withAppCheck.GET("/calls/:call", s.handleCallGet)
 					withAppCheck.GET("/calls/:call/log", s.handleCallLogGet)
 					withAppCheck.GET("/calls", s.handleCallList)
+
+					withAppCheck.GET("/triggers", s.handleFuncsList)
+					withAppCheck.GET("/triggers/:trigger", s.handleFuncsGet)
+					withAppCheck.PUT("/triggers/:trigger", s.handleFuncsPut)
+					withAppCheck.DELETE("/triggers/:trigger", s.handleFuncsDelete)
 				}
 
 				apps.POST("/routes", s.handleRoutesPostPut)
@@ -1007,4 +1019,15 @@ type callsResponse struct {
 	Message    string         `json:"message"`
 	NextCursor string         `json:"next_cursor"`
 	Calls      []*models.Call `json:"calls"`
+}
+
+type funcResponse struct {
+	Message string       `json:"message"`
+	Func    *models.Func `json:"func"`
+}
+
+type funcsResponse struct {
+	Message    string         `json:"message"`
+	NextCursor string         `json:"next_cursor"`
+	Funcs      []*models.Func `json:"funcs"`
 }


### PR DESCRIPTION
this simply plumbs the function API model and CRUD endpoints, without doing
any removal of existing constructs in fn. that is, it is possible to
create/read/update/delete functions without the ability to invoke them at all,
whatsoever. the hope is that this reiterates that we have too many test
suites, reiterates that my karma is far more negative than originally thought,
and this allows the CLI and other datastore implementers to get unblocked on
this, and we can then begin the re-plumbing of agent to invoke functions
rather than routes on top of this.

note that this does not reflect extremely recent discussions around certain
fields on a func, it should be rather easy to modify this code to change/add
any fields that we want to. we need to put them on an app as we've decided,
which is pretty straightforward from this, too. The other thing that sticks
out is that PUT behaves very much like PATCH and there is maybe a discussion
to have around that (esp. keeping in mind that we're adding revisions).

we can quickly rename this to `fns` too, nothing final here.