### PR TITLE
HTTP Triggers hookup

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -112,7 +112,7 @@ type agent struct {
 	onStartup []func()
 }
 
-type AgentOption func(*agent) error
+type AgentOption func(*agent)
 
 // New creates an Agent that executes functions locally as Docker containers.
 func New(da CallHandler, options ...AgentOption) Agent {
@@ -149,7 +149,6 @@ func New(da CallHandler, options ...AgentOption) Agent {
 	for _, sup := range a.onStartup {
 		sup()
 	}
-	// TODO assert that agent doesn't get started for API nodes up above ?
 	return a
 }
 
@@ -228,15 +227,6 @@ func (a *agent) Close() error {
 		}
 	})
 
-	// shutdown any db/queue resources
-	// associated with DataAccess
-
-	// TODO TRIGGERWIP: stopped agent from closing data access
-
-	daErr := a.da.Close()
-	if daErr != nil {
-		return daErr
-	}
 	return err
 }
 

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -177,7 +177,7 @@ func WithConfig(cfg *AgentConfig) AgentOption {
 	}
 }
 
-// Provide a customer driver to agent
+// WithDockerDriver Provides a customer driver to agent
 func WithDockerDriver(drv drivers.Driver) AgentOption {
 	return func(a *agent) error {
 		if a.driver != nil {
@@ -189,7 +189,7 @@ func WithDockerDriver(drv drivers.Driver) AgentOption {
 	}
 }
 
-// Agents can use this to register a CallOverrider to modify a Call and extensions
+// WithCallOverrider registers register a CallOverrider to modify a Call and extensions on call construction
 func WithCallOverrider(fn CallOverrider) AgentOption {
 	return func(a *agent) error {
 		if a.callOverrider != nil {
@@ -200,7 +200,7 @@ func WithCallOverrider(fn CallOverrider) AgentOption {
 	}
 }
 
-// Create a default docker driver from agent config
+// NewDockerDriver creates a default docker driver from agent config
 func NewDockerDriver(cfg *AgentConfig) *docker.DockerDriver {
 	return docker.NewDocker(drivers.Config{
 		DockerNetworks:       cfg.DockerNetworks,
@@ -827,7 +827,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 	state.UpdateState(ctx, ContainerStateStart, call.slots)
 	defer state.UpdateState(ctx, ContainerStateDone, call.slots)
 
-	container, closer := NewHotContainer(ctx, call, &a.cfg)
+	container, closer := newHotContainer(ctx, call, &a.cfg)
 	defer closer()
 
 	logger := logrus.WithFields(logrus.Fields{"id": container.id, "app_id": call.AppID, "route": call.Path, "image": call.Image, "memory": call.Memory, "cpus": call.CPUs, "format": call.Format, "idle_timeout": call.IdleTimeout})
@@ -1012,7 +1012,8 @@ type container struct {
 	stats  *drivers.Stats
 }
 
-func NewHotContainer(ctx context.Context, call *call, cfg *AgentConfig) (*container, func()) {
+//newHotContainer creates a container that can be used for multiple sequential events
+func newHotContainer(ctx context.Context, call *call, cfg *AgentConfig) (*container, func()) {
 	// if freezer is enabled, be consistent with freezer behavior and
 	// block stdout and stderr between calls.
 	isBlockIdleIO := MaxDisabledMsecs != cfg.FreezeIdle

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -112,7 +112,8 @@ type agent struct {
 	onStartup []func()
 }
 
-type AgentOption func(*agent)
+// AgentOption configures an agent at startup
+type AgentOption func(*agent) error
 
 // New creates an Agent that executes functions locally as Docker containers.
 func New(da CallHandler, options ...AgentOption) Agent {

--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -11,7 +11,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func (a *agent) asyncDequeue() {
+func (a *agent) asyncDequeue(dqda DequeueDataAccess) {
+
 	// this is just so we can hang up the dequeue request if we get shut down
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -37,7 +38,7 @@ func (a *agent) asyncDequeue() {
 		case <-a.shutWg.Closer():
 			a.shutWg.DoneSession()
 			return
-		case model, ok := <-a.asyncChew(ctx):
+		case model, ok := <-a.asyncChew(ctx, dqda):
 			if ok {
 				go func(model *models.Call) {
 					a.asyncRun(ctx, model)
@@ -53,14 +54,14 @@ func (a *agent) asyncDequeue() {
 	}
 }
 
-func (a *agent) asyncChew(ctx context.Context) <-chan *models.Call {
+func (a *agent) asyncChew(ctx context.Context, dqda DequeueDataAccess) <-chan *models.Call {
 	ch := make(chan *models.Call, 1)
 
 	go func() {
 		ctx, cancel := context.WithTimeout(ctx, a.cfg.AsyncChewPoll)
 		defer cancel()
 
-		call, err := a.da.Dequeue(ctx)
+		call, err := dqda.Dequeue(ctx)
 		if call != nil {
 			ch <- call
 		} else { // call is nil / error

--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -12,7 +12,6 @@ import (
 )
 
 func (a *agent) asyncDequeue(dqda DequeueDataAccess) {
-
 	// this is just so we can hang up the dequeue request if we get shut down
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -261,9 +261,6 @@ func reqURL(req *http.Request) string {
 	return req.URL.String()
 }
 
-// TODO this currently relies on FromRequest having happened before to create the model
-// here, to be a fully qualified model. We probably should double check but having a way
-// to bypass will likely be what's used anyway unless forced.
 func FromModel(mCall *models.Call) CallOpt {
 	return func(c *call) error {
 		c.Call = mCall

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -46,16 +46,12 @@ type CallOverrider func(*models.Call, map[string]string) (map[string]string, err
 // TODO build w/o closures... lazy
 type CallOpt func(c *call) error
 
-type Param struct {
-	Key   string
-	Value string
-}
-type Params []Param
-
 const (
 	ceMimeType = "application/cloudevents+json"
 )
 
+// FromRequest initialises a call to a route from an HTTP request
+// deprecate with routes
 func FromRequest(app *models.App, route *models.Route, req *http.Request) CallOpt {
 	return func(c *call) error {
 		ctx := req.Context()
@@ -136,7 +132,7 @@ func FromRequest(app *models.App, route *models.Route, req *http.Request) CallOp
 }
 
 // Sets up a call from an http trigger request
-func FromHttpTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trigger, req *http.Request) CallOpt {
+func FromHTTPTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trigger, req *http.Request) CallOpt {
 	return func(c *call) error {
 		ctx := req.Context()
 
@@ -261,6 +257,7 @@ func reqURL(req *http.Request) string {
 	return req.URL.String()
 }
 
+// FromModel creates a call object from an existing stored call model object, reading the body from the stored call payload
 func FromModel(mCall *models.Call) CallOpt {
 	return func(c *call) error {
 		c.Call = mCall
@@ -277,6 +274,7 @@ func FromModel(mCall *models.Call) CallOpt {
 	}
 }
 
+// FromModelAndInput creates a call object from an existing stored call model object , reading the body from a provided stream
 func FromModelAndInput(mCall *models.Call, in io.ReadCloser) CallOpt {
 	return func(c *call) error {
 		c.Call = mCall
@@ -293,6 +291,7 @@ func FromModelAndInput(mCall *models.Call, in io.ReadCloser) CallOpt {
 	}
 }
 
+// WithWriter sets the writier that the call uses to send its output message to
 // TODO this should be required
 func WithWriter(w io.Writer) CallOpt {
 	return func(c *call) error {
@@ -301,6 +300,7 @@ func WithWriter(w io.Writer) CallOpt {
 	}
 }
 
+// WithContext overrides the context on the call
 func WithContext(ctx context.Context) CallOpt {
 	return func(c *call) error {
 		c.req = c.req.WithContext(ctx)
@@ -308,6 +308,7 @@ func WithContext(ctx context.Context) CallOpt {
 	}
 }
 
+// WithExtensions adds internal attributes to the call that can be interpreted by extensions in the agent
 // Pure runner can use this to pass an extension to the call
 func WithExtensions(extensions map[string]string) CallOpt {
 	return func(c *call) error {
@@ -406,6 +407,8 @@ type call struct {
 	extensions map[string]string
 }
 
+// SlotHashId returns a string identity for this call that can be used to uniquely place the call in a given container
+// This should correspond to a unique identity (including data changes) of the underlying function
 func (c *call) SlotHashId() string {
 	return c.slotHashId
 }

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -192,6 +192,8 @@ func FromHTTPTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trig
 			URL:         reqURL(req),
 			Method:      req.Method,
 			AppID:       app.ID,
+			FnID:        fn.ID,
+			TriggerID:   trigger.ID,
 			SyslogURL:   syslogURL,
 		}
 
@@ -224,21 +226,22 @@ func buildConfig(app *models.App, route *models.Route) models.Config {
 	return conf
 }
 
-func buildTriggerConfig(app *models.App, route *models.Fn, trigger *models.Trigger) models.Config {
-	conf := make(models.Config, 8+len(app.Config)+len(route.Config))
+func buildTriggerConfig(app *models.App, fn *models.Fn, trigger *models.Trigger) models.Config {
+	conf := make(models.Config, 8+len(app.Config)+len(fn.Config))
 	for k, v := range app.Config {
 		conf[k] = v
 	}
-	for k, v := range route.Config {
+	for k, v := range fn.Config {
 		conf[k] = v
 	}
 
-	conf["FN_FORMAT"] = route.Format
+	conf["FN_FORMAT"] = fn.Format
 	conf["FN_APP_NAME"] = app.Name
 	conf["FN_PATH"] = trigger.Source
 	// TODO: might be a good idea to pass in: "FN_BASE_PATH" = fmt.Sprintf("/r/%s", appName) || "/" if using DNS entries per app
-	conf["FN_MEMORY"] = fmt.Sprintf("%d", route.Memory)
+	conf["FN_MEMORY"] = fmt.Sprintf("%d", fn.Memory)
 	conf["FN_TYPE"] = "sync"
+	conf["FN_FN_ID"] = fn.ID
 
 	return conf
 }

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -168,18 +168,6 @@ func FromHttpTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trig
 			rw.Header().Add("FN_CALL_ID", id)
 		}
 
-		// this ensures that there is an image, path, timeouts, memory, etc are valid.
-		// NOTE: this means assign any changes above into route's fields
-		err = fn.Validate()
-		if err != nil {
-			return err
-		}
-
-		err = trigger.Validate()
-		if err != nil {
-			return err
-		}
-
 		var syslogURL string
 		if app.SyslogURL != nil {
 			syslogURL = *app.SyslogURL

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -166,12 +166,6 @@ func FromHttpTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trig
 		// TODO async should probably supply an http.ResponseWriter that records the logs, to attach response headers to
 		if rw, ok := c.w.(http.ResponseWriter); ok {
 			rw.Header().Add("FN_CALL_ID", id)
-			//for k, vs := range route.Headers {
-			//	for _, v := range vs {
-			//		// pre-write in these headers to response
-			//		rw.Header().Add(k, v)
-			//	}
-			//}
 		}
 
 		// this ensures that there is an image, path, timeouts, memory, etc are valid.

--- a/api/agent/data_access.go
+++ b/api/agent/data_access.go
@@ -237,3 +237,13 @@ func (da *directDataAccess) Close() error {
 	return da.mq.Close()
 
 }
+
+type noAsyncEnqueueAccess struct{}
+
+func (noAsyncEnqueueAccess) Enqueue(ctx context.Context, mCall *models.Call) error {
+	return models.ErrAsyncUnsupported
+}
+
+func NewUnsupportedAsyncEnqueueAccess() EnqueueDataAccess {
+	return &noAsyncEnqueueAccess{}
+}

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -152,6 +152,15 @@ func (cl *client) GetRoute(ctx context.Context, appID, route string) (*models.Ro
 	return &r.R, err
 }
 
+func (cl *client) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
+	panic("implement me")
+}
+
+func (cl *client) GetFnByID(ctx context.Context, fnId string) (*models.Fn, error) {
+	//TRIGGERWIP
+	panic("implement me")
+}
+
 type httpErr struct {
 	code int
 	error

--- a/api/agent/hybrid/nop.go
+++ b/api/agent/hybrid/nop.go
@@ -14,12 +14,15 @@ import (
 type nopDataStore struct{}
 
 func (cl *nopDataStore) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
-	panic("implement me")
+	ctx, span := trace.StartSpan(ctx, "nop_datastore_get_trigger_by_source")
+	defer span.End()
+	return nil, errors.New("should not call GetTriggerBySource on a NOP data store")
 }
 
 func (cl *nopDataStore) GetFnByID(ctx context.Context, fnId string) (*models.Fn, error) {
-	//TRIGGERWIP
-	panic("implement me")
+	ctx, span := trace.StartSpan(ctx, "nop_datastore_get_fn_by_id")
+	defer span.End()
+	return nil, errors.New("should not call GetFnByID on a NOP data store")
 }
 
 func NewNopDataStore() (agent.DataAccess, error) {

--- a/api/agent/hybrid/nop.go
+++ b/api/agent/hybrid/nop.go
@@ -13,6 +13,15 @@ import (
 // nopDataStore implements agent.DataAccess
 type nopDataStore struct{}
 
+func (cl *nopDataStore) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
+	panic("implement me")
+}
+
+func (cl *nopDataStore) GetFnByID(ctx context.Context, fnId string) (*models.Fn, error) {
+	//TRIGGERWIP
+	panic("implement me")
+}
+
 func NewNopDataStore() (agent.DataAccess, error) {
 	return &nopDataStore{}, nil
 }

--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	runner "github.com/fnproject/fn/api/agent/grpc"
+	"github.com/fnproject/fn/api/agent/grpc"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn/fnext"
@@ -495,23 +495,8 @@ type pureRunner struct {
 }
 
 // implements Agent
-func (pr *pureRunner) GetAppID(ctx context.Context, appName string) (string, error) {
-	return pr.a.GetAppID(ctx, appName)
-}
-
-// implements Agent
-func (pr *pureRunner) GetAppByID(ctx context.Context, appID string) (*models.App, error) {
-	return pr.a.GetAppByID(ctx, appID)
-}
-
-// implements Agent
 func (pr *pureRunner) GetCall(opts ...CallOpt) (Call, error) {
 	return pr.a.GetCall(opts...)
-}
-
-// implements Agent
-func (pr *pureRunner) GetRoute(ctx context.Context, appID string, path string) (*models.Route, error) {
-	return pr.a.GetRoute(ctx, appID, path)
 }
 
 // implements Agent
@@ -534,11 +519,6 @@ func (pr *pureRunner) Close() error {
 // implements Agent
 func (pr *pureRunner) AddCallListener(cl fnext.CallListener) {
 	pr.a.AddCallListener(cl)
-}
-
-// implements Agent
-func (pr *pureRunner) Enqueue(context.Context, *models.Call) error {
-	return errors.New("Enqueue cannot be called directly in a Pure Runner.")
 }
 
 func (pr *pureRunner) spawnSubmit(state *callHandle) {
@@ -653,9 +633,9 @@ func (pr *pureRunner) Status(ctx context.Context, _ *empty.Empty) (*runner.Runne
 	}, nil
 }
 
-func DefaultPureRunner(cancel context.CancelFunc, addr string, da DataAccess, cert string, key string, ca string) (Agent, error) {
+func DefaultPureRunner(cancel context.CancelFunc, addr string, da CallHandler, cert string, key string, ca string) (Agent, error) {
 
-	agent := New(da, WithoutAsyncDequeue())
+	agent := New(da)
 
 	// WARNING: SSL creds are optional.
 	if cert == "" || key == "" || ca == "" {

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -278,6 +278,7 @@ func (a *slotQueueMgr) deleteSlotQueue(slots *slotQueue) bool {
 	return isDeleted
 }
 
+// TODO this should be at least SHA-256 or more
 var shapool = &sync.Pool{New: func() interface{} { return sha1.New() }}
 
 // TODO do better; once we have app+route versions this function

--- a/api/const.go
+++ b/api/const.go
@@ -7,6 +7,8 @@ const (
 	AppID string = "app_id"
 	// Path is a route's path context key
 	Path string = "path"
+	// Func is a  routes function ID context key
+	FuncID    string = "func_id"
 
 	// ParamAppID is the url path parameter for app id
 	ParamAppID string = "appID"
@@ -20,4 +22,7 @@ const (
 	ParamCallID string = "call"
 	// ParamFnID is the url path parameter for fn id
 	ParamFnID string = "fnID"
+	// ParamSource is the triggers source parameter
+	ParamSource string = "source"
+)
 )

--- a/api/const.go
+++ b/api/const.go
@@ -7,8 +7,6 @@ const (
 	AppID string = "app_id"
 	// Path is a route's path context key
 	Path string = "path"
-	// Func is a  routes function ID context key
-	FuncID    string = "func_id"
 
 	// ParamAppID is the url path parameter for app id
 	ParamAppID string = "appID"
@@ -24,5 +22,4 @@ const (
 	ParamFnID string = "fnID"
 	// ParamSource is the triggers source parameter
 	ParamSource string = "source"
-)
 )

--- a/api/const.go
+++ b/api/const.go
@@ -20,6 +20,9 @@ const (
 	ParamCallID string = "call"
 	// ParamFnID is the url path parameter for fn id
 	ParamFnID string = "fnID"
-	// ParamSource is the triggers source parameter
-	ParamSource string = "source"
+	// ParamTriggerSource is the triggers source parameter
+	ParamTriggerSource string = "triggerSource"
+
+	//ParamTriggerType is the trigger type parameter - only used in hybrid API
+	ParamTriggerType string = "triggerType"
 )

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -16,6 +16,12 @@ type metricds struct {
 	ds models.Datastore
 }
 
+func (m *metricds) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
+	ctx, span := trace.StartSpan(ctx, "ds_get_trigger_by_source")
+	defer span.End()
+	return m.ds.GetTriggerBySource(ctx, appId, triggerType, source)
+}
+
 func (m *metricds) GetAppID(ctx context.Context, appName string) (string, error) {
 	ctx, span := trace.StartSpan(ctx, "ds_get_app_id")
 	defer span.End()

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -31,8 +31,13 @@ func NewMock() models.Datastore {
 var _ models.Datastore = &mock{}
 
 func (m *mock) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
-	//TRIGGERWIP
-	panic("implement me")
+	for _, t := range m.Triggers {
+		if t.AppID == appId && t.Type == triggerType && t.Source == source {
+			return t, nil
+		}
+	}
+
+	return nil, models.ErrTriggerNotFound
 }
 
 // args helps break tests less if we change stuff

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -28,6 +28,13 @@ func NewMock() models.Datastore {
 	return NewMockInit()
 }
 
+var _ models.Datastore = &mock{}
+
+func (m *mock) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
+	//TRIGGERWIP
+	panic("implement me")
+}
+
 // args helps break tests less if we change stuff
 func NewMockInit(args ...interface{}) models.Datastore {
 	var mocker mock

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -428,6 +428,12 @@ func (m *mock) InsertTrigger(ctx context.Context, trigger *models.Trigger) (*mod
 				t.Name == trigger.Name) {
 			return nil, models.ErrTriggerExists
 		}
+
+		if t.AppID == trigger.AppID &&
+			t.Source == trigger.Source &&
+			t.Type == trigger.Type {
+			return nil, models.ErrTriggerSourceExists
+		}
 	}
 
 	cl := trigger.Clone()

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -127,6 +127,8 @@ const (
 	triggerSelector   = `SELECT id,name,app_id,fn_id,type,source,annotations,created_at,updated_at FROM triggers`
 	triggerIDSelector = triggerSelector + ` WHERE id=?`
 
+	triggerIDSourceSelector = triggerSelector + ` WHERE app_id=? AND type=? AND source=?`
+
 	EnvDBPingMaxRetries = "FN_DS_DB_PING_MAX_RETRIES"
 )
 
@@ -1405,6 +1407,25 @@ func (ds *SQLStore) GetTriggers(ctx context.Context, filter *models.TriggerFilte
 		}
 	}
 	return res, nil
+}
+
+func (ds *SQLStore) GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*models.Trigger, error) {
+	var trigger models.Trigger
+	// TRIGGERWIP
+	// TODO : Currently matches first trigger that has a source that matches - TODO make these unique
+
+	query := ds.db.Rebind(triggerIDSourceSelector)
+	row := ds.db.QueryRowxContext(ctx, query, appId, triggerType, source)
+
+	err := row.StructScan(&trigger)
+	if err == sql.ErrNoRows {
+		return nil, models.ErrTriggerNotFound
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return &trigger, nil
 }
 
 // Close closes the database, releasing any open resources.

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -150,10 +150,10 @@ type Call struct {
 	// App this call belongs to.
 	AppID string `json:"app_id" db:"app_id"`
 
-	// App this call belongs to.
+	// Trigger this call belongs to.
 	TriggerID string `json:"trigger_id" db:"trigger_id"`
 
-	// App this call belongs to.
+	// Fn this call belongs to.
 	FnID string `json:"fn_id" db:"fn_id"`
 }
 

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -149,6 +149,12 @@ type Call struct {
 
 	// App this call belongs to.
 	AppID string `json:"app_id" db:"app_id"`
+
+	// App this call belongs to.
+	TriggerID string `json:"trigger_id" db:"trigger_id"`
+
+	// App this call belongs to.
+	FnID string `json:"fn_id" db:"fn_id"`
 }
 
 type CallFilter struct {

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -93,8 +93,7 @@ type Datastore interface {
 	// Return ErrDatastoreEmptyAppId if no AppID set in the filter
 	GetTriggers(ctx context.Context, filter *TriggerFilter) (*TriggerList, error)
 
-	GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*Trigger, error)
-
+	// GetTriggerBySource loads a trigger by type and source ID - this is only needed when the data store is also used for agent read access
 	GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*Trigger, error)
 
 	// implements io.Closer to shutdown

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -93,6 +93,10 @@ type Datastore interface {
 	// Return ErrDatastoreEmptyAppId if no AppID set in the filter
 	GetTriggers(ctx context.Context, filter *TriggerFilter) (*TriggerList, error)
 
+	GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*Trigger, error)
+
+	GetTriggerBySource(ctx context.Context, appId string, triggerType, source string) (*Trigger, error)
+
 	// implements io.Closer to shutdown
 	io.Closer
 }

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -198,6 +198,11 @@ var (
 		code:  http.StatusBadRequest,
 		error: fmt.Errorf("Invalid annotation change, new key(s) exceed maximum permitted number of annotations keys (%d)", maxAnnotationsKeys),
 	}
+
+	ErrAsyncUnsupported = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Async functions are not supported on this server"),
+	}
 )
 
 // APIError any error that implements this interface will return an API response

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -109,6 +109,9 @@ var (
 	ErrTriggerExists = err{
 		code:  http.StatusConflict,
 		error: errors.New("Trigger already exists")}
+	ErrTriggerSourceExists = err{
+		code:  http.StatusConflict,
+		error: errors.New("Trigger with the same type and source exists on this app")}
 )
 
 func (t *Trigger) Validate() error {

--- a/api/models/trigger_test.go
+++ b/api/models/trigger_test.go
@@ -5,17 +5,17 @@ import (
 	"testing"
 )
 
-var openEmptyJson = `{"id":"","name":"","app_id":"","fn_id":"","created_at":"0001-01-01T00:00:00.000Z","updated_at":"0001-01-01T00:00:00.000Z","type":"","source":""`
+var openEmptyJSON = `{"id":"","name":"","app_id":"","fn_id":"","created_at":"0001-01-01T00:00:00.000Z","updated_at":"0001-01-01T00:00:00.000Z","type":"","source":""`
 
-var triggerJsonCases = []struct {
+var triggerJSONCases = []struct {
 	val       *Trigger
 	valString string
 }{
-	{val: &Trigger{}, valString: openEmptyJson + "}"},
+	{val: &Trigger{}, valString: openEmptyJSON + "}"},
 }
 
 func TestTriggerJsonMarshalling(t *testing.T) {
-	for _, tc := range triggerJsonCases {
+	for _, tc := range triggerJSONCases {
 		v, err := json.Marshal(tc.val)
 		if err != nil {
 			t.Fatalf("Failed to marshal json into %s: %v", tc.valString, err)

--- a/api/server/apps_v1_get.go
+++ b/api/server/apps_v1_get.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO: Deprecate with V1 API
-func (s *Server) handleV1AppGetByName(c *gin.Context) {
+func (s *Server) handleV1AppGetByIdOrName(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	param := c.MustGet(api.AppID).(string)

--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -154,6 +154,7 @@ func loggerWrap(c *gin.Context) {
 
 	c.Request = c.Request.WithContext(ctx)
 	c.Next()
+
 }
 
 type ctxPathKey string
@@ -186,7 +187,7 @@ func AppFromContext(ctx context.Context) string {
 	return r
 }
 
-func (s *Server) checkAppPresenceByNameAtRunner() gin.HandlerFunc {
+func (s *Server) checkAppPresenceByNameAtLB() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx, _ := common.LoggerWithFields(c.Request.Context(), extractFields(c))
 

--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -154,7 +154,6 @@ func loggerWrap(c *gin.Context) {
 
 	c.Request = c.Request.WithContext(ctx)
 	c.Next()
-
 }
 
 type ctxPathKey string

--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -192,7 +192,7 @@ func (s *Server) checkAppPresenceByNameAtRunner() gin.HandlerFunc {
 
 		appName := c.Param(api.ParamAppName)
 		if appName != "" {
-			appID, err := s.agent.GetAppID(ctx, appName)
+			appID, err := s.lbReadAccess.GetAppID(ctx, appName)
 			if err != nil {
 				handleV1ErrorResponse(c, err)
 				c.Abort()

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -55,7 +55,7 @@ func (s *Server) handleRunnerEnqueue(c *gin.Context) {
 	// will ensure the call exists in the db in 'running' state there.
 	// s.datastore.InsertCall(ctx, &call)
 
-	c.String(204, "")
+	c.String(http.StatusNoContent, "")
 }
 
 func (s *Server) handleRunnerDequeue(c *gin.Context) {

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -5,9 +5,14 @@ import (
 	"strings"
 	"time"
 
+	"errors"
+	"fmt"
+	"github.com/fnproject/fn/api"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
+	"net/http"
+	"path"
 )
 
 func (s *Server) handleRunnerEnqueue(c *gin.Context) {
@@ -18,9 +23,9 @@ func (s *Server) handleRunnerEnqueue(c *gin.Context) {
 	err := c.BindJSON(&call)
 	if err != nil {
 		if models.IsAPIError(err) {
-			handleV1ErrorResponse(c, err)
+			handleErrorResponse(c, err)
 		} else {
-			handleV1ErrorResponse(c, models.ErrInvalidJSON)
+			handleErrorResponse(c, models.ErrInvalidJSON)
 		}
 		return
 	}
@@ -39,7 +44,7 @@ func (s *Server) handleRunnerEnqueue(c *gin.Context) {
 	call.Status = "queued"
 	_, err = s.mq.Push(ctx, &call)
 	if err != nil {
-		handleV1ErrorResponse(c, err)
+		handleErrorResponse(c, err)
 		return
 	}
 
@@ -50,9 +55,7 @@ func (s *Server) handleRunnerEnqueue(c *gin.Context) {
 	// will ensure the call exists in the db in 'running' state there.
 	// s.datastore.InsertCall(ctx, &call)
 
-	c.JSON(200, struct {
-		M string `json:"msg"`
-	}{M: "enqueued call"})
+	c.String(204, "")
 }
 
 func (s *Server) handleRunnerDequeue(c *gin.Context) {
@@ -70,7 +73,7 @@ func (s *Server) handleRunnerDequeue(c *gin.Context) {
 	for {
 		call, err := s.mq.Reserve(ctx)
 		if err != nil {
-			handleV1ErrorResponse(c, err)
+			handleErrorResponse(c, err)
 			return
 		}
 		if call != nil {
@@ -97,9 +100,9 @@ func (s *Server) handleRunnerStart(c *gin.Context) {
 	err := c.BindJSON(&call)
 	if err != nil {
 		if models.IsAPIError(err) {
-			handleV1ErrorResponse(c, err)
+			handleErrorResponse(c, err)
 		} else {
-			handleV1ErrorResponse(c, models.ErrInvalidJSON)
+			handleErrorResponse(c, models.ErrInvalidJSON)
 		}
 		return
 	}
@@ -129,7 +132,7 @@ func (s *Server) handleRunnerStart(c *gin.Context) {
 	// TODO change this to only delete message if the status change fails b/c it already ran
 	// after messaging semantics change
 	if err := s.mq.Delete(ctx, &call); err != nil { // TODO change this to take some string(s), not a whole call
-		handleV1ErrorResponse(c, err)
+		handleErrorResponse(c, err)
 		return
 	}
 	//}
@@ -137,9 +140,7 @@ func (s *Server) handleRunnerStart(c *gin.Context) {
 	//return
 	//}
 
-	c.JSON(200, struct {
-		M string `json:"msg"`
-	}{M: "slingshot: engage"})
+	c.String(http.StatusNoContent, "")
 }
 
 func (s *Server) handleRunnerFinish(c *gin.Context) {
@@ -152,9 +153,9 @@ func (s *Server) handleRunnerFinish(c *gin.Context) {
 	err := c.BindJSON(&body)
 	if err != nil {
 		if models.IsAPIError(err) {
-			handleV1ErrorResponse(c, err)
+			handleErrorResponse(c, err)
 		} else {
-			handleV1ErrorResponse(c, models.ErrInvalidJSON)
+			handleErrorResponse(c, models.ErrInvalidJSON)
 		}
 		return
 	}
@@ -184,7 +185,49 @@ func (s *Server) handleRunnerFinish(c *gin.Context) {
 	//// note: Not returning err here since the job could have already finished successfully.
 	//}
 
-	c.JSON(200, struct {
-		M string `json:"msg"`
-	}{M: "good night, sweet prince"})
+	c.String(http.StatusNoContent, "")
+}
+
+// This is a sort of interim route  that is V2 API style but due for deprectation
+func (s *Server) handleRunnerGetRoute(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	routePath := path.Clean("/" + c.MustGet(api.Path).(string))
+	route, err := s.datastore.GetRoute(ctx, c.MustGet(api.AppID).(string), routePath)
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, route)
+}
+
+func (s *Server) handleRunnerGetTriggerBySource(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	appId := c.MustGet(api.AppID).(string)
+
+	triggerType := c.Param(api.ParamTriggerType)
+	if triggerType == "" {
+		handleErrorResponse(c, errors.New("no trigger type in request"))
+		return
+	}
+	triggerSource := strings.TrimPrefix(c.Param(api.ParamTriggerSource), "/")
+
+	trigger, err := s.datastore.GetTriggerBySource(ctx, appId, triggerType, triggerSource)
+
+	if err != nil {
+		handleErrorResponse(c, err)
+		return
+	}
+	// Not clear that we really need to annotate the trigger here but ... lets do it just in case.
+	app, err := s.datastore.GetAppByID(ctx, trigger.AppID)
+
+	if err != nil {
+		handleErrorResponse(c, fmt.Errorf("unexpected error - trigger app not available: %s", err))
+	}
+
+	s.triggerAnnotator.AnnotateTrigger(c, app, trigger)
+
+	c.JSON(http.StatusOK, trigger)
 }

--- a/api/server/hybrid_test.go
+++ b/api/server/hybrid_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/fnproject/fn/api/datastore"
+	"github.com/fnproject/fn/api/id"
+	"github.com/fnproject/fn/api/logs"
+	"github.com/fnproject/fn/api/models"
+	"github.com/fnproject/fn/api/mqs"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHybridEndpoints(t *testing.T) {
+	buf := setLogBuffer()
+	app := &models.App{ID: "app_id", Name: "myapp"}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Route{{
+			AppID: app.ID,
+			Path:  "yodawg",
+		}},
+	)
+
+	logDB := logs.NewMock()
+
+	srv := testServer(ds, &mqs.Mock{}, logDB, nil /* TODO */, ServerTypeAPI)
+
+	newCallBody := func() string {
+		call := &models.Call{
+			AppID: app.ID,
+			ID:    id.New().String(),
+			Path:  "yodawg",
+			// TODO ?
+		}
+		var b bytes.Buffer
+		json.NewEncoder(&b).Encode(&call)
+		return b.String()
+	}
+
+	for _, test := range []struct {
+		name         string
+		method       string
+		path         string
+		body         string
+		expectedCode int
+	}{
+		// TODO change all these tests to just do an async task in normal order once plumbing is done
+
+		{"post async call", "PUT", "/v2/runner/async", newCallBody(), http.StatusNoContent},
+
+		// TODO this one only works if it's not the same as the first since update isn't hooked up
+		{"finish call", "POST", "/v2/runner/finish", newCallBody(), http.StatusNoContent},
+
+		// TODO these won't work until update works and the agent gets shut off
+		//{"get async call", "GET", "/v1/runner/async", "", http.StatusOK},
+		//{"start call", "POST", "/v1/runner/start", "TODO", http.StatusOK},
+	} {
+		_, rec := routerRequest(t, srv.Router, test.method, test.path, strings.NewReader(test.body))
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Errorf("Test \"%s\": Expected status code to be %d but was %d",
+				test.name, test.expectedCode, rec.Code)
+		}
+	}
+}

--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -43,7 +43,7 @@ func (c *middlewareController) CallFunction(w http.ResponseWriter, r *http.Reque
 		c.ginContext.Set(api.AppID, appID)
 	}
 
-	c.server.handleFunctionCall(c.ginContext)
+	c.server.handleV1FunctionCall(c.ginContext)
 	c.ginContext.Abort()
 }
 func (c *middlewareController) FunctionCalled() bool {

--- a/api/server/routes_get.go
+++ b/api/server/routes_get.go
@@ -1,30 +1,21 @@
 package server
 
 import (
-	"net/http"
-	"path"
-
 	"github.com/fnproject/fn/api"
 	"github.com/gin-gonic/gin"
+	"net/http"
+	"path"
 )
 
-func routeGet(s *Server, appID string, c *gin.Context) {
+func (s *Server) handleRouteGetAPI(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	routePath := path.Clean("/" + c.MustGet(api.Path).(string))
-	route, err := s.datastore.GetRoute(ctx, appID, routePath)
+	route, err := s.datastore.GetRoute(ctx, c.MustGet(api.AppID).(string), routePath)
 	if err != nil {
 		handleV1ErrorResponse(c, err)
 		return
 	}
 
 	c.JSON(http.StatusOK, routeResponse{"Successfully loaded route", route})
-}
-
-func (s *Server) handleRouteGetAPI(c *gin.Context) {
-	routeGet(s, c.MustGet(api.AppID).(string), c)
-}
-
-func (s *Server) handleRouteGetRunner(c *gin.Context) {
-	routeGet(s, c.MustGet(api.AppID).(string), c)
 }

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -17,12 +17,14 @@ func testRouterAsync(ds models.Datastore, mq models.MessageQueue, rnr agent.Agen
 	ctx := context.Background()
 	engine := gin.New()
 	s := &Server{
-		agent:       rnr,
-		Router:      engine,
-		AdminRouter: engine,
-		datastore:   ds,
-		mq:          mq,
-		nodeType:    ServerTypeFull,
+		agent:        rnr,
+		Router:       engine,
+		AdminRouter:  engine,
+		datastore:    ds,
+		lbReadAccess: ds,
+		lbEnqueue:    agent.NewDirectEnqueueAccess(mq),
+		mq:           mq,
+		nodeType:     ServerTypeFull,
 	}
 
 	r := s.Router

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"path"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/fnproject/fn/api"
@@ -17,26 +16,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// handleV1FunctionCall executes the function, for router handlers
-func (s *Server) handleV1FunctionCall(c *gin.Context) {
-	err := s.handleFunctionCall2(c)
+// handleHttpTriggerCall executes the function, for router handlers
+func (s *Server) handleHttpTriggerCall(c *gin.Context) {
+	err := s.handleTriggerHttpFunctionCall2(c)
 	if err != nil {
-		handleV1ErrorResponse(c, err)
+		handleErrorResponse(c, err)
 	}
 }
 
-// handleFunctionCall2 executes the function and returns an error
+// handleTriggerHttpFunctionCall2 executes the function and returns an error
 // Requires the following in the context:
-// * "app"
-// * "path"
-func (s *Server) handleFunctionCall2(c *gin.Context) error {
+func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 	ctx := c.Request.Context()
-	var p string
-	r := PathFromContext(ctx)
-	if r == "" {
+	p := c.Param(api.ParamSource)
+	if p == "" {
 		p = "/"
-	} else {
-		p = r
 	}
 
 	appID := c.MustGet(api.AppID).(string)
@@ -46,23 +40,22 @@ func (s *Server) handleFunctionCall2(c *gin.Context) error {
 	}
 
 	routePath := path.Clean(p)
-	route, err := s.lbReadAccess.GetRoute(ctx, appID, routePath)
+	trigger, err := s.lbReadAccess.GetTriggerBySource(ctx, appID, "http", routePath)
+
 	if err != nil {
 		return err
 	}
+
+	fn, err := s.lbReadAccess.GetFnByID(ctx, trigger.FnID)
 	// gin sets this to 404 on NoRoute, so we'll just ensure it's 200 by default.
 	c.Status(200) // this doesn't write the header yet
 
-	return s.serve(c, app, route)
+	return s.ServeHTTPTrigger(c, app, fn, trigger)
 }
-
-var (
-	bufPool = &sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
-)
 
 // TODO it would be nice if we could make this have nothing to do with the gin.Context but meh
 // TODO make async store an *http.Request? would be sexy until we have different api format...
-func (s *Server) serve(c *gin.Context, app *models.App, route *models.Route) error {
+func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn, trigger *models.Trigger) error {
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	writer := syncResponseWriter{
@@ -80,7 +73,7 @@ func (s *Server) serve(c *gin.Context, app *models.App, route *models.Route) err
 
 	call, err := s.agent.GetCall(
 		agent.WithWriter(&writer), // XXX (reed): order matters [for now]
-		agent.FromRequest(app, route, c.Request),
+		agent.FromHttpTriggerRequest(app, fn, trigger, c.Request),
 	)
 	if err != nil {
 		return err
@@ -91,7 +84,9 @@ func (s *Server) serve(c *gin.Context, app *models.App, route *models.Route) err
 		c.Request = c.Request.WithContext(ctx)
 	}
 
+	// TODO TRIGGERWIP  not clear this makes sense here - but it works  so...
 	if model.Type == "async" {
+
 		// TODO we should push this into GetCall somehow (CallOpt maybe) or maybe agent.Queue(Call) ?
 		if c.Request.ContentLength > 0 {
 			buf.Grow(int(c.Request.ContentLength))
@@ -123,6 +118,8 @@ func (s *Server) serve(c *gin.Context, app *models.App, route *models.Route) err
 		return err
 	}
 
+	// TODO TRIGGERWIP  Not sure I want this evil magic in my life here - shoud remove
+
 	// if they don't set a content-type - detect it
 	if writer.Header().Get("Content-Type") == "" {
 		// see http.DetectContentType, the go server is supposed to do this for us but doesn't appear to?
@@ -146,19 +143,3 @@ func (s *Server) serve(c *gin.Context, app *models.App, route *models.Route) err
 
 	return nil
 }
-
-var _ http.ResponseWriter = new(syncResponseWriter)
-
-// implements http.ResponseWriter
-// this little guy buffers responses from user containers and lets them still
-// set headers and such without us risking writing partial output [as much, the
-// server could still die while we're copying the buffer]. this lets us set
-// content length and content type nicely, as a bonus. it is sad, yes.
-type syncResponseWriter struct {
-	headers http.Header
-	status  int
-	*bytes.Buffer
-}
-
-func (s *syncResponseWriter) Header() http.Header  { return s.headers }
-func (s *syncResponseWriter) WriteHeader(code int) { s.status = code }

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"path"
 	"strconv"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 // handleHttpTriggerCall executes the function, for router handlers
@@ -29,7 +27,7 @@ func (s *Server) handleHttpTriggerCall(c *gin.Context) {
 // Requires the following in the context:
 func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 	ctx := c.Request.Context()
-	p := c.Param(api.ParamSource)
+	p := c.Param(api.ParamTriggerSource)
 	if p == "" {
 		p = "/"
 	}
@@ -46,10 +44,8 @@ func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 		return err
 	}
 
-	routePath := path.Clean(p)
-	if !strings.HasPrefix(routePath, "/") {
-		routePath = "/" + routePath
-	}
+	routePath := p
+
 	trigger, err := s.lbReadAccess.GetTriggerBySource(ctx, appID, "http", routePath)
 
 	if err != nil {

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -15,17 +15,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// handleHttpTriggerCall executes the function, for router handlers
-func (s *Server) handleHttpTriggerCall(c *gin.Context) {
-	err := s.handleTriggerHttpFunctionCall2(c)
+// handleHTTPTriggerCall executes the function, for router handlers
+func (s *Server) handleHTTPTriggerCall(c *gin.Context) {
+	err := s.handleTriggerHTTPFunctionCall2(c)
 	if err != nil {
 		handleErrorResponse(c, err)
 	}
 }
 
-// handleTriggerHttpFunctionCall2 executes the function and returns an error
+// handleTriggerHTTPFunctionCall2 executes the function and returns an error
 // Requires the following in the context:
-func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
+func (s *Server) handleTriggerHTTPFunctionCall2(c *gin.Context) error {
 	ctx := c.Request.Context()
 	p := c.Param(api.ParamTriggerSource)
 	if p == "" {
@@ -62,8 +62,8 @@ func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 	return s.ServeHTTPTrigger(c, app, fn, trigger)
 }
 
-// TODO it would be nice if we could make this have nothing to do with the gin.Context but meh
-// TODO make async store an *http.Request? would be sexy until we have different api format...
+//ServeHTTPTrigger serves an HTTP trigger for a given app/fn/trigger  based on the current request
+// This is exported to allow extensions to handle their own trigger naming and publishing
 func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn, trigger *models.Trigger) error {
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
@@ -82,7 +82,7 @@ func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn
 
 	call, err := s.agent.GetCall(
 		agent.WithWriter(&writer), // XXX (reed): order matters [for now]
-		agent.FromHttpTriggerRequest(app, fn, trigger, c.Request),
+		agent.FromHTTPTriggerRequest(app, fn, trigger, c.Request),
 	)
 	if err != nil {
 		return err

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -57,6 +57,9 @@ func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 	}
 
 	fn, err := s.lbReadAccess.GetFnByID(ctx, trigger.FnID)
+	if err != nil {
+		return err
+	}
 	// gin sets this to 404 on NoRoute, so we'll just ensure it's 200 by default.
 	c.Status(200) // this doesn't write the header yet
 

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"strings"
 )
 
 // handleHttpTriggerCall executes the function, for router handlers
@@ -33,13 +34,22 @@ func (s *Server) handleTriggerHttpFunctionCall2(c *gin.Context) error {
 		p = "/"
 	}
 
-	appID := c.MustGet(api.AppID).(string)
+	appName := c.Param(api.ParamAppName)
+
+	appID, err := s.lbReadAccess.GetAppID(ctx, appName)
+	if err != nil {
+		return err
+	}
+
 	app, err := s.lbReadAccess.GetAppByID(ctx, appID)
 	if err != nil {
 		return err
 	}
 
 	routePath := path.Clean(p)
+	if !strings.HasPrefix(routePath, "/") {
+		routePath = "/" + routePath
+	}
 	trigger, err := s.lbReadAccess.GetTriggerBySource(ctx, appID, "http", routePath)
 
 	if err != nil {

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -127,8 +127,6 @@ func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn
 		return err
 	}
 
-	// TODO TRIGGERWIP  Not sure I want this evil magic in my life here - shoud remove
-
 	// if they don't set a content-type - detect it
 	if writer.Header().Get("Content-Type") == "" {
 		// see http.DetectContentType, the go server is supposed to do this for us but doesn't appear to?

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -435,7 +435,6 @@ func TestTriggerRunnerExecution(t *testing.T) {
 
 			if test.expectedErrSubStr != "" && !strings.Contains(respBody, test.expectedErrSubStr) {
 				isFailure = true
-				fmt.Sprintf("Errorr %s", respBody)
 				t.Errorf("Test %d: Expected response to include %s but got body: %s",
 					i, test.expectedErrSubStr, respBody[:maxBody])
 

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -259,7 +259,7 @@ func TestTriggerRunnerExecEmptyBody(t *testing.T) {
 	testCases := []struct {
 		path string
 	}{
-		{"/t/soup/cold/"},
+		{"/t/soup/cold"},
 		{"/t/soup/hothttp"},
 		{"/t/soup/hothttp"},
 		{"/t/soup/hotjson"},
@@ -267,26 +267,27 @@ func TestTriggerRunnerExecEmptyBody(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		trx := fmt.Sprintf("_trx_%d_", i)
-		body := strings.NewReader(strings.Replace(emptyBody, "_TRX_ID_", trx, 1))
-		_, rec := routerRequest(t, srv.Router, "GET", test.path, body)
-		respBytes, _ := ioutil.ReadAll(rec.Body)
-		respBody := string(respBytes)
-		maxBody := len(respBody)
-		if maxBody > 1024 {
-			maxBody = 1024
-		}
+		t.Run(fmt.Sprintf("%d_%s", i, strings.Replace(test.path, "/", "_", -1)), func(t *testing.T) {
+			trx := fmt.Sprintf("_trx_%d_", i)
+			body := strings.NewReader(strings.Replace(emptyBody, "_TRX_ID_", trx, 1))
+			_, rec := routerRequest(t, srv.Router, "GET", test.path, body)
+			respBytes, _ := ioutil.ReadAll(rec.Body)
+			respBody := string(respBytes)
+			maxBody := len(respBody)
+			if maxBody > 1024 {
+				maxBody = 1024
+			}
 
-		if rec.Code != http.StatusOK {
-			isFailure = true
-			t.Errorf("Test %d: Expected status code to be %d but was %d. body: %s",
-				i, http.StatusOK, rec.Code, respBody[:maxBody])
-		} else if len(respBytes) != 0 {
-			isFailure = true
-			t.Errorf("Test %d: Expected empty body but got %d. body: %s",
-				i, len(respBytes), respBody[:maxBody])
-		}
-
+			if rec.Code != http.StatusOK {
+				isFailure = true
+				t.Errorf("Test %d: Expected status code to be %d but was %d. body: %s",
+					i, http.StatusOK, rec.Code, respBody[:maxBody])
+			} else if len(respBytes) != 0 {
+				isFailure = true
+				t.Errorf("Test %d: Expected empty body but got %d. body: %s",
+					i, len(respBytes), respBody[:maxBody])
+			}
+		})
 	}
 }
 
@@ -434,6 +435,7 @@ func TestTriggerRunnerExecution(t *testing.T) {
 
 			if test.expectedErrSubStr != "" && !strings.Contains(respBody, test.expectedErrSubStr) {
 				isFailure = true
+				fmt.Sprintf("Errorr %s", respBody)
 				t.Errorf("Test %d: Expected response to include %s but got body: %s",
 					i, test.expectedErrSubStr, respBody[:maxBody])
 

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -1,0 +1,493 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fnproject/fn/api/datastore"
+	"github.com/fnproject/fn/api/logs"
+	"github.com/fnproject/fn/api/models"
+	"github.com/fnproject/fn/api/mqs"
+)
+
+func TestTriggerRunnerGet(t *testing.T) {
+	buf := setLogBuffer()
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+	)
+
+	rnr, cancel := testRunner(t, ds)
+	defer cancel()
+	logDB := logs.NewMock()
+	srv := testServer(ds, &mqs.Mock{}, logDB, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{"/t/app/route", "", http.StatusNotFound, models.ErrAppsNotFound},
+		{"/t/myapp/route", "", http.StatusNotFound, models.ErrTriggerNotFound},
+	} {
+		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Fatalf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`, but got `%s`",
+					i, test.expectedError.Error(), resp.Message)
+			}
+		}
+	}
+}
+
+func TestTriggerRunnerPost(t *testing.T) {
+	buf := setLogBuffer()
+
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+	)
+
+	rnr, cancel := testRunner(t, ds)
+	defer cancel()
+
+	fnl := logs.NewMock()
+	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{"/t/app/route", `{ "payload": "" }`, http.StatusNotFound, models.ErrAppsNotFound},
+		{"/t/myapp/route", `{ "payload": "" }`, http.StatusNotFound, models.ErrTriggerNotFound},
+	} {
+		body := bytes.NewBuffer([]byte(test.body))
+		_, rec := routerRequest(t, srv.Router, "POST", test.path, body)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Errorf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+			respMsg := resp.Message
+			expMsg := test.expectedError.Error()
+			if respMsg != expMsg && !strings.Contains(respMsg, expMsg) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`",
+					i, test.expectedError.Error())
+			}
+		}
+	}
+}
+
+func TestTriggerRunnerExecEmptyBody(t *testing.T) {
+	buf := setLogBuffer()
+	isFailure := false
+
+	defer func() {
+		if isFailure {
+			t.Log(buf.String())
+		}
+	}()
+
+	rCfg := map[string]string{"ENABLE_HEADER": "yes", "ENABLE_FOOTER": "yes"} // enable container start/end header/footer
+	rImg := "fnproject/fn-test-utils"
+
+	app := &models.App{ID: "app_id", Name: "soup"}
+
+	f1 := &models.Fn{ID: "cold", Name: "cold", AppID: app.ID, Image: rImg, ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 10, IdleTimeout: 20}, Config: rCfg}
+	f2 := &models.Fn{ID: "hothttp", Name: "hothttp", AppID: app.ID, Image: rImg, Format: "http", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 10, IdleTimeout: 20}, Config: rCfg}
+	f3 := &models.Fn{ID: "hotjson", Name: "hotjson", AppID: app.ID, Image: rImg, Format: "json", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 10, IdleTimeout: 20}, Config: rCfg}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Fn{f1, f2, f3},
+		[]*models.Trigger{
+			{ID: "t1", Name: "t1", AppID: app.ID, FnID: f1.ID, Type: "http", Source: "/cold"},
+			{ID: "t2", Name: "t2", AppID: app.ID, FnID: f1.ID, Type: "http", Source: "/hothttp"},
+			{ID: "t3", Name: "t3", AppID: app.ID, FnID: f1.ID, Type: "http", Source: "/hotjson"},
+		},
+	)
+	ls := logs.NewMock()
+
+	rnr, cancelrnr := testRunner(t, ds, ls)
+	defer cancelrnr()
+
+	srv := testServer(ds, &mqs.Mock{}, ls, rnr, ServerTypeFull)
+
+	emptyBody := `{"echoContent": "_TRX_ID_", "isDebug": true, "isEmptyBody": true}`
+
+	// Test hot cases twice to rule out hot-containers corrupting next request.
+	testCases := []struct {
+		path string
+	}{
+		{"/t/soup/cold/"},
+		{"/t/soup/hothttp"},
+		{"/t/soup/hothttp"},
+		{"/t/soup/hotjson"},
+		{"/t/soup/hotjson"},
+	}
+
+	for i, test := range testCases {
+		trx := fmt.Sprintf("_trx_%d_", i)
+		body := strings.NewReader(strings.Replace(emptyBody, "_TRX_ID_", trx, 1))
+		_, rec := routerRequest(t, srv.Router, "GET", test.path, body)
+		respBytes, _ := ioutil.ReadAll(rec.Body)
+		respBody := string(respBytes)
+		maxBody := len(respBody)
+		if maxBody > 1024 {
+			maxBody = 1024
+		}
+
+		if rec.Code != http.StatusOK {
+			isFailure = true
+			t.Errorf("Test %d: Expected status code to be %d but was %d. body: %s",
+				i, http.StatusOK, rec.Code, respBody[:maxBody])
+		} else if len(respBytes) != 0 {
+			isFailure = true
+			t.Errorf("Test %d: Expected empty body but got %d. body: %s",
+				i, len(respBytes), respBody[:maxBody])
+		}
+
+	}
+}
+
+func TestTriggerRunnerExecution(t *testing.T) {
+	buf := setLogBuffer()
+	isFailure := false
+	tweaker := envTweaker("FN_MAX_RESPONSE_SIZE", "2048")
+	defer tweaker()
+
+	// Log once after we are done, flow of events are important (hot/cold containers, idle timeout, etc.)
+	// for figuring out why things failed.
+	defer func() {
+		if isFailure {
+			t.Log(buf.String())
+		}
+	}()
+
+	rCfg := map[string]string{"ENABLE_HEADER": "yes", "ENABLE_FOOTER": "yes"} // enable container start/end header/footer
+	rImg := "fnproject/fn-test-utils"
+	rImgBs1 := "fnproject/imagethatdoesnotexist"
+	rImgBs2 := "localhost:5050/fnproject/imagethatdoesnotexist"
+
+	app := &models.App{ID: "app_id", Name: "myapp"}
+
+	defaultDneFn := &models.Fn{ID: "default_dne_fn_id", Name: "default_dne_fn", AppID: app.ID, Image: rImgBs1, Format: "", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	defaultFn := &models.Fn{ID: "default_fn_id", Name: "default_fn", AppID: app.ID, Image: rImg, Format: "", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	httpFn := &models.Fn{ID: "http_fn_id", Name: "http_fn", AppID: app.ID, Image: rImg, Format: "http", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	httpDneFn := &models.Fn{ID: "http_dne_fn_id", Name: "http_dne_fn", AppID: app.ID, Image: rImgBs1, Format: "http", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	httpDneRegistryFn := &models.Fn{ID: "http_dnereg_fn_id", Name: "http_dnereg_fn", AppID: app.ID, Image: rImgBs2, Format: "http", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	jsonFn := &models.Fn{ID: "json_fn_id", Name: "json_fn", AppID: app.ID, Image: rImg, Format: "json", ResourceConfig: models.ResourceConfig{Memory: 64, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+	oomFn := &models.Fn{ID: "http_fn_id", Name: "http_fn", AppID: app.ID, Image: rImg, Format: "http", ResourceConfig: models.ResourceConfig{Memory: 8, Timeout: 30, IdleTimeout: 30}, Config: rCfg}
+
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Fn{defaultFn, defaultDneFn, httpDneRegistryFn, oomFn, httpFn, jsonFn},
+		[]*models.Trigger{
+			{ID: "1", Name: "1", Source: "/", Type: "http", AppID: app.ID, FnID: defaultFn.ID},
+			{ID: "2", Name: "2", Source: "/myhot", Type: "http", AppID: app.ID, FnID: httpFn.ID},
+			{ID: "3", Name: "3", Source: "/myhotjason", Type: "http", AppID: app.ID, FnID: jsonFn.ID},
+			{ID: "4", Name: "4", Source: "/myroute", Type: "http", AppID: app.ID, FnID: defaultFn.ID},
+			{ID: "5", Name: "5", Source: "/myerror", Type: "http", AppID: app.ID, FnID: defaultFn.ID},
+			{ID: "6", Name: "6", Source: "/mydne", Type: "http", AppID: app.ID, FnID: defaultDneFn.ID},
+			{ID: "7", Name: "7", Source: "/mydnehot", Type: "http", AppID: app.ID, FnID: httpDneFn.ID},
+			{ID: "8", Name: "8", Source: "/mydneregistry", Type: "http", AppID: app.ID, FnID: httpDneRegistryFn.ID},
+			{ID: "9", Name: "9", Source: "/myoom", Type: "http", AppID: app.ID, FnID: oomFn.ID},
+			{ID: "10", Name: "10", Source: "/mybigoutputcold", Type: "http", AppID: app.ID, FnID: defaultFn.ID},
+			{ID: "11", Name: "11", Source: "/mybigoutputhttp", Type: "http", AppID: app.ID, FnID: httpFn.ID},
+			{ID: "12", Name: "12", Source: "/mybigoutputjson", Type: "http", AppID: app.ID, FnID: jsonFn.ID},
+		},
+	)
+	ls := logs.NewMock()
+
+	rnr, cancelrnr := testRunner(t, ds, ls)
+	defer cancelrnr()
+
+	srv := testServer(ds, &mqs.Mock{}, ls, rnr, ServerTypeFull)
+
+	//expHeaders := map[string][]string{"Content-Type": {"application/json; charset=utf-8"}}
+	//expCTHeaders := map[string][]string{"Content-Type": {"foo/bar"}}
+	//
+	//// Checking for EndOfLogs currently depends on scheduling of go-routines (in docker/containerd) that process stderr & stdout.
+	//// Therefore, not testing for EndOfLogs for hot containers (which has complex I/O processing) anymore.
+	//multiLogExpectCold := []string{"BeginOfLogs", "EndOfLogs"}
+	//multiLogExpectHot := []string{"BeginOfLogs" /*, "EndOfLogs" */}
+	//
+	//crasher := `{"echoContent": "_TRX_ID_", "isDebug": true, "isCrash": true}`                      // crash container
+	//oomer := `{"echoContent": "_TRX_ID_", "isDebug": true, "allocateMemory": 12000000}`             // ask for 12MB
+	//badHot := `{"echoContent": "_TRX_ID_", "invalidResponse": true, "isDebug": true}`               // write a not json/http as output
+	//ok := `{"echoContent": "_TRX_ID_", "isDebug": true}`                                            // good response / ok
+	//respTypeLie := `{"echoContent": "_TRX_ID_", "responseContentType": "foo/bar", "isDebug": true}` // Content-Type: foo/bar
+	//respTypeJason := `{"echoContent": "_TRX_ID_", "jasonContentType": "foo/bar", "isDebug": true}`  // Content-Type: foo/bar
+	//
+	//// sleep between logs and with debug enabled, fn-test-utils will log header/footer below:
+	//multiLog := `{"echoContent": "_TRX_ID_", "sleepTime": 1000, "isDebug": true}`
+	//bigoutput := `{"echoContent": "_TRX_ID_", "isDebug": true, "trailerRepeat": 1000}` // 1000 trailers to exceed 2K
+	//smalloutput := `{"echoContent": "_TRX_ID_", "isDebug": true, "trailerRepeat": 1}`  // 1 trailer < 2K
+
+	testCases := []struct {
+		path               string
+		body               string
+		method             string
+		expectedCode       int
+		expectedHeaders    map[string][]string
+		expectedErrSubStr  string
+		expectedLogsSubStr []string
+	}{
+		//{"/t/myapp/", ok, "GET", http.StatusOK, expHeaders, "", nil},
+		//
+		//{"/t/myapp/myhot", badHot, "GET", http.StatusBadGateway, expHeaders, "invalid http response", nil},
+		//// hot container now back to normal:
+		//{"/t/myapp/myhot", ok, "GET", http.StatusOK, expHeaders, "", nil},
+		//
+		//{"/t/myapp/myhotjason", badHot, "GET", http.StatusBadGateway, expHeaders, "invalid json response", nil},
+		//// hot container now back to normal:
+		//{"/t/myapp/myhotjason", ok, "GET", http.StatusOK, expHeaders, "", nil},
+		//
+		//{"/t/myapp/myhot", respTypeLie, "GET", http.StatusOK, expCTHeaders, "", nil},
+		//{"/t/myapp/myhotjason", respTypeLie, "GET", http.StatusOK, expCTHeaders, "", nil},
+		//{"/t/myapp/myhotjason", respTypeJason, "GET", http.StatusOK, expCTHeaders, "", nil},
+		//
+		//{"/t/myapp/myroute", ok, "GET", http.StatusOK, expHeaders, "", nil},
+		//{"/t/myapp/myerror", crasher, "GET", http.StatusBadGateway, expHeaders, "container exit code 2", nil},
+		//{"/t/myapp/mydne", ``, "GET", http.StatusNotFound, nil, "pull access denied", nil},
+		{"/t/myapp/mydnehot", ``, "GET", http.StatusNotFound, nil, "pull access denied", nil},
+		//{"/t/myapp/mydneregistry", ``, "GET", http.StatusInternalServerError, nil, "connection refused", nil},
+		//
+		//{"/t/myapp/myoom", oomer, "GET", http.StatusBadGateway, nil, "container out of memory", nil},
+		//{"/t/myapp/myhot", multiLog, "GET", http.StatusOK, nil, "", multiLogExpectHot},
+		//{"/t/myapp/", multiLog, "GET", http.StatusOK, nil, "", multiLogExpectCold},
+		//{"/t/myapp/mybigoutputjson", bigoutput, "GET", http.StatusBadGateway, nil, "function response too large", nil},
+		//{"/t/myapp/mybigoutputjson", smalloutput, "GET", http.StatusOK, nil, "", nil},
+		//{"/t/myapp/mybigoutputhttp", bigoutput, "GET", http.StatusBadGateway, nil, "", nil},
+		//{"/t/myapp/mybigoutputhttp", smalloutput, "GET", http.StatusOK, nil, "", nil},
+		//{"/t/myapp/mybigoutputcold", bigoutput, "GET", http.StatusBadGateway, nil, "", nil},
+		//{"/t/myapp/mybigoutputcold", smalloutput, "GET", http.StatusOK, nil, "", nil},
+	}
+
+	callIds := make([]string, len(testCases))
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("Test_%d_%s", i, strings.Replace(test.path, "/", "_", -1)), func(t *testing.T) {
+			trx := fmt.Sprintf("_trx_%d_", i)
+			body := strings.NewReader(strings.Replace(test.body, "_TRX_ID_", trx, 1))
+			_, rec := routerRequest(t, srv.Router, test.method, test.path, body)
+			respBytes, _ := ioutil.ReadAll(rec.Body)
+			respBody := string(respBytes)
+			maxBody := len(respBody)
+			if maxBody > 1024 {
+				maxBody = 1024
+			}
+
+			callIds[i] = rec.Header().Get("Fn_call_id")
+
+			if rec.Code != test.expectedCode {
+				isFailure = true
+				t.Errorf("Test %d: Expected status code to be %d but was %d. body: %s",
+					i, test.expectedCode, rec.Code, respBody[:maxBody])
+			}
+
+			if rec.Code == http.StatusOK && !strings.Contains(respBody, trx) {
+				isFailure = true
+				t.Errorf("Test %d: Expected response to include %s but got body: %s",
+					i, trx, respBody[:maxBody])
+
+			}
+
+			if test.expectedErrSubStr != "" && !strings.Contains(respBody, test.expectedErrSubStr) {
+				isFailure = true
+				t.Errorf("Test %d: Expected response to include %s but got body: %s",
+					i, test.expectedErrSubStr, respBody[:maxBody])
+
+			}
+
+			if test.expectedHeaders != nil {
+				for name, header := range test.expectedHeaders {
+					if header[0] != rec.Header().Get(name) {
+						isFailure = true
+						t.Errorf("Test %d: Expected header `%s` to be %s but was %s. body: %s",
+							i, name, header[0], rec.Header().Get(name), respBody)
+					}
+				}
+			}
+		})
+
+	}
+
+	for i, test := range testCases {
+		if test.expectedLogsSubStr != nil {
+			if !checkLogs(t, i, ls, callIds[i], test.expectedLogsSubStr) {
+				isFailure = true
+			}
+		}
+	}
+}
+
+func TestTriggerRunnerTimeout(t *testing.T) {
+	buf := setLogBuffer()
+	isFailure := false
+
+	// Log once after we are done, flow of events are important (hot/cold containers, idle timeout, etc.)
+	// for figuring out why things failed.
+	defer func() {
+		if isFailure {
+			t.Log(buf.String())
+		}
+	}()
+
+	models.RouteMaxMemory = uint64(1024 * 1024 * 1024) // 1024 TB
+	hugeMem := uint64(models.RouteMaxMemory - 1)
+
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Route{
+			{Path: "/cold", Image: "fnproject/fn-test-utils", Type: "sync", Memory: 128, Timeout: 4, IdleTimeout: 30, AppID: app.ID},
+			{Path: "/hot", Image: "fnproject/fn-test-utils", Type: "sync", Format: "http", Memory: 128, Timeout: 4, IdleTimeout: 30, AppID: app.ID},
+			{Path: "/hot-json", Image: "fnproject/fn-test-utils", Type: "sync", Format: "json", Memory: 128, Timeout: 4, IdleTimeout: 30, AppID: app.ID},
+			{Path: "/bigmem-cold", Image: "fnproject/fn-test-utils", Type: "sync", Memory: hugeMem, Timeout: 1, IdleTimeout: 30, AppID: app.ID},
+			{Path: "/bigmem-hot", Image: "fnproject/fn-test-utils", Type: "sync", Format: "http", Memory: hugeMem, Timeout: 1, IdleTimeout: 30, AppID: app.ID},
+		},
+	)
+
+	fnl := logs.NewMock()
+	rnr, cancelrnr := testRunner(t, ds, fnl)
+	defer cancelrnr()
+
+	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path            string
+		body            string
+		method          string
+		expectedCode    int
+		expectedHeaders map[string][]string
+	}{
+		{"/r/myapp/cold", `{"echoContent": "_TRX_ID_", "sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
+		{"/r/myapp/cold", `{"echoContent": "_TRX_ID_", "sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot", `{"echoContent": "_TRX_ID_", "sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot", `{"echoContent": "_TRX_ID_", "sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
+		{"/r/myapp/hot-json", `{"echoContent": "_TRX_ID_", "sleepTime": 5000, "isDebug": true}`, "POST", http.StatusGatewayTimeout, nil},
+		{"/r/myapp/hot-json", `{"echoContent": "_TRX_ID_", "sleepTime": 0, "isDebug": true}`, "POST", http.StatusOK, nil},
+		{"/r/myapp/bigmem-cold", `{"echoContent": "_TRX_ID_", "sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},
+		{"/r/myapp/bigmem-hot", `{"echoContent": "_TRX_ID_", "sleepTime": 0, "isDebug": true}`, "POST", http.StatusServiceUnavailable, map[string][]string{"Retry-After": {"15"}}},
+	} {
+		trx := fmt.Sprintf("_trx_%d_", i)
+		body := strings.NewReader(strings.Replace(test.body, "_TRX_ID_", trx, 1))
+		_, rec := routerRequest(t, srv.Router, test.method, test.path, body)
+		respBytes, _ := ioutil.ReadAll(rec.Body)
+		respBody := string(respBytes)
+		maxBody := len(respBody)
+		if maxBody > 1024 {
+			maxBody = 1024
+		}
+
+		if rec.Code != test.expectedCode {
+			isFailure = true
+			t.Errorf("Test %d: Expected status code to be %d but was %d body: %#v",
+				i, test.expectedCode, rec.Code, respBody[:maxBody])
+		}
+
+		if rec.Code == http.StatusOK && !strings.Contains(respBody, trx) {
+			isFailure = true
+			t.Errorf("Test %d: Expected response to include %s but got body: %s",
+				i, trx, respBody[:maxBody])
+
+		}
+
+		if test.expectedHeaders != nil {
+			for name, header := range test.expectedHeaders {
+				if header[0] != rec.Header().Get(name) {
+					isFailure = true
+					t.Errorf("Test %d: Expected header `%s` to be %s but was %s body: %#v",
+						i, name, header[0], rec.Header().Get(name), respBody[:maxBody])
+				}
+			}
+		}
+	}
+}
+
+// Minimal test that checks the possibility of invoking concurrent hot sync functions.
+func TestTriggerRunnerMinimalConcurrentHotSync(t *testing.T) {
+	buf := setLogBuffer()
+
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Route{
+			{Path: "/hot", AppID: app.ID, Image: "fnproject/fn-test-utils", Type: "sync", Format: "http", Memory: 128, Timeout: 30, IdleTimeout: 5},
+		},
+	)
+
+	fnl := logs.NewMock()
+	rnr, cancelrnr := testRunner(t, ds, fnl)
+	defer cancelrnr()
+
+	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
+
+	for i, test := range []struct {
+		path            string
+		body            string
+		method          string
+		expectedCode    int
+		expectedHeaders map[string][]string
+	}{
+		{"/r/myapp/hot", `{"sleepTime": 100, "isDebug": true}`, "POST", http.StatusOK, nil},
+	} {
+		errs := make(chan error)
+		numCalls := 4
+		for k := 0; k < numCalls; k++ {
+			go func() {
+				body := strings.NewReader(test.body)
+				_, rec := routerRequest(t, srv.Router, test.method, test.path, body)
+
+				if rec.Code != test.expectedCode {
+					t.Log(buf.String())
+					errs <- fmt.Errorf("Test %d: Expected status code to be %d but was %d body: %#v",
+						i, test.expectedCode, rec.Code, rec.Body.String())
+					return
+				}
+
+				if test.expectedHeaders == nil {
+					errs <- nil
+					return
+				}
+				for name, header := range test.expectedHeaders {
+					if header[0] != rec.Header().Get(name) {
+						t.Log(buf.String())
+						errs <- fmt.Errorf("Test %d: Expected header `%s` to be %s but was %s body: %#v",
+							i, name, header[0], rec.Header().Get(name), rec.Body.String())
+						return
+					}
+				}
+				errs <- nil
+			}()
+		}
+		for k := 0; k < numCalls; k++ {
+			err := <-errs
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+		}
+	}
+}

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -40,20 +40,17 @@ func envTweaker(name, value string) func() {
 }
 
 func testRunner(_ *testing.T, args ...interface{}) (agent.Agent, context.CancelFunc) {
-	ds := datastore.NewMock()
 	ls := logs.NewMock()
 	var mq models.MessageQueue = &mqs.Mock{}
 	for _, a := range args {
 		switch arg := a.(type) {
-		case models.Datastore:
-			ds = arg
 		case models.MessageQueue:
 			mq = arg
 		case models.LogStore:
 			ls = arg
 		}
 	}
-	r := agent.New(agent.NewDirectDataAccess(ds, ls, mq))
+	r := agent.New(agent.NewDirectCallDataAccess(ls, mq))
 	return r, func() { r.Close() }
 }
 
@@ -219,6 +216,7 @@ func TestRouteRunnerExecEmptyBody(t *testing.T) {
 		}
 	}
 }
+
 func TestRouteRunnerExecution(t *testing.T) {
 	buf := setLogBuffer()
 	isFailure := false

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -2,57 +2,19 @@ package server
 
 import (
 	"bytes"
-	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/logs"
 	"github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn/api/mqs"
 )
 
-func envTweaker(name, value string) func() {
-	bck, ok := os.LookupEnv(name)
-
-	err := os.Setenv(name, value)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	return func() {
-		var err error
-		if !ok {
-			err = os.Unsetenv(name)
-		} else {
-			err = os.Setenv(name, bck)
-		}
-		if err != nil {
-			panic(err.Error())
-		}
-	}
-}
-
-func testRunner(_ *testing.T, args ...interface{}) (agent.Agent, context.CancelFunc) {
-	ls := logs.NewMock()
-	var mq models.MessageQueue = &mqs.Mock{}
-	for _, a := range args {
-		switch arg := a.(type) {
-		case models.MessageQueue:
-			mq = arg
-		case models.LogStore:
-			ls = arg
-		}
-	}
-	r := agent.New(agent.NewDirectCallDataAccess(ls, mq))
-	return r, func() { r.Close() }
-}
+// TODO Deprecate with Routes
 
 func TestRouteRunnerGet(t *testing.T) {
 	buf := setLogBuffer()
@@ -374,85 +336,6 @@ func TestRouteRunnerExecution(t *testing.T) {
 			if !checkLogs(t, i, ls, callIds[i], test.expectedLogsSubStr) {
 				isFailure = true
 			}
-		}
-	}
-}
-
-func checkLogs(t *testing.T, tnum int, ds models.LogStore, callID string, expected []string) bool {
-
-	logReader, err := ds.GetLog(context.Background(), "myapp", callID)
-	if err != nil {
-		t.Errorf("Test %d: GetLog for call_id:%s returned err %s",
-			tnum, callID, err.Error())
-		return false
-	}
-
-	logBytes, err := ioutil.ReadAll(logReader)
-	if err != nil {
-		t.Errorf("Test %d: GetLog read IO call_id:%s returned err %s",
-			tnum, callID, err.Error())
-		return false
-	}
-
-	logBody := string(logBytes)
-	maxLog := len(logBody)
-	if maxLog > 1024 {
-		maxLog = 1024
-	}
-
-	for _, match := range expected {
-		if !strings.Contains(logBody, match) {
-			t.Errorf("Test %d: GetLog read IO call_id:%s cannot find: %s in logs: %s",
-				tnum, callID, match, logBody[:maxLog])
-			return false
-		}
-	}
-
-	return true
-}
-
-// implement models.MQ and models.APIError
-type errorMQ struct {
-	error
-	code int
-}
-
-func (mock *errorMQ) Push(context.Context, *models.Call) (*models.Call, error) { return nil, mock }
-func (mock *errorMQ) Reserve(context.Context) (*models.Call, error)            { return nil, mock }
-func (mock *errorMQ) Delete(context.Context, *models.Call) error               { return mock }
-func (mock *errorMQ) Code() int                                                { return mock.code }
-func (mock *errorMQ) Close() error                                             { return nil }
-func TestFailedEnqueue(t *testing.T) {
-	buf := setLogBuffer()
-	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
-	ds := datastore.NewMockInit(
-		[]*models.App{app},
-		[]*models.Route{
-			{Path: "/dummy", Image: "dummy/dummy", Type: "async", Memory: 128, Timeout: 30, IdleTimeout: 30, AppID: app.ID},
-		},
-	)
-	err := errors.New("Unable to push task to queue")
-	mq := &errorMQ{err, http.StatusInternalServerError}
-	fnl := logs.NewMock()
-	rnr, cancelrnr := testRunner(t, ds, mq, fnl)
-	defer cancelrnr()
-
-	srv := testServer(ds, mq, fnl, rnr, ServerTypeFull)
-	for i, test := range []struct {
-		path            string
-		body            string
-		method          string
-		expectedCode    int
-		expectedHeaders map[string][]string
-	}{
-		{"/r/myapp/dummy", ``, "POST", http.StatusInternalServerError, nil},
-	} {
-		body := strings.NewReader(test.body)
-		_, rec := routerRequest(t, srv.Router, test.method, test.path, body)
-		if rec.Code != test.expectedCode {
-			t.Log(buf.String())
-			t.Errorf("Test %d: Expected status code to be %d but was %d",
-				i, test.expectedCode, rec.Code)
 		}
 	}
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -170,7 +170,6 @@ func (s NodeType) String() string {
 	default:
 		return fmt.Sprintf("unknown(%d)", s)
 	}
-
 }
 
 // Server is the object which ties together all the fn things, it is the entrypoint

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -179,28 +179,29 @@ type Server struct {
 	Router      *gin.Engine
 	AdminRouter *gin.Engine
 
-	webListenPort    int
-	adminListenPort  int
-	grpcListenPort   int
-	agent            agent.Agent
-	datastore        models.Datastore
-	mq               models.MessageQueue
-	logstore         models.LogStore
-	nodeType         NodeType
+	webListenPort   int
+	adminListenPort int
+	grpcListenPort  int
+	agent           agent.Agent
+	datastore       models.Datastore
+	mq              models.MessageQueue
+	logstore        models.LogStore
+	nodeType        NodeType
 	// Agent enqueue  and read stores
-	lbEnqueue    agent.EnqueueDataAccess
-	lbReadAccess agent.ReadDataAccess
-	cert             string
-	certKey          string
-	certAuthority    string
-	appListeners     *appListeners
-	routeListeners   *routeListeners
-	fnListeners      *fnListeners
-	triggerListeners *triggerListeners
-	rootMiddlewares  []fnext.Middleware
-	apiMiddlewares   []fnext.Middleware
-	promExporter     *prometheus.Exporter
-	triggerAnnotator TriggerAnnotator
+	lbEnqueue              agent.EnqueueDataAccess
+	lbReadAccess           agent.ReadDataAccess
+	noHTTTPTriggerEndpoint bool
+	cert                   string
+	certKey                string
+	certAuthority          string
+	appListeners           *appListeners
+	routeListeners         *routeListeners
+	fnListeners            *fnListeners
+	triggerListeners       *triggerListeners
+	rootMiddlewares        []fnext.Middleware
+	apiMiddlewares         []fnext.Middleware
+	promExporter           *prometheus.Exporter
+	triggerAnnotator       TriggerAnnotator
 	// Extensions can append to this list of contexts so that cancellations are properly handled.
 	extraCtxs []context.Context
 }
@@ -758,7 +759,7 @@ func WithPrometheus() Option {
 // WithoutHTTPTriggerEndpoints optionally disables the trigger and route endpoints from a LB -supporting server, allowing extensions to replace them with their own versions
 func WithoutHTTPTriggerEndpoints() Option {
 	return func(ctx context.Context, s *Server) error {
-		s.noHttpTriggerEndpoint = true
+		s.noHTTTPTriggerEndpoint = true
 		return nil
 	}
 }
@@ -1138,7 +1139,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 
 	switch s.nodeType {
 	case ServerTypeFull, ServerTypeLB, ServerTypeRunner:
-		if !s.noHttpTriggerEndpoint {
+		if !s.noHTTTPTriggerEndpoint {
 			lbRouteGroup := engine.Group("/r")
 			lbRouteGroup.Use(s.checkAppPresenceByNameAtLB())
 			lbRouteGroup.Any("/:appName", s.handleV1FunctionCall)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -447,7 +447,9 @@ func WithReadDataAccess(ds agent.ReadDataAccess) Option {
 func WithDatastore(ds models.Datastore) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.datastore = ds
-		s.lbReadAccess = agent.NewCachedDataAccess(ds)
+		if s.lbReadAccess == nil {
+			s.lbReadAccess = agent.NewCachedDataAccess(ds)
+		}
 		return nil
 	}
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -250,10 +250,10 @@ func NewFromEnv(ctx context.Context, opts ...Option) *Server {
 	opts = append(opts, WithNodeCertKey(getEnv(EnvCertKey, "")))
 	opts = append(opts, WithNodeCertAuthority(getEnv(EnvCertAuth, "")))
 
-	publicLbUrl := getEnv(EnvPublicLoadBalancerURL, "")
-	if publicLbUrl != "" {
-		logrus.Infof("using LB Base URL: '%s'", publicLbUrl)
-		opts = append(opts, WithTriggerAnnotator(NewStaticURLTriggerAnnotator(publicLbUrl)))
+	publicLBURL := getEnv(EnvPublicLoadBalancerURL, "")
+	if publicLBURL != "" {
+		logrus.Infof("using LB Base URL: '%s'", publicLBURL)
+		opts = append(opts, WithTriggerAnnotator(NewStaticURLTriggerAnnotator(publicLBURL)))
 	} else {
 		opts = append(opts, WithTriggerAnnotator(NewRequestBasedTriggerAnnotator()))
 	}
@@ -1127,13 +1127,13 @@ func (s *Server) bindHandlers(ctx context.Context) {
 			runner.POST("/start", s.handleRunnerStart)
 			runner.POST("/finish", s.handleRunnerFinish)
 
-			runnerAppApi := runner.Group(
+			runnerAppAPI := runner.Group(
 				"/apps/:appID")
-			runnerAppApi.Use(setAppIDInCtx)
+			runnerAppAPI.Use(setAppIDInCtx)
 			// Both of these are somewhat odd -
 			// Deprecate, remove with routes
-			runnerAppApi.GET("/routes/*route", s.handleRunnerGetRoute)
-			runnerAppApi.GET("/triggerBySource/:triggerType/*triggerSource", s.handleRunnerGetTriggerBySource)
+			runnerAppAPI.GET("/routes/*route", s.handleRunnerGetRoute)
+			runnerAppAPI.GET("/triggerBySource/:triggerType/*triggerSource", s.handleRunnerGetTriggerBySource)
 
 		}
 	}
@@ -1142,8 +1142,8 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	case ServerTypeFull, ServerTypeLB, ServerTypeRunner:
 		if !s.noHTTTPTriggerEndpoint {
 			lbTriggerGroup := engine.Group("/t")
-			lbTriggerGroup.Any("/:appName", s.handleHttpTriggerCall)
-			lbTriggerGroup.Any("/:appName/*triggerSource", s.handleHttpTriggerCall)
+			lbTriggerGroup.Any("/:appName", s.handleHTTPTriggerCall)
+			lbTriggerGroup.Any("/:appName/*triggerSource", s.handleHTTPTriggerCall)
 
 			// TODO Deprecate with routes
 			lbRouteGroup := engine.Group("/r")

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -10,14 +10,12 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/datastore/sql"
 	_ "github.com/fnproject/fn/api/datastore/sql/sqlite"
-	"github.com/fnproject/fn/api/id"
 	"github.com/fnproject/fn/api/logs"
 	"github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn/api/mqs"
@@ -274,61 +272,6 @@ func TestApiNode(t *testing.T) {
 		{"get deleted route on deleted app", "GET", "/v1/apps/myapp/routes/myroute", ``, http.StatusNotFound, 0},
 	} {
 		_, rec := routerRequest(t, srv.Router, test.method, test.path, bytes.NewBuffer([]byte(test.body)))
-		if rec.Code != test.expectedCode {
-			t.Log(buf.String())
-			t.Errorf("Test \"%s\": Expected status code to be %d but was %d",
-				test.name, test.expectedCode, rec.Code)
-		}
-	}
-}
-
-func TestHybridEndpoints(t *testing.T) {
-	buf := setLogBuffer()
-	app := &models.App{ID: "app_id", Name: "myapp"}
-	ds := datastore.NewMockInit(
-		[]*models.App{app},
-		[]*models.Route{{
-			AppID: app.ID,
-			Path:  "yodawg",
-		}},
-	)
-
-	logDB := logs.NewMock()
-
-	srv := testServer(ds, &mqs.Mock{}, logDB, nil /* TODO */, ServerTypeAPI)
-
-	newCallBody := func() string {
-		call := &models.Call{
-			AppID: app.ID,
-			ID:    id.New().String(),
-			Path:  "yodawg",
-			// TODO ?
-		}
-		var b bytes.Buffer
-		json.NewEncoder(&b).Encode(&call)
-		return b.String()
-	}
-
-	for _, test := range []struct {
-		name         string
-		method       string
-		path         string
-		body         string
-		expectedCode int
-	}{
-		// TODO change all these tests to just do an async task in normal order once plumbing is done
-
-		{"post async call", "PUT", "/v2/runner/async", newCallBody(), http.StatusOK},
-
-		// TODO this one only works if it's not the same as the first since update isn't hooked up
-		{"finish call", "POST", "/v2/runner/finish", newCallBody(), http.StatusOK},
-
-		// TODO these won't work until update works and the agent gets shut off
-		//{"get async call", "GET", "/v1/runner/async", "", http.StatusOK},
-		//{"start call", "POST", "/v1/runner/start", "TODO", http.StatusOK},
-	} {
-		_, rec := routerRequest(t, srv.Router, test.method, test.path, strings.NewReader(test.body))
-
 		if rec.Code != test.expectedCode {
 			t.Log(buf.String())
 			t.Errorf("Test \"%s\": Expected status code to be %d but was %d",

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -318,10 +318,10 @@ func TestHybridEndpoints(t *testing.T) {
 	}{
 		// TODO change all these tests to just do an async task in normal order once plumbing is done
 
-		{"post async call", "PUT", "/v1/runner/async", newCallBody(), http.StatusOK},
+		{"post async call", "PUT", "/v2/runner/async", newCallBody(), http.StatusOK},
 
 		// TODO this one only works if it's not the same as the first since update isn't hooked up
-		{"finish call", "POST", "/v1/runner/finish", newCallBody(), http.StatusOK},
+		{"finish call", "POST", "/v2/runner/finish", newCallBody(), http.StatusOK},
 
 		// TODO these won't work until update works and the agent gets shut off
 		//{"get async call", "GET", "/v1/runner/async", "", http.StatusOK},

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -220,13 +220,16 @@ func TestRunnerNode(t *testing.T) {
 		{"get all routes not found", "GET", "/v1/apps/myapp/routes", ``, http.StatusBadRequest, 0},
 		{"delete app not found", "DELETE", "/v1/apps/myapp", ``, http.StatusBadRequest, 0},
 	} {
-		_, rec := routerRequest(t, srv.Router, test.method, test.path, bytes.NewBuffer([]byte(test.body)))
+		t.Run(test.name, func(t *testing.T) {
+			_, rec := routerRequest(t, srv.Router, test.method, test.path, bytes.NewBuffer([]byte(test.body)))
 
-		if rec.Code != test.expectedCode {
-			t.Log(buf.String())
-			t.Errorf("Test \"%s\": Expected status code to be %d but was %d",
-				test.name, test.expectedCode, rec.Code)
-		}
+			if rec.Code != test.expectedCode {
+				t.Log(buf.String())
+				t.Errorf("Test \"%s\": Expected status code to be %d but was %d",
+					test.name, test.expectedCode, rec.Code)
+			}
+		})
+
 	}
 }
 

--- a/api/server/trigger_annotator.go
+++ b/api/server/trigger_annotator.go
@@ -15,7 +15,7 @@ type TriggerAnnotator interface {
 
 type requestBasedTriggerAnnotator struct{}
 
-func annotateTriggerWithBaseUrl(baseURL string, app *models.App, t *models.Trigger) (*models.Trigger, error) {
+func annotateTriggerWithBaseURL(baseURL string, app *models.App, t *models.Trigger) (*models.Trigger, error) {
 	if t.Type != models.TriggerTypeHTTP {
 		return t, nil
 	}
@@ -41,23 +41,25 @@ func (tp *requestBasedTriggerAnnotator) AnnotateTrigger(ctx *gin.Context, app *m
 		scheme = "https"
 	}
 
-	return annotateTriggerWithBaseUrl(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), app, t)
+	return annotateTriggerWithBaseURL(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), app, t)
 }
 
+//NewRequestBasedTriggerAnnotator creates a TriggerAnnotator that inspects the incoming request host and port, and uses this to generate http trigger endpoint URLs based on those
 func NewRequestBasedTriggerAnnotator() TriggerAnnotator {
 	return &requestBasedTriggerAnnotator{}
 }
 
-type staticUrlTriggerAnnotator struct {
-	urlBase string
+type staticURLTriggerAnnotator struct {
+	baseURL string
 }
 
-func NewStaticURLTriggerAnnotator(baseUrl string) TriggerAnnotator {
+//NewStaticURLTriggerAnnotator annotates triggers bases on a given, specified URL base - e.g. "https://my.domain" --->  "https://my.domain/t/app/source"
+func NewStaticURLTriggerAnnotator(baseURL string) TriggerAnnotator {
 
-	return &staticUrlTriggerAnnotator{urlBase: baseUrl}
+	return &staticURLTriggerAnnotator{baseURL: baseURL}
 }
 
-func (s *staticUrlTriggerAnnotator) AnnotateTrigger(ctx *gin.Context, app *models.App, trigger *models.Trigger) (*models.Trigger, error) {
-	return annotateTriggerWithBaseUrl(s.urlBase, app, trigger)
+func (s *staticURLTriggerAnnotator) AnnotateTrigger(ctx *gin.Context, app *models.App, trigger *models.Trigger) (*models.Trigger, error) {
+	return annotateTriggerWithBaseURL(s.baseURL, app, trigger)
 
 }

--- a/api/server/trigger_get.go
+++ b/api/server/trigger_get.go
@@ -1,11 +1,10 @@
 package server
 
 import (
-	"net/http"
-
 	"fmt"
 	"github.com/fnproject/fn/api"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 func (s *Server) handleTriggerGet(c *gin.Context) {

--- a/test/fn-system-tests/exec_route_test.go
+++ b/test/fn-system-tests/exec_route_test.go
@@ -1,0 +1,341 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fnproject/fn/api/models"
+)
+
+// TODO deprecate with routes
+
+func TestCanExecuteFunction(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rt := ensureRoute(t)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`
+	content := bytes.NewBuffer([]byte(body))
+	output := &bytes.Buffer{}
+
+	resp, err := callFN(ctx, u.String(), content, output, "POST")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	echo, err := getEchoContent(output.Bytes())
+	if err != nil || echo != "HelloWorld" {
+		t.Fatalf("getEchoContent/HelloWorld check failed on %v", output)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode check failed on %v", resp.StatusCode)
+	}
+
+	// Now let's check FN_CHEESE, since LB and runners have override/extension mechanism
+	// to insert FN_CHEESE into config
+	cheese, err := getConfigContent("FN_CHEESE", output.Bytes())
+	if err != nil || cheese != "Tete de Moine" {
+		t.Fatalf("getConfigContent/FN_CHEESE check failed (%v) on %v", err, output)
+	}
+
+	// Now let's check FN_WINE, since runners have override to insert this.
+	wine, err := getConfigContent("FN_WINE", output.Bytes())
+	if err != nil || wine != "1982 Margaux" {
+		t.Fatalf("getConfigContent/FN_WINE check failed (%v) on %v", err, output)
+	}
+}
+
+func TestCanExecuteBigOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rt := ensureRoute(t)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	// Approx 5.3MB output
+	body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true, "trailerRepeat": 410000}`
+	content := bytes.NewBuffer([]byte(body))
+	output := &bytes.Buffer{}
+
+	resp, err := callFN(ctx, u.String(), content, output, "POST")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	t.Logf("getEchoContent/HelloWorld size %d", len(output.Bytes()))
+
+	echo, err := getEchoContent(output.Bytes())
+	if err != nil || echo != "HelloWorld" {
+		t.Fatalf("getEchoContent/HelloWorld check failed on %v", output)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode check failed on %v", resp.StatusCode)
+	}
+}
+
+func TestCanExecuteTooBigOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rt := ensureRoute(t)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	// > 6MB output
+	body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true, "trailerRepeat": 600000}`
+	content := bytes.NewBuffer([]byte(body))
+	output := &bytes.Buffer{}
+
+	resp, err := callFN(ctx, u.String(), content, output, "POST")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	exp := "{\"error\":{\"message\":\"function response too large\"}}\n"
+	actual := output.String()
+
+	if !strings.Contains(exp, actual) || len(exp) != len(actual) {
+		t.Fatalf("Assertion error.\n\tExpected: %v\n\tActual: %v", exp, output.String())
+	}
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("StatusCode check failed on %v", resp.StatusCode)
+	}
+}
+
+func TestCanExecuteEmptyOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rt := ensureRoute(t)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	// empty body output
+	body := `{"sleepTime": 0, "isDebug": true, "isEmptyBody": true}`
+	content := bytes.NewBuffer([]byte(body))
+	output := &bytes.Buffer{}
+
+	resp, err := callFN(ctx, u.String(), content, output, "POST")
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	actual := output.String()
+
+	if 0 != len(actual) {
+		t.Fatalf("Assertion error.\n\tExpected empty\n\tActual: %v", output.String())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode check failed on %v", resp.StatusCode)
+	}
+}
+
+func TestBasicConcurrentExecution(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rt := ensureRoute(t)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	results := make(chan error)
+	concurrentFuncs := 10
+	for i := 0; i < concurrentFuncs; i++ {
+		go func() {
+			body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`
+			content := bytes.NewBuffer([]byte(body))
+			output := &bytes.Buffer{}
+			resp, err := callFN(ctx, u.String(), content, output, "POST")
+			if err != nil {
+				results <- fmt.Errorf("Got unexpected error: %v", err)
+				return
+			}
+
+			echo, err := getEchoContent(output.Bytes())
+			if err != nil || echo != "HelloWorld" {
+				results <- fmt.Errorf("Assertion error.\n\tActual: %v", output.String())
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				results <- fmt.Errorf("StatusCode check failed on %v", resp.StatusCode)
+				return
+			}
+
+			results <- nil
+		}()
+	}
+	for i := 0; i < concurrentFuncs; i++ {
+		err := <-results
+		if err != nil {
+			t.Fatalf("Error in basic concurrency execution test: %v", err)
+		}
+	}
+
+}
+
+func TestSaturatedSystem(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	rt := &models.Route{
+		Path:    routeName,
+		Timeout: 1,
+		Image:   "fnproject/fn-test-utils",
+		Format:  "json",
+		Memory:  300,
+		Type:    "sync",
+	}
+	rt = ensureRoute(t, rt)
+
+	lb, err := LB()
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	u := url.URL{
+		Scheme: "http",
+		Host:   lb,
+	}
+	u.Path = path.Join(u.Path, "r", appName, rt.Path)
+
+	body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`
+	content := bytes.NewBuffer([]byte(body))
+	output := &bytes.Buffer{}
+
+	resp, err := callFN(ctx, u.String(), content, output, "POST")
+	if resp != nil || err == nil || ctx.Err() == nil {
+		t.Fatalf("Expected response: %v err:%v", resp, err)
+	}
+}
+
+func callFN(ctx context.Context, u string, content io.Reader, output io.Writer, method string) (*http.Response, error) {
+	if method == "" {
+		if content == nil {
+			method = "GET"
+		} else {
+			method = "POST"
+		}
+	}
+
+	req, err := http.NewRequest(method, u, content)
+	if err != nil {
+		return nil, fmt.Errorf("error running route: %s", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error running route: %s", err)
+	}
+
+	io.Copy(output, resp.Body)
+
+	return resp, nil
+}
+
+func ensureRoute(t *testing.T, rts ...*models.Route) *models.Route {
+	var rt *models.Route
+	if len(rts) > 0 {
+		rt = rts[0]
+	} else {
+		rt = &models.Route{
+			Path:   routeName + "yabbadabbadoo",
+			Image:  image,
+			Format: format,
+			Memory: memory,
+			Type:   typ,
+		}
+	}
+	var wrapped struct {
+		Route *models.Route `json:"route"`
+	}
+
+	wrapped.Route = rt
+
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(wrapped)
+	if err != nil {
+		t.Fatal("error encoding body", err)
+	}
+
+	urlStr := host() + "/v1/apps/" + appName + "/routes" + rt.Path
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatal("error creating url", urlStr, err)
+	}
+
+	req, err := http.NewRequest("PUT", u.String(), &buf)
+	if err != nil {
+		t.Fatal("error creating request", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("error creating route", err)
+	}
+
+	buf.Reset()
+	io.Copy(&buf, resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatal("error creating/updating app or otherwise ensuring it exists:", resp.StatusCode, buf.String())
+	}
+
+	wrapped.Route = nil
+	err = json.NewDecoder(&buf).Decode(&wrapped)
+	if err != nil {
+		t.Fatal("error decoding response")
+	}
+
+	return wrapped.Route
+}

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -229,7 +229,7 @@ func SetUpLBNode(ctx context.Context) (*server.Server, error) {
 		return nil, err
 	}
 
-	opts = append(opts, server.WithAgent(lbAgent), server.WithReadDataAccess(cl))
+	opts = append(opts, server.WithAgent(lbAgent), server.WithReadDataAccess(agent.NewCachedDataAccess(cl)))
 	return server.New(ctx, opts...), nil
 }
 

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -224,12 +224,12 @@ func SetUpLBNode(ctx context.Context) (*server.Server, error) {
 
 	// Create an LB Agent with a Call Overrider to intercept calls in GetCall(). Overrider in this example
 	// scrubs CPU/TmpFsSize and adds FN_CHEESE key/value into extensions.
-	lbAgent, err := agent.NewLBAgent(agent.NewCachedDataAccess(cl), nodePool, placer, agent.WithLBCallOverrider(LBCallOverrider))
+	lbAgent, err := agent.NewLBAgent(cl, nodePool, placer, agent.WithLBCallOverrider(LBCallOverrider))
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append(opts, server.WithAgent(lbAgent))
+	opts = append(opts, server.WithAgent(lbAgent), server.WithReadDataAccess(cl))
 	return server.New(ctx, opts...), nil
 }
 
@@ -267,7 +267,6 @@ func SetUpPureRunnerNode(ctx context.Context, nodeNum int) (*server.Server, erro
 	innerAgent := agent.New(ds,
 		agent.WithConfig(cfg),
 		agent.WithDockerDriver(drv),
-		agent.WithoutAsyncDequeue(),
 		agent.WithCallOverrider(PureRunnerCallOverrider))
 
 	cancelCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
This doesn't add invoke yet - and that will necessarily pay down some of the refactoring debt created here but I wanted to get black-box testing and functionality in place for HTTP triggers before we started the larger invoke refactor. 

This also adds "unique by appId, source, type" to triggers and tests. 


A lot of the changes are an initial refactor of the data store interfaces  with a view to removing: 
* NoPStore from the pure runner 
* Store calls from the Agent (Agent as a proxy for the DB) 
* Storage operations from agent.call 

None of these are completely payed down yet so it's a bit entangled at the moment - Many of these things can wash out of invoke. 