### PR TITLE
fn: introducing lb placer basic metrics

### DIFF
--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 
 	"github.com/dchest/siphash"
-	"github.com/fnproject/fn/api/common"
 	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
 )
 
 type chPlacer struct {
@@ -30,28 +31,34 @@ func NewCHPlacer() Placer {
 // the LB_WAIT to drive placement decisions: runners only accept work if they have the capacity for it.
 func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall) error {
 
+	startTime := time.Now()
 	log := common.Logger(ctx)
 
 	// The key is just the path in this case
 	key := call.Model().Path
 	sum64 := siphash.Hash(0, 0x4c617279426f6174, []byte(key))
 
+OutTries:
 	for {
 		runners, err := rp.Runners(call)
 		if err != nil {
+			stats.Record(ctx, errorPoolCountMeasure.M(0))
 			log.WithError(err).Error("Failed to find runners for call")
 		} else {
-			i := int(jumpConsistentHash(sum64, int32(len(runners))))
-			for j := 0; j < len(runners); j++ {
+			if len(runners) == 0 {
+				stats.Record(ctx, emptyPoolCountMeasure.M(0))
+			}
 
-				select {
-				case <-ctx.Done():
-					return models.ErrCallTimeoutServerBusy
-				default:
+			i := int(jumpConsistentHash(sum64, int32(len(runners))))
+
+			for j := 0; j < len(runners); j++ {
+				if ctx.Err() != nil {
+					break OutTries
 				}
 
 				r := runners[i]
 
+				attemptTime := time.Now()
 				tryCtx, tryCancel := context.WithCancel(ctx)
 				placed, err := r.TryExec(tryCtx, call)
 				tryCancel()
@@ -60,20 +67,47 @@ func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall
 					log.WithError(err).Error("Failed during call placement")
 				}
 				if placed {
+					if err != nil {
+						stats.Record(ctx, placedErrorCountMeasure.M(0))
+					} else {
+						stats.Record(ctx, placedOKCountMeasure.M(0))
+					}
+					// IMPORTANT: here we use (attempt_time - start_time). We want to exclude TryExec
+					// latency *if* TryExec() goes through with success. Placer latency metric only shows
+					// how much time are spending in Placer loop/retries. The metric includes rtt/latency of
+					// *all* unsuccessful NACK (retriable) responses from runners as well. For example, if
+					// Placer loop here retries 4 runners (which takes 5 msecs each) and then 5th runner
+					// succeeds (but takes 35 seconds to finish execution), we report 20 msecs as our LB
+					// latency.
+					stats.Record(ctx, placerLatencyMeasure.M(int64(attemptTime.Sub(startTime)/time.Millisecond)))
 					return err
 				}
 
 				i = (i + 1) % len(runners)
+
+				// Too Busy is super common case, we track it separately
+				if err == models.ErrCallTimeoutServerBusy {
+					stats.Record(ctx, retryTooBusyCountMeasure.M(0))
+				} else {
+					stats.Record(ctx, retryErrorCountMeasure.M(0))
+				}
 			}
 		}
+
+		stats.Record(ctx, fullScanCountMeasure.M(0))
 
 		// backoff
 		select {
 		case <-ctx.Done():
-			return models.ErrCallTimeoutServerBusy
+			break OutTries
 		case <-time.After(p.rrInterval):
 		}
 	}
+
+	// Cancel Exit Path / Client cancelled/timedout
+	stats.Record(ctx, cancelCountMeasure.M(0))
+	stats.Record(ctx, placerLatencyMeasure.M(int64(time.Now().Sub(startTime)/time.Millisecond)))
+	return models.ErrCallTimeoutServerBusy
 }
 
 // A Fast, Minimal Memory, Consistent Hash Algorithm:

--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -31,7 +31,7 @@ func NewCHPlacer() Placer {
 // the LB_WAIT to drive placement decisions: runners only accept work if they have the capacity for it.
 func (p *chPlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall) error {
 
-	startTime := time.Now()
+	tracker := newAttemptTracker(ctx)
 	log := common.Logger(ctx)
 
 	// The key is just the path in this case
@@ -42,59 +42,53 @@ OutTries:
 	for {
 		runners, err := rp.Runners(call)
 		if err != nil {
-			stats.Record(ctx, errorPoolCountMeasure.M(0))
 			log.WithError(err).Error("Failed to find runners for call")
-		} else {
-			if len(runners) == 0 {
-				stats.Record(ctx, emptyPoolCountMeasure.M(0))
+			stats.Record(ctx, errorPoolCountMeasure.M(0))
+			tracker.finalizeAttempts(false)
+			return err
+		}
+
+		i := int(jumpConsistentHash(sum64, int32(len(runners))))
+		for j := 0; j < len(runners); j++ {
+			if ctx.Err() != nil {
+				break OutTries
 			}
 
-			i := int(jumpConsistentHash(sum64, int32(len(runners))))
+			r := runners[i]
 
-			for j := 0; j < len(runners); j++ {
-				if ctx.Err() != nil {
-					break OutTries
-				}
+			tracker.recordAttempt()
+			tryCtx, tryCancel := context.WithCancel(ctx)
+			placed, err := r.TryExec(tryCtx, call)
+			tryCancel()
 
-				r := runners[i]
+			// Only log unusual (except for too-busy) errors
+			if err != nil && err != models.ErrCallTimeoutServerBusy {
+				log.WithError(err).Errorf("Failed during call placement, placed=%v", placed)
+			}
 
-				attemptTime := time.Now()
-				tryCtx, tryCancel := context.WithCancel(ctx)
-				placed, err := r.TryExec(tryCtx, call)
-				tryCancel()
-
-				if err != nil && err != models.ErrCallTimeoutServerBusy {
-					log.WithError(err).Error("Failed during call placement")
-				}
-				if placed {
-					if err != nil {
-						stats.Record(ctx, placedErrorCountMeasure.M(0))
-					} else {
-						stats.Record(ctx, placedOKCountMeasure.M(0))
-					}
-					// IMPORTANT: here we use (attempt_time - start_time). We want to exclude TryExec
-					// latency *if* TryExec() goes through with success. Placer latency metric only shows
-					// how much time are spending in Placer loop/retries. The metric includes rtt/latency of
-					// *all* unsuccessful NACK (retriable) responses from runners as well. For example, if
-					// Placer loop here retries 4 runners (which takes 5 msecs each) and then 5th runner
-					// succeeds (but takes 35 seconds to finish execution), we report 20 msecs as our LB
-					// latency.
-					stats.Record(ctx, placerLatencyMeasure.M(int64(attemptTime.Sub(startTime)/time.Millisecond)))
-					return err
-				}
-
-				i = (i + 1) % len(runners)
-
-				// Too Busy is super common case, we track it separately
-				if err == models.ErrCallTimeoutServerBusy {
-					stats.Record(ctx, retryTooBusyCountMeasure.M(0))
+			if placed {
+				if err != nil {
+					stats.Record(ctx, placedErrorCountMeasure.M(0))
 				} else {
-					stats.Record(ctx, retryErrorCountMeasure.M(0))
+					stats.Record(ctx, placedOKCountMeasure.M(0))
 				}
+				tracker.finalizeAttempts(true)
+				return err
+			}
+
+			i = (i + 1) % len(runners)
+
+			// Too Busy is super common case, we track it separately
+			if err == models.ErrCallTimeoutServerBusy {
+				stats.Record(ctx, retryTooBusyCountMeasure.M(0))
+			} else {
+				stats.Record(ctx, retryErrorCountMeasure.M(0))
 			}
 		}
 
-		stats.Record(ctx, fullScanCountMeasure.M(0))
+		if len(runners) == 0 {
+			stats.Record(ctx, emptyPoolCountMeasure.M(0))
+		}
 
 		// backoff
 		select {
@@ -106,7 +100,7 @@ OutTries:
 
 	// Cancel Exit Path / Client cancelled/timedout
 	stats.Record(ctx, cancelCountMeasure.M(0))
-	stats.Record(ctx, placerLatencyMeasure.M(int64(time.Now().Sub(startTime)/time.Millisecond)))
+	tracker.finalizeAttempts(true)
 	return models.ErrCallTimeoutServerBusy
 }
 

--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -100,7 +100,7 @@ OutTries:
 
 	// Cancel Exit Path / Client cancelled/timedout
 	stats.Record(ctx, cancelCountMeasure.M(0))
-	tracker.finalizeAttempts(true)
+	tracker.finalizeAttempts(false)
 	return models.ErrCallTimeoutServerBusy
 }
 

--- a/api/runnerpool/naive_placer.go
+++ b/api/runnerpool/naive_placer.go
@@ -5,10 +5,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 
-	"github.com/fnproject/fn/api/common"
 	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
 )
 
 type naivePlacer struct {
@@ -27,23 +28,28 @@ func NewNaivePlacer() Placer {
 
 func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call RunnerCall) error {
 
+	startTime := time.Now()
 	log := common.Logger(ctx)
+
+OutTries:
 	for {
 		runners, err := rp.Runners(call)
 		if err != nil {
+			stats.Record(ctx, errorPoolCountMeasure.M(0))
 			log.WithError(err).Error("Failed to find runners for call")
 		} else {
+			if len(runners) == 0 {
+				stats.Record(ctx, emptyPoolCountMeasure.M(0))
+			}
 			for j := 0; j < len(runners); j++ {
-
-				select {
-				case <-ctx.Done():
-					return models.ErrCallTimeoutServerBusy
-				default:
+				if ctx.Err() != nil {
+					break OutTries
 				}
 
 				i := atomic.AddUint64(&sp.rrIndex, uint64(1))
 				r := runners[int(i)%len(runners)]
 
+				attemptTime := time.Now()
 				tryCtx, tryCancel := context.WithCancel(ctx)
 				placed, err := r.TryExec(tryCtx, call)
 				tryCancel()
@@ -52,16 +58,43 @@ func (sp *naivePlacer) PlaceCall(rp RunnerPool, ctx context.Context, call Runner
 					log.WithError(err).Error("Failed during call placement")
 				}
 				if placed {
+					if err != nil {
+						stats.Record(ctx, placedErrorCountMeasure.M(0))
+					} else {
+						stats.Record(ctx, placedOKCountMeasure.M(0))
+					}
+					// IMPORTANT: here we use (attempt_time - start_time). We want to exclude TryExec
+					// latency *if* TryExec() goes through with success. Placer latency metric only shows
+					// how much time are spending in Placer loop/retries. The metric includes rtt/latency of
+					// *all* unsuccessful NACK (retriable) responses from runners as well. For example, if
+					// Placer loop here retries 4 runners (which takes 5 msecs each) and then 5th runner
+					// succeeds (but takes 35 seconds to finish execution), we report 20 msecs as our LB
+					// latency.
+					stats.Record(ctx, placerLatencyMeasure.M(int64(attemptTime.Sub(startTime)/time.Millisecond)))
 					return err
+				}
+
+				// Too Busy is super common case, we track it separately
+				if err == models.ErrCallTimeoutServerBusy {
+					stats.Record(ctx, retryTooBusyCountMeasure.M(0))
+				} else {
+					stats.Record(ctx, retryErrorCountMeasure.M(0))
 				}
 			}
 		}
 
+		stats.Record(ctx, fullScanCountMeasure.M(0))
+
 		// backoff
 		select {
 		case <-ctx.Done():
-			return models.ErrCallTimeoutServerBusy
+			break OutTries
 		case <-time.After(sp.rrInterval):
 		}
 	}
+
+	// Cancel Exit Path / Client cancelled/timedout
+	stats.Record(ctx, cancelCountMeasure.M(0))
+	stats.Record(ctx, placerLatencyMeasure.M(int64(time.Now().Sub(startTime)/time.Millisecond)))
+	return models.ErrCallTimeoutServerBusy
 }

--- a/api/runnerpool/placer_stats.go
+++ b/api/runnerpool/placer_stats.go
@@ -1,0 +1,59 @@
+package runnerpool
+
+import (
+	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	fullScanCountMeasure     = stats.Int64("lb_placer_fullscan_count", "LB Placer Full RunnerList Scan Count", "")
+	errorPoolCountMeasure    = stats.Int64("lb_placer_rp_error_count", "LB Placer RunnerPool RunnerList Error Count", "")
+	emptyPoolCountMeasure    = stats.Int64("lb_placer_rp_empty_count", "LB Placer RunnerPool RunnerList Empty Count", "")
+	cancelCountMeasure       = stats.Int64("lb_placer_client_cancelled_count", "LB Placer Client Cancel Count", "")
+	placedErrorCountMeasure  = stats.Int64("lb_placer_placed_error_count", "LB Placer Placed Call Count With Errors", "")
+	placedOKCountMeasure     = stats.Int64("lb_placer_placed_ok_count", "LB Placer Placed Call Count Without Errors", "")
+	retryTooBusyCountMeasure = stats.Int64("lb_placer_retry_busy_count", "LB Placer Retry Count - Too Busy", "")
+	retryErrorCountMeasure   = stats.Int64("lb_placer_retry_error_count", "LB Placer Retry Count - Errors", "")
+	placerLatencyMeasure     = stats.Int64("lb_placer_latency", "LB Placer Latency", "msecs")
+)
+
+func makeKeys(names []string) []tag.Key {
+	var tagKeys []tag.Key
+	for _, name := range names {
+		key, err := tag.NewKey(name)
+		if err != nil {
+			logrus.WithError(err).Fatal("cannot create tag key for %v", name)
+		}
+		tagKeys = append(tagKeys, key)
+	}
+	return tagKeys
+}
+
+func createView(measure stats.Measure, agg *view.Aggregation, tagKeys []string) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		TagKeys:     makeKeys(tagKeys),
+		Measure:     measure,
+		Aggregation: agg,
+	}
+}
+
+func RegisterPlacerViews(tagKeys []string) {
+	err := view.Register(
+		createView(fullScanCountMeasure, view.Count(), tagKeys),
+		createView(errorPoolCountMeasure, view.Count(), tagKeys),
+		createView(emptyPoolCountMeasure, view.Count(), tagKeys),
+		createView(cancelCountMeasure, view.Count(), tagKeys),
+		createView(placedErrorCountMeasure, view.Count(), tagKeys),
+		createView(placedOKCountMeasure, view.Count(), tagKeys),
+		createView(retryTooBusyCountMeasure, view.Count(), tagKeys),
+		createView(retryErrorCountMeasure, view.Count(), tagKeys),
+		createView(placerLatencyMeasure, view.Distribution(1, 10, 25, 50, 200, 1000, 10000, 60000), tagKeys),
+	)
+	if err != nil {
+		logrus.WithError(err).Fatal("cannot create view")
+	}
+}

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -16,6 +16,7 @@ type Placer interface {
 
 // RunnerPool is the abstraction for getting an ordered list of runners to try for a call
 type RunnerPool interface {
+	// returns an error for unrecoverable errors that should not be retried
 	Runners(call RunnerCall) ([]Runner, error)
 	Shutdown(ctx context.Context) error
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -468,8 +468,11 @@ func WithAgentFromEnv() ServerOption {
 				placer = pool.NewNaivePlacer()
 			}
 
-			keys := []string{"fn_appname", "fn_path"}
-			pool.RegisterPlacerViews(keys)
+			// If prometheus is enabled, add LB placer metrics to the views
+			if s.promExporter != nil {
+				keys := []string{"fn_appname", "fn_path"}
+				pool.RegisterPlacerViews(keys)
+			}
 
 			s.agent, err = agent.NewLBAgent(agent.NewCachedDataAccess(cl), runnerPool, placer)
 			if err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -468,6 +468,9 @@ func WithAgentFromEnv() ServerOption {
 				placer = pool.NewNaivePlacer()
 			}
 
+			keys := []string{"fn_appname", "fn_path"}
+			pool.RegisterPlacerViews(keys)
+
 			s.agent, err = agent.NewLBAgent(agent.NewCachedDataAccess(cl), runnerPool, placer)
 			if err != nil {
 				return errors.New("LBAgent creation failed")

--- a/system_test.sh
+++ b/system_test.sh
@@ -10,7 +10,9 @@ function remove_system_containers {
 
 remove_system_containers
 
-case "$1" in
+DB_NAME=$1
+
+case "$DB_NAME" in
     "sqlite3" )
     rm -fr /tmp/fn_system_tests.db
     touch /tmp/fn_system_tests.db
@@ -44,6 +46,11 @@ export FN_DS_DB_PING_MAX_RETRIES=60
 export FN_MAX_REQUEST_SIZE=6291456
 export FN_MAX_RESPONSE_SIZE=6291456
 export FN_ENABLE_NB_RESOURCE_TRACKER=1
+
+#
+# dump prometheus metrics to this file
+#
+export SYSTEM_TEST_PROMETHEUS_FILE=./prometheus.${DB_NAME}.txt
 
 cd test/fn-system-tests && FN_DB_URL=${FN_DB_URL} FN_API_URL=${FN_API_URL} go test -v -parallel ${2:-1} ./...; cd ../../
 

--- a/test/fn-system-tests/.gitignore
+++ b/test/fn-system-tests/.gitignore
@@ -1,0 +1,1 @@
+prometheus.*.txt

--- a/test/fn-system-tests/exec_test.go
+++ b/test/fn-system-tests/exec_test.go
@@ -17,16 +17,6 @@ import (
 	sdkmodels "github.com/fnproject/fn_go/models"
 )
 
-func LB() (string, error) {
-	lbURL := "http://127.0.0.1:8081"
-
-	u, err := url.Parse(lbURL)
-	if err != nil {
-		return "", err
-	}
-	return u.Host, nil
-}
-
 func getEchoContent(respBytes []byte) (string, error) {
 
 	var respJs map[string]interface{}


### PR DESCRIPTION
This change adds basic metrics to naive and consistent
hash LB placers. The stats show how many times we scanned
the full runner list, if runner pool failed to return a
runner list or if runner pool returned an empty list.

Placed and not placed status are also tracked along with
if TryExec returned an error or not. Most common error
code, Too-Busy is specifically tracked.

If client cancels/times out, this is also tracked as
a client cancel metric.

For placer latency, we would like to know how much time
the placer spent on searching for a runner until it
successfully places a call. This includes round-trip
times for NACK responses from the runners until a successful
TryExec() call. By excluding last successful TryExec() latency,
we try to exclude function execution & runner container
startup time from this metric in an attempt to isolate
Placer only latency.