### PR TITLE
Use context logging more to ensure context vars are present in log lines

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1006,7 +1006,7 @@ func NewHotContainer(ctx context.Context, call *call, cfg *AgentConfig) (*contai
 	syslogConns, err := syslogConns(ctx, call.SyslogURL)
 	if err != nil {
 		// TODO we could write this to between stderr but between stderr doesn't go to user either. kill me.
-		logrus.WithError(err).WithFields(logrus.Fields{"app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}).Error("error dialing syslog urls")
+		common.Logger(ctx).WithError(err).WithFields(logrus.Fields{"app_id": call.AppID, "path": call.Path, "image": call.Image, "container_id": id}).Error("error dialing syslog urls")
 	}
 
 	// for use if no freezer (or we ever make up our minds)

--- a/api/agent/func_logger.go
+++ b/api/agent/func_logger.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 	"github.com/sirupsen/logrus"
 )
@@ -41,7 +42,7 @@ func setupLogger(ctx context.Context, maxSize uint64, c *models.Call) io.ReadWri
 	limitw := &nopCloser{newLimitWriter(int(maxSize), dbuf)}
 
 	// accumulate all line writers, wrap in same line writer (to re-use buffer)
-	stderrLogger := logrus.WithFields(logrus.Fields{"user_log": true, "app_id": c.AppID, "path": c.Path, "image": c.Image, "call_id": c.ID})
+	stderrLogger := common.Logger(ctx).WithFields(logrus.Fields{"user_log": true, "app_id": c.AppID, "path": c.Path, "image": c.Image, "call_id": c.ID})
 	loggo := &nopCloser{&logWriter{stderrLogger}}
 
 	// we don't need to limit the log writer(s), but we do need it to dispense lines

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -181,8 +181,9 @@ func (a *lbAgent) Submit(callI Call) error {
 	if buf != nil {
 		defer bufPool.Put(buf)
 	}
+
 	if err != nil {
-		logrus.WithError(err).Error("Failed to process call body")
+		common.Logger(call.req.Context()).WithError(err).Error("Failed to process call body")
 		return a.handleCallEnd(ctx, call, err, true)
 	}
 
@@ -192,7 +193,7 @@ func (a *lbAgent) Submit(callI Call) error {
 	// isStarted=true means we will call Call.End().
 	err = a.placer.PlaceCall(a.rp, ctx, call)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to place call")
+		common.Logger(call.req.Context()).WithError(err).Error("Failed to place call")
 	}
 
 	return a.handleCallEnd(ctx, call, err, true)

--- a/api/runnerpool/naive_placer.go
+++ b/api/runnerpool/naive_placer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fnproject/fn/api/models"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,10 +27,11 @@ func NewNaivePlacer() Placer {
 
 func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall) error {
 
+	log := common.Logger(ctx)
 	for {
 		runners, err := rp.Runners(call)
 		if err != nil {
-			logrus.WithError(err).Error("Failed to find runners for call")
+			log.WithError(err).Error("Failed to find runners for call")
 		} else {
 			for j := 0; j < len(runners); j++ {
 
@@ -47,7 +49,7 @@ func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call Runner
 				tryCancel()
 
 				if err != nil && err != models.ErrCallTimeoutServerBusy {
-					logrus.WithError(err).Error("Failed during call placement")
+					log.WithError(err).Error("Failed during call placement")
 				}
 				if placed {
 					return err

--- a/grpcutil/dial.go
+++ b/grpcutil/dial.go
@@ -10,8 +10,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/fnproject/fn/api/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -23,23 +22,24 @@ func DialWithBackoff(ctx context.Context, address string, creds credentials.Tran
 
 // uses grpc connection backoff protocol https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
 func dial(ctx context.Context, address string, creds credentials.TransportCredentials, timeoutDialer time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-
 	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
+		log := common.Logger(ctx).WithField("grpc_addr", address)
+
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		conn, err := (&net.Dialer{Cancel: ctx.Done(), Timeout: timeoutDialer}).Dial("tcp", address)
 		if err != nil {
-			logrus.WithError(err).WithField("grpc_addr", address).Warn("Failed to dial grpc connection")
+			log.WithError(err).Warn("Failed to dial grpc connection")
 			return nil, err
 		}
 		if creds == nil {
-			logrus.WithField("grpc_addr", address).Warn("Created insecure grpc connection")
+			log.Warn("Created insecure grpc connection")
 			return conn, nil
 		}
 
 		conn, _, err = creds.ClientHandshake(ctx, address, conn)
 		if err != nil {
-			logrus.WithError(err).WithField("grpc_addr", address).Warn("Failed grpc TLS handshake")
+			log.Warn("Failed grpc TLS handshake")
 			return nil, err
 		}
 		return conn, nil


### PR DESCRIPTION
Scan through all log lines to add context logging where (I think) it's appropriate. 

This doesn't deal with context fields transfering over gRPC but should imrove the quality of some of the current runner messages when that is done