### PR TITLE
create issue_template.md

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,54 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and will close it. We
+will, however, reopen it if you later provide the information.
+
+---------------------------------------------------
+GENERAL SUPPORT INFORMATION
+---------------------------------------------------
+
+The GitHub issue tracker is for bug reports and feature requests.
+General support for **fn** can be found at the following locations:
+
+- Slack - https://fnproject.slack.com #general channel
+- Post a question on StackOverflow, using the ‘fn' tag: https://stackoverflow.com/questions/tagged/fn
+
+---------------------------------------------------
+BUG REPORT INFORMATION
+---------------------------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce the issue:**
+1.
+2.
+3.
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+**Output of `fn version` (CLI command):**
+
+```
+(paste your output here)
+```
+
+**Additional environment details (OSX, Linux, flags, etc.):**


### PR DESCRIPTION
part 1 of #1067 - this will help users create issues with all (most of?) the context we need without having to ask. it also includes a policy to close bugs that are left stale after 7 days, which is convenient to keep issues from growing like a weed.