### PR TITLE
Removing Swaggerv2 error wrapping

### DIFF
--- a/docs/swagger_v2.yml
+++ b/docs/swagger_v2.yml
@@ -581,7 +581,7 @@ definitions:
         items:
           $ref: '#/definitions/Trigger'
 
-  ErrorBody:
+  Error:
     type: object
     properties:
       message:
@@ -590,12 +590,6 @@ definitions:
       fields:
         type: string
         readOnly: true
-
-  Error:
-    type: object
-    properties:
-      error:
-        $ref: '#/definitions/ErrorBody'
 
 parameters:
   cursor:


### PR DESCRIPTION
The code does not produce errors in the shape specified by the swagger, causing the generated client to explode on errors.

This change removed the error wrapper from the swagger, bringing the two views into line.
