### PR TITLE
fn: agent call overrider

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -120,6 +120,8 @@ type agent struct {
 	shutonce            sync.Once
 	callEndCount        int64
 	disableAsyncDequeue bool
+
+	callOverrider CallOverrider
 }
 
 type AgentOption func(*agent) error
@@ -190,6 +192,17 @@ func WithDockerDriver(drv drivers.Driver) AgentOption {
 func WithoutAsyncDequeue() AgentOption {
 	return func(a *agent) error {
 		a.disableAsyncDequeue = true
+		return nil
+	}
+}
+
+// Agents can use this to register a CallOverrider to modify a Call and extensions
+func WithCallOverrider(fn CallOverrider) AgentOption {
+	return func(a *agent) error {
+		if a.callOverrider != nil {
+			return errors.New("lb-agent call overriders already exists")
+		}
+		a.callOverrider = fn
 		return nil
 	}
 }

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -17,8 +17,6 @@ import (
 	"github.com/fnproject/fn/fnext"
 )
 
-type CallOverrider func(*models.Call, map[string]string) (map[string]string, error)
-
 type lbAgent struct {
 	cfg           AgentConfig
 	da            DataAccess
@@ -40,7 +38,7 @@ func WithLBAgentConfig(cfg *AgentConfig) LBAgentOption {
 }
 
 // LB agents can use this to register a CallOverrider to modify a Call and extensions
-func WithCallOverrider(fn CallOverrider) LBAgentOption {
+func WithLBCallOverrider(fn CallOverrider) LBAgentOption {
 	return func(a *lbAgent) error {
 		if a.callOverrider != nil {
 			return errors.New("lb-agent call overriders already exists")

--- a/test/fn-system-tests/exec_test.go
+++ b/test/fn-system-tests/exec_test.go
@@ -110,6 +110,12 @@ func TestCanExecuteFunction(t *testing.T) {
 	if err != nil || cheese != "Tete de Moine" {
 		t.Fatalf("getConfigContent/FN_CHEESE check failed (%v) on %v", err, output)
 	}
+
+	// Now let's check FN_WINE, since runners have override to insert this.
+	wine, err := getConfigContent("FN_WINE", output.Bytes())
+	if err != nil || wine != "1982 Margaux" {
+		t.Fatalf("getConfigContent/FN_WINE check failed (%v) on %v", err, output)
+	}
 }
 
 func TestCanExecuteBigOutput(t *testing.T) {


### PR DESCRIPTION
Similar to LB Agent call overrider, this PR adds Agent overrider
for Agents to modify/analyze a Call/Extensions during GetCall().

With this PR, we end up with 3 points where a service-provider
might override things:
1) LB GetCall() interception
2) Pure Runner GetCall() interception
3) Pure Runner drivers.driver.CreateCookie() interception 