### PR TITLE
fn: remove confusing parallelism in test scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
           docker version
       - run: docker version
       - run: nproc
+      # fixes git-diff warning: "warning: inexact rename detection was skipped due to too many files.""
+      - run: git config diff.renamelimit 65535
       - run: make clear-images
 
       # Work out what needs rebuilding and what has changed

--- a/Makefile
+++ b/Makefile
@@ -46,25 +46,25 @@ test-basic: checkfmt pull-images fn-test-utils
 test: checkfmt pull-images test-basic test-middleware test-extensions test-api test-system
 
 test-api: test-basic
-	./api_test.sh sqlite3 4
-	./api_test.sh mysql 4 0
-	./api_test.sh postgres 4 0
+	./api_test.sh sqlite3
+	./api_test.sh mysql
+	./api_test.sh postgres
 
 test-system: test-basic
-	./system_test.sh sqlite3 4
-	./system_test.sh mysql 4 0
-	./system_test.sh postgres 4 0
+	./system_test.sh sqlite3
+	./system_test.sh mysql
+	./system_test.sh postgres
 
 img-busybox:
 	docker pull busybox
 img-hello:
 	docker pull fnproject/hello
 img-mysql:
-	docker pull mysql:5.7.22
+	source ./helpers.sh && docker_pull_mysql
 img-postgres:
-	docker pull postgres:9.3-alpine
+	source ./helpers.sh && docker_pull_postgres
 img-minio:
-	docker pull minio/minio
+	source ./helpers.sh && docker_pull_minio
 
 pull-images: img-hello img-mysql img-postgres img-minio img-busybox
 
@@ -91,15 +91,6 @@ docker-build:
 
 docker-run: docker-build
 	docker run --rm --privileged -it -e NO_PROXY -e HTTP_PROXY -e FN_LOG_LEVEL=debug -e "FN_DB_URL=sqlite3:///app/data/fn.db" -v ${CURDIR}/data:/app/data -p 8080:8080 fnproject/fnserver
-
-docker-test-run-with-sqlite3:
-	./api_test.sh sqlite3 4
-
-docker-test-run-with-mysql:
-	./api_test.sh mysql 4
-
-docker-test-run-with-postgres:
-	./api_test.sh postgres 4
 
 docker-test:
 	docker run -ti --privileged --rm -e FN_LOG_LEVEL=debug \

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ img-busybox:
 img-hello:
 	docker pull fnproject/hello
 img-mysql:
-	source ./helpers.sh && docker_pull_mysql
+	/bin/bash -c "source ./helpers.sh && docker_pull_mysql"
 img-postgres:
-	source ./helpers.sh && docker_pull_postgres
+	/bin/bash -c "source ./helpers.sh && docker_pull_postgres"
 img-minio:
-	source ./helpers.sh && docker_pull_minio
+	/bin/bash -c "source ./helpers.sh && docker_pull_minio"
 
 pull-images: img-hello img-mysql img-postgres img-minio img-busybox
 

--- a/api_test.sh
+++ b/api_test.sh
@@ -28,6 +28,6 @@ export FN_DB_URL=$(spawn_${DB_NAME} ${CONTEXT})
 #./fn-api-tests.test -test.v  -test.parallel ${2:-1} ./...; cd ../../
 
 export FN_DS_DB_PING_MAX_RETRIES=60
-cd test/fn-api-tests && FN_API_URL="http://localhost:8080"  FN_DB_URL=${FN_DB_URL} go test -v  -parallel ${2:-1} ./...; cd ../../
+cd test/fn-api-tests && FN_API_URL="http://localhost:8080"  FN_DB_URL=${FN_DB_URL} go test -v  ./...; cd ../../
 
 remove_containers ${CONTEXT}

--- a/helpers.sh
+++ b/helpers.sh
@@ -95,6 +95,18 @@ function spawn_minio {
     echo "s3://admin:password@${HOST}:${PORT}/us-east-1/fnlogs"
 }
 
+function docker_pull_postgres {
+	docker pull postgres:9.3-alpine
+}
+
+function docker_pull_mysql {
+	docker pull mysql:5.7.22
+}
+
+function docker_pull_minio {
+	docker pull minio/minio
+}
+
 function remove_containers {
     local CONTEXT=$1
     for i in mysql minio postgres

--- a/system_test.sh
+++ b/system_test.sh
@@ -22,6 +22,6 @@ export FN_ENABLE_NB_RESOURCE_TRACKER=1
 #
 export SYSTEM_TEST_PROMETHEUS_FILE=./prometheus.${DB_NAME}.txt
 
-cd test/fn-system-tests && FN_DB_URL=${FN_DB_URL} FN_API_URL=${FN_API_URL} go test -v -parallel ${2:-1} ./...; cd ../../
+cd test/fn-system-tests && FN_DB_URL=${FN_DB_URL} FN_API_URL=${FN_API_URL} go test -v ./...; cd ../../
 
 remove_containers ${CONTEXT}

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,14 @@ export MYSQL_URL=$(spawn_mysql ${CONTEXT})
 export MINIO_URL=$(spawn_minio ${CONTEXT})
 export FN_DS_DB_PING_MAX_RETRIES=60
 
-go test -v $(go list ./... | grep -v vendor | grep -v examples | grep -v test/fn-api-tests | grep -v test/fn-system-tests | grep -v images/fn-test-utils)
+go test -v $(go list ./... | \
+    grep -v vendor | \
+    grep -v examples | \
+    grep -v test/fn-api-tests | \
+    grep -v test/fn-system-tests | \
+    grep -v images/fn-test-utils\
+)
+
 go vet $(go list ./... | grep -v vendor)
 
 remove_containers ${CONTEXT}


### PR DESCRIPTION
*) Tests should be consistent when run from makefile versus
running these test scripts from command line. Let go use
GOMAXPROCS instead of hardcoded 4 cpus in Makefile.
*) Moved docker pull for specific image versions into
helpers scripts as well. Easier to maintain image version
for tests in the same place.
*) Minor Makefile cleanup: removed unused makefile targets.