### PR TITLE
Add a finer-grained view for placer latency metrics

### DIFF
--- a/api/runnerpool/placer_stats.go
+++ b/api/runnerpool/placer_stats.go
@@ -95,7 +95,7 @@ func RegisterPlacerViews(tagKeys []string) {
 		createView(placedOKCountMeasure, view.Count(), tagKeys),
 		createView(retryTooBusyCountMeasure, view.Count(), tagKeys),
 		createView(retryErrorCountMeasure, view.Count(), tagKeys),
-		createView(placerLatencyMeasure, view.Distribution(1, 10, 25, 50, 200, 1000, 10000, 60000), tagKeys),
+		createView(placerLatencyMeasure, view.Distribution(1, 10, 25, 50, 200, 1000, 1500, 2000, 2500, 3000, 10000, 60000), tagKeys),
 	)
 	if err != nil {
 		logrus.WithError(err).Fatal("cannot create view")


### PR DESCRIPTION
This is a small tweak to the placer latency stats. If we have a cluster of values
around the 1-2s mark, then having a single relatively broad bucket that captures
the (1s, 10s] range will obscure that. In particular, typical Prometheus quartile
estimates may be distorted by this bucket size.

We should probably do something better here - either let the end-user inject their distributions, or perhaps generate a log-linear spread across likely values with far more intervals.