### PR TITLE
Add vboxnet0 to the list of interface names that shouldn't be used for testing

### DIFF
--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -240,7 +240,7 @@ func getEnvInt(key string, fallback int) int {
 func whoAmI() net.IP {
 	ints, _ := net.Interfaces()
 	for _, i := range ints {
-		if i.Name == "docker0" || i.Name == "lo" {
+		if i.Name == "docker0" || i.Name == "vboxnet0" || i.Name == "lo" {
 			// not perfect
 			continue
 		}


### PR DESCRIPTION
This was breaking system tests for me on macOS with VirtualBox installed.
This blacklist of interface names is definitely far from perfect, but this fixes it for me.