### PR TITLE
fn: introducing hot function max requests limit

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -842,6 +842,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 	ctx, shutdownContainer := context.WithCancel(ctx)
 	defer shutdownContainer() // close this if our waiter returns, to call off slots
 	go func() {
+		remaining := call.MaxRequests
 		defer shutdownContainer() // also close if we get an agent shutdown / idle timeout
 
 		for {
@@ -870,6 +871,13 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 			if slot.fatalErr != nil {
 				logger.WithError(slot.fatalErr).Info("hot function terminating")
 				return
+			}
+
+			if remaining != 0 {
+				remaining--
+				if remaining == 0 {
+					return
+				}
 			}
 		}
 	}()

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -120,6 +120,7 @@ func FromRequest(a Agent, app *models.App, path string, req *http.Request) CallO
 			Timeout:     route.Timeout,
 			IdleTimeout: route.IdleTimeout,
 			TmpFsSize:   route.TmpFsSize,
+			MaxRequests: route.MaxRequests,
 			Memory:      route.Memory,
 			CPUs:        route.CPUs,
 			Config:      buildConfig(app, route),

--- a/api/datastore/sql/migrations/15_add_max_requests_route.go
+++ b/api/datastore/sql/migrations/15_add_max_requests_route.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up15(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE routes ADD max_requests int;")
+
+	return err
+}
+
+func down15(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE routes DROP COLUMN max_requests;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(15),
+		UpFunc:      up15,
+		DownFunc:    down15,
+	})
+}

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -48,6 +48,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 	cpus int,
 	timeout int NOT NULL,
 	idle_timeout int NOT NULL,
+	max_requests int,
 	tmpfs_size int,
 	type varchar(16) NOT NULL,
 	headers text NOT NULL,
@@ -89,7 +90,7 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS routes (
 }
 
 const (
-	routeSelector     = `SELECT app_id, path, image, format, memory, type, cpus, timeout, idle_timeout, tmpfs_size, headers, config, annotations, created_at, updated_at FROM routes`
+	routeSelector     = `SELECT app_id, path, image, format, memory, type, cpus, timeout, idle_timeout, max_requests, tmpfs_size, headers, config, annotations, created_at, updated_at FROM routes`
 	callSelector      = `SELECT id, created_at, started_at, completed_at, status, app_id, path, stats, error FROM calls`
 	appIDSelector     = `SELECT id, name, config, annotations, syslog_url, created_at, updated_at FROM apps WHERE id=?`
 	ensureAppSelector = `SELECT id FROM apps WHERE name=?`
@@ -529,6 +530,7 @@ func (ds *SQLStore) InsertRoute(ctx context.Context, route *models.Route) (*mode
 			type,
 			timeout,
 			idle_timeout,
+			max_requests,
 			tmpfs_size,
 			headers,
 			config,
@@ -546,6 +548,7 @@ func (ds *SQLStore) InsertRoute(ctx context.Context, route *models.Route) (*mode
 			:type,
 			:timeout,
 			:idle_timeout,
+			:max_requests,
 			:tmpfs_size,
 			:headers,
 			:config,
@@ -589,6 +592,7 @@ func (ds *SQLStore) UpdateRoute(ctx context.Context, newroute *models.Route) (*m
 			type = :type,
 			timeout = :timeout,
 			idle_timeout = :idle_timeout,
+			max_requests = :max_requests,
 			tmpfs_size = :tmpfs_size,
 			headers = :headers,
 			config = :config,

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -111,6 +111,9 @@ type Call struct {
 	// Tmpfs size in megabytes.
 	TmpFsSize uint32 `json:"tmpfs_size,omitempty" db:"-"`
 
+	// Maximum number of requests allowed in a hot container
+	MaxRequests uint64 `json:"max_requests,omitempty" db:"-"`
+
 	// Memory is the amount of RAM this call is allocated.
 	Memory uint64 `json:"memory,omitempty" db:"-"`
 

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -36,6 +36,7 @@ type Route struct {
 	Timeout     int32           `json:"timeout" db:"timeout"`
 	IdleTimeout int32           `json:"idle_timeout" db:"idle_timeout"`
 	TmpFsSize   uint32          `json:"tmpfs_size" db:"tmpfs_size"`
+	MaxRequests uint64          `json:"max_requests" db:"max_requests"`
 	Config      Config          `json:"config,omitempty" db:"config"`
 	Annotations Annotations     `json:"annotations,omitempty" db:"annotations"`
 	CreatedAt   strfmt.DateTime `json:"created_at,omitempty" db:"created_at"`
@@ -176,6 +177,7 @@ func (r1 *Route) Equals(r2 *Route) bool {
 	eq = eq && r1.Timeout == r2.Timeout
 	eq = eq && r1.IdleTimeout == r2.IdleTimeout
 	eq = eq && r1.TmpFsSize == r2.TmpFsSize
+	eq = eq && r1.MaxRequests == r2.MaxRequests
 	eq = eq && r1.Config.Equals(r2.Config)
 	eq = eq && r1.Annotations.Equals(r2.Annotations)
 	// NOTE: datastore tests are not very fun to write with timestamp checks,
@@ -211,6 +213,9 @@ func (r *Route) Update(patch *Route) {
 	}
 	if patch.TmpFsSize != 0 {
 		r.TmpFsSize = patch.TmpFsSize
+	}
+	if patch.MaxRequests != 0 {
+		r.MaxRequests = patch.MaxRequests
 	}
 	if patch.Format != "" {
 		r.Format = patch.Format

--- a/docs/developers/function-file.md
+++ b/docs/developers/function-file.md
@@ -84,3 +84,5 @@ hot functions support also adds two extra options to this configuration file.
 
 `idle_timeout` (optional) is the time in seconds a container will remain alive without receiving any new requests; 
 hot functions will stay alive as long as they receive a request in this interval. Default: `30`.
+
+`max_requests` (optional) max number of requests a container can execute. After max_requests of requests are handled, the container will be terminated. Default: `0` unlimited.

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: fn
   description: The open source serverless platform.
-  version: "0.2.4"
+  version: "0.2.5"
 # the domain of the service
 host: "127.0.0.1:8080"
 # array of all schemes that your API supports
@@ -522,6 +522,10 @@ definitions:
         default: 30
         format: int32
         description: Hot functions idle timeout before termination. Value in Seconds
+      max_requests:
+        type: integer
+        format: uint64
+        description: Max number of requests that can be handled in a hot function.
       annotations:
         type: object
         description: Route annotations - this is a map of annotations attached to this route, keys must not exceed 128 bytes and must consist of non-whitespace printable ascii characters, and the seralized representation of individual values must not exeed 512 bytes


### PR DESCRIPTION
Other than idle_timeout, hot-functions have a potential
of staying alive unbounded amount of time. In certain routes,
it may be desirable to limit total request count.

Setting max_requests to 1 also simulates a cold-function behavior
(but with superior formats: json, cloudevents, http) since
only one execution will be performed in a given container.
This change is also a preliminary step for decommissioning cold-format
since max_requests parameter can now meet cold requirements.

In busy deployments, max_requests can be valuable workaround
for resource leaks in problematic routes.

In future, max_time can also be added to limit the total
execution time.