### PR TITLE
List Cursor management moved into datastore layer.

### DIFF
--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -375,22 +375,30 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 		t.Run("List apps", func(t *testing.T) {
 			h := NewHarness(t, ctx, ds)
 			defer h.Cleanup()
-			testApp := h.GivenAppInDb(rp.ValidApp())
+			a1 := h.GivenAppInDb(rp.ValidApp())
+			h.GivenAppInDb(rp.ValidApp())
 
 			// Testing list apps
 			apps, err := ds.GetApps(ctx, &models.AppFilter{PerPage: 100})
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(apps) == 0 {
-				t.Fatal("expected result count to be greater than 0")
+			if len(apps) != 2 {
+				t.Fatalf("expected result count to be 2, got %d", len(apps))
+			}
+			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Name: a1.Name})
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if len(apps) != 1 {
+				t.Fatalf("expected result count to be 1, got %d", len(apps))
 			}
 			for _, app := range apps {
-				if app.Name == testApp.Name {
+				if app.Name == a1.Name {
 					return
 				}
 			}
-			t.Fatalf("expected app list to contain app %s, got %#v", testApp.Name, apps)
+			t.Fatalf("expected app list to contain app %s, got %#v", a1.Name, apps)
 		})
 
 		t.Run("Simple Pagination", func(t *testing.T) {

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -442,7 +442,7 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", gendApps[0].Name, apps.Items[0].Name)
 			}
 
-			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Cursor: apps.Items[0].Name})
+			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Cursor: apps.NextCursor})
 			if err != nil {
 				t.Fatalf(" error: %s", err)
 			}

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -206,11 +206,10 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 
 			start := time.Now()
 			returnedApp, err := ds.InsertApp(ctx, rp.ValidApp())
-
-			h.AppForDeletion(returnedApp)
 			if err != nil {
 				t.Fatalf("Expected succcess, got %s", err)
 			}
+			h.AppForDeletion(returnedApp)
 
 			if !time.Time(returnedApp.CreatedAt).After(start) {
 				t.Fatalf("expected created to be set %s", returnedApp.CreatedAt)

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -383,17 +383,17 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(apps) != 2 {
-				t.Fatalf("expected result count to be 2, got %d", len(apps))
+			if len(apps.Items) != 2 {
+				t.Fatalf("expected result count to be 2, got %d", len(apps.Items))
 			}
 			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Name: a1.Name})
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(apps) != 1 {
-				t.Fatalf("expected result count to be 1, got %d", len(apps))
+			if len(apps.Items) != 1 {
+				t.Fatalf("expected result count to be 1, got %d", len(apps.Items))
 			}
-			for _, app := range apps {
+			for _, app := range apps.Items {
 				if app.Name == a1.Name {
 					return
 				}
@@ -413,22 +413,22 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf(" error: %s", err)
 			}
-			if len(apps) != 1 {
-				t.Fatalf(" expected result count to be 1 but got %d", len(apps))
-			} else if apps[0].Name != a1.Name {
-				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a1.Name, apps[0].Name)
+			if len(apps.Items) != 1 {
+				t.Fatalf(" expected result count to be 1 but got %d", len(apps.Items))
+			} else if apps.Items[0].Name != a1.Name {
+				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a1.Name, apps.Items[0].Name)
 			}
 
-			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Cursor: apps[0].Name})
+			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100, Cursor: apps.Items[0].Name})
 			if err != nil {
 				t.Fatalf(" error: %s", err)
 			}
-			if len(apps) != 2 {
-				t.Fatalf(" expected result count to be 2 but got %d", len(apps))
-			} else if apps[0].Name != a2.Name {
-				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a2.Name, apps[0].Name)
-			} else if apps[1].Name != a3.Name {
-				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a3.Name, apps[1].Name)
+			if len(apps.Items) != 2 {
+				t.Fatalf(" expected result count to be 2 but got %d", len(apps.Items))
+			} else if apps.Items[0].Name != a2.Name {
+				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a2.Name, apps.Items[0].Name)
+			} else if apps.Items[1].Name != a3.Name {
+				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a3.Name, apps.Items[1].Name)
 			}
 
 			a4 := h.GivenAppInDb(rp.ValidApp())
@@ -437,10 +437,10 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf(" error: %s", err)
 			}
-			if len(apps) != 4 {
-				t.Fatalf(" expected result count to be 4 but got %d", len(apps))
-			} else if apps[3].Name != a4.Name {
-				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a4.Name, apps[0].Name)
+			if len(apps.Items) != 4 {
+				t.Fatalf(" expected result count to be 4 but got %d", len(apps.Items))
+			} else if apps.Items[3].Name != a4.Name {
+				t.Fatalf(" expected `app.Name` to be `%s` but it was `%s`", a4.Name, apps.Items[0].Name)
 			}
 
 		})
@@ -1000,7 +1000,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(fns) != 0 {
+			if len(fns.Items) != 0 {
 				t.Fatal("expected result count to be  0")
 			}
 		})
@@ -1018,31 +1018,31 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(fns) != 3 {
-				t.Fatalf("expected result count to be 3, but was %d", len(fns))
+			if len(fns.Items) != 3 {
+				t.Fatalf("expected result count to be 3, but was %d", len(fns.Items))
 			}
 			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, PerPage: 1})
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
-			if len(fns) != 1 {
-				t.Fatalf("expected result count to be 1, but was %d", len(fns))
+			if len(fns.Items) != 1 {
+				t.Fatalf("expected result count to be 1, but was %d", len(fns.Items))
 			}
 
-			if !f1.EqualsWithAnnotationSubset(fns[0]) {
-				t.Fatalf("Expecting function to be %#v but was %#v", f1, fns[0])
+			if !f1.EqualsWithAnnotationSubset(fns.Items[0]) {
+				t.Fatalf("Expecting function to be %#v but was %#v", f1, fns.Items[0])
 			}
 
-			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, PerPage: 2, Cursor: fns[0].Name})
+			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, PerPage: 2, Cursor: fns.Items[0].Name})
 			if err != nil {
 				t.Fatalf("error: %s", err)
 			}
-			if len(fns) != 2 {
-				t.Fatalf("expected result count to be 2 but got %d", len(fns))
-			} else if !f2.EqualsWithAnnotationSubset(fns[0]) {
-				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f2, fns[0])
-			} else if !f3.EqualsWithAnnotationSubset(fns[1]) {
-				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f3, fns[1])
+			if len(fns.Items) != 2 {
+				t.Fatalf("expected result count to be 2 but got %d", len(fns.Items))
+			} else if !f2.EqualsWithAnnotationSubset(fns.Items[0]) {
+				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f2, fns.Items[0])
+			} else if !f3.EqualsWithAnnotationSubset(fns.Items[1]) {
+				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f3, fns.Items[1])
 			}
 		})
 
@@ -1180,8 +1180,8 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 		t.Run("non-existant app", func(t *testing.T) {
 			nonMatchingFilter := &models.TriggerFilter{AppID: "notexist"}
 			triggers, err := ds.GetTriggers(ctx, nonMatchingFilter)
-			if len(triggers) != 0 && err == nil {
-				t.Fatalf("expected empty trigger list and no error, but got list [%v] and err %s", triggers, err)
+			if len(triggers.Items) != 0 && err == nil {
+				t.Fatalf("expected empty trigger list and no error, but got list [%v] and err %s", triggers.Items, err)
 			}
 		})
 
@@ -1225,13 +1225,13 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Test GetTriggers(get all triggers for app), not expecting err %s", err)
 			}
 
-			if len(triggers) != 11 {
-				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 10 results, got %d", len(triggers))
+			if len(triggers.Items) != 11 {
+				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 10 results, got %d", len(triggers.Items))
 			}
 
 			for i := 1; i < 10; i++ {
-				if !storedTriggers[i].EqualsWithAnnotationSubset(triggers[i]) {
-					t.Fatalf("expecting ordered by names, but aren't: %s, %s", storedTriggers[i].Name, triggers[i].Name)
+				if !storedTriggers[i].EqualsWithAnnotationSubset(triggers.Items[i]) {
+					t.Fatalf("expecting ordered by names, but aren't: %s, %s", storedTriggers[i].Name, triggers.Items[i].Name)
 
 				}
 			}
@@ -1242,12 +1242,12 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Test GetTriggers(filter by name), not expecting err %s", err)
 			}
 
-			if len(triggers) != 1 {
-				t.Fatalf("Test GetTriggers(filter by name), expecting 1 results, got %d", len(triggers))
+			if len(triggers.Items) != 1 {
+				t.Fatalf("Test GetTriggers(filter by name), expecting 1 results, got %d", len(triggers.Items))
 			}
 
-			if !storedTriggers[0].EqualsWithAnnotationSubset(triggers[0]) {
-				t.Fatalf("expect single result to equal first stored result : %#v != %#v", triggers[4], storedTriggers[4])
+			if !storedTriggers[0].EqualsWithAnnotationSubset(triggers.Items[0]) {
+				t.Fatalf("expect single result to equal first stored result : %#v != %#v", triggers.Items[4], storedTriggers[4])
 			}
 
 			appIDPagedFilter := &models.TriggerFilter{AppID: testApp.ID, PerPage: 5}
@@ -1256,27 +1256,27 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Test GetTriggers(page triggers for app), not expecting err %s", err)
 			}
 
-			if len(triggers) != 5 {
-				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 5 results, got %d", len(triggers))
+			if len(triggers.Items) != 5 {
+				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 5 results, got %d", len(triggers.Items))
 			}
 
-			if !triggers[4].Equals(storedTriggers[4]) {
-				t.Fatalf("expect 5th result to equal 5th stored result : %#v != %#v", triggers[4], storedTriggers[4])
+			if !triggers.Items[4].Equals(storedTriggers[4]) {
+				t.Fatalf("expect 5th result to equal 5th stored result : %#v != %#v", triggers.Items[4], storedTriggers[4])
 			}
 
-			appIDPagedFilter.Cursor = triggers[4].ID
+			appIDPagedFilter.Cursor = triggers.Items[4].ID
 			triggers, err = ds.GetTriggers(ctx, appIDPagedFilter)
 
 			if err != nil {
 				t.Fatalf("Test GetTriggers(page triggers for app), not expecting err %s", err)
 			}
 
-			if len(triggers) != 5 {
-				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 5 results, got %d", len(triggers))
+			if len(triggers.Items) != 5 {
+				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 5 results, got %d", len(triggers.Items))
 			}
 
-			if !storedTriggers[9].EqualsWithAnnotationSubset(triggers[4]) {
-				t.Fatalf("expect 5th result to equal 9th stored result : %#v != %#v", triggers[4], storedTriggers[9])
+			if !storedTriggers[9].EqualsWithAnnotationSubset(triggers.Items[4]) {
+				t.Fatalf("expect 5th result to equal 9th stored result : %#v != %#v", triggers.Items[4], storedTriggers[9])
 			}
 
 			// components are AND'd
@@ -1285,8 +1285,8 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("Test GetTriggers(AND filtering), not expecting err %s", err)
 			}
-			if len(triggers) != 10 {
-				t.Fatalf("Test GetTriggers(AND filtering), expecting 10 results, got %d", len(triggers))
+			if len(triggers.Items) != 10 {
+				t.Fatalf("Test GetTriggers(AND filtering), expecting 10 results, got %d", len(triggers.Items))
 			}
 		})
 

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -273,7 +273,7 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("error when updating app: %v", err)
 			}
 			expected := &models.App{ID: testApp.ID, Name: testApp.Name, Config: map[string]string{"TEST": "1"}}
-			if !updated.Equals(expected) {
+			if !expected.EqualsWithAnnotationSubset(updated) {
 				t.Fatalf("expected updated `%v` but got `%v`", expected, updated)
 			}
 		})
@@ -296,7 +296,7 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("error when updating app: %v", err)
 			}
 			expected := &models.App{Name: testApp.Name, ID: testApp.ID, Config: map[string]string{"TEST": "1", "OTHER": "TEST"}}
-			if !updated.Equals(expected) {
+			if !expected.EqualsWithAnnotationSubset(updated) {
 				t.Fatalf("expected updated `%v` but got `%v`", expected, updated)
 			}
 		})
@@ -344,7 +344,7 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("error when updating app: %v", err)
 			}
 			expected := &models.App{Name: testApp.Name, ID: testApp.ID, Config: map[string]string{"OTHER": "TEST"}}
-			if !updated.Equals(expected) {
+			if !expected.EqualsWithAnnotationSubset(updated) {
 				t.Fatalf("expected updated `%#v` but got `%#v`", expected, updated)
 			}
 		})
@@ -881,7 +881,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("unexpected error %v : %s", err, testFn.ID)
 			}
-			if !fn.Equals(testFn) {
+			if !testFn.EqualsWithAnnotationSubset(fn) {
 				t.Fatalf("expected to get the right func:\n%v\nbut got:\n%v", testFn, fn)
 			}
 		})
@@ -926,7 +926,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 					"THIRD":  "3",
 				},
 			}
-			if !updated.Equals(expected) {
+			if !expected.EqualsWithAnnotationSubset(updated) {
 				t.Fatalf("expected updated `%#v` but got `%#v`", expected, updated)
 			}
 
@@ -978,7 +978,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 					"THIRD": "3",
 				},
 			}
-			if !updated.Equals(expected) {
+			if !expected.EqualsWithAnnotationSubset(updated) {
 				t.Fatalf("expected updated:\n`%v`\nbut got:\n`%v`", expected, updated)
 			}
 		})
@@ -1021,7 +1021,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("expected result count to be 1, but was %d", len(fns))
 			}
 
-			if !f1.Equals(fns[0]) {
+			if !f1.EqualsWithAnnotationSubset(fns[0]) {
 				t.Fatalf("Expecting function to be %#v but was %#v", f1, fns[0])
 			}
 
@@ -1031,9 +1031,9 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			}
 			if len(fns) != 2 {
 				t.Fatalf("expected result count to be 2 but got %d", len(fns))
-			} else if !fns[0].Equals(f2) {
+			} else if !f2.EqualsWithAnnotationSubset(fns[0]) {
 				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f2, fns[0])
-			} else if !fns[1].Equals(f3) {
+			} else if !f3.EqualsWithAnnotationSubset(fns[1]) {
 				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", f3, fns[1])
 			}
 		})
@@ -1104,7 +1104,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("error when storing new trigger: %s", err)
 			}
 			newTrigger.ID = insertedTrigger.ID
-			if !insertedTrigger.Equals(newTrigger) {
+			if !newTrigger.EqualsWithAnnotationSubset(insertedTrigger) {
 				t.Errorf("Expecting returned trigger %#v to equal %#v", insertedTrigger, newTrigger)
 			}
 
@@ -1130,7 +1130,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("No ID ")
 			}
 			newTrigger.ID = insertedTrigger.ID
-			if !insertedTrigger.Equals(newTrigger) {
+			if !newTrigger.EqualsWithAnnotationSubset(insertedTrigger) {
 				t.Errorf("Expecting returned trigger %#v to equal %#v", insertedTrigger, newTrigger)
 			}
 		})
@@ -1156,7 +1156,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			}
 
 			newTrigger.ID = insertedTrigger.ID
-			if !gotTrigger.Equals(newTrigger) {
+			if !newTrigger.EqualsWithAnnotationSubset(gotTrigger) {
 				t.Errorf("Expecting returned trigger %#v to equal %#v", gotTrigger, newTrigger)
 			}
 		})
@@ -1222,7 +1222,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			}
 
 			for i := 1; i < 10; i++ {
-				if !storedTriggers[i].Equals(triggers[i]) {
+				if !storedTriggers[i].EqualsWithAnnotationSubset(triggers[i]) {
 					t.Fatalf("expecting ordered by names, but aren't: %s, %s", storedTriggers[i].Name, triggers[i].Name)
 
 				}
@@ -1238,7 +1238,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Test GetTriggers(filter by name), expecting 1 results, got %d", len(triggers))
 			}
 
-			if !triggers[0].Equals(storedTriggers[0]) {
+			if !storedTriggers[0].EqualsWithAnnotationSubset(triggers[0]) {
 				t.Fatalf("expect single result to equal first stored result : %#v != %#v", triggers[4], storedTriggers[4])
 			}
 
@@ -1267,7 +1267,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Test GetTriggers(get all triggers for app), expecting 5 results, got %d", len(triggers))
 			}
 
-			if !triggers[4].Equals(storedTriggers[9]) {
+			if !storedTriggers[9].EqualsWithAnnotationSubset(triggers[4]) {
 				t.Fatalf("expect 5th result to equal 9th stored result : %#v != %#v", triggers[4], storedTriggers[9])
 			}
 
@@ -1299,7 +1299,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("error when updating trigger: %s", err)
 			}
 
-			if !gotTrigger.Equals(testTrigger) {
+			if !testTrigger.EqualsWithAnnotationSubset(gotTrigger) {
 				t.Fatalf("expecting returned triggers equal, got  : %#v : %#v", testTrigger, gotTrigger)
 			}
 
@@ -1307,7 +1307,7 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if err != nil {
 				t.Fatalf("wasn't expecting an error : %s", err)
 			}
-			if !gotTrigger.Equals(testTrigger) {
+			if !testTrigger.EqualsWithAnnotationSubset(gotTrigger) {
 				t.Fatalf("expecting fetch trigger to be updated got  : %v : %v", testTrigger, gotTrigger)
 			}
 

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -1061,7 +1061,7 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 				t.Fatalf("Expecting function to be %#v but was %#v", gendFns[0], fns.Items[0])
 			}
 
-			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, PerPage: 2, Cursor: fns.Items[0].Name})
+			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, PerPage: 2, Cursor: fns.NextCursor})
 			if err != nil {
 				t.Fatalf("error: %s", err)
 			}

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -1333,6 +1333,16 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if triggers.NextCursor != "" {
 				t.Fatalf("Test GetTriggers(negative page triggers), expected no NextCursor, got %s", triggers.NextCursor)
 			}
+
+			emptyListFilter := &models.TriggerFilter{AppID: "notexist"}
+			triggers, err = ds.GetTriggers(ctx, emptyListFilter)
+			if err != nil {
+				t.Fatalf("Test GetTriggers(zero page triggers), not expecting err %s", err)
+			}
+
+			if len(triggers.Items) != 0 {
+				t.Fatalf("Test GetTriggers(negative page triggers), expecting 0 results, got %d", len(triggers.Items))
+			}
 		})
 
 		t.Run("filter triggers", func(t *testing.T) {

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -402,11 +402,24 @@ func RunAppsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 		t.Run("List apps", func(t *testing.T) {
 			h := NewHarness(t, ctx, ds)
 			defer h.Cleanup()
+
+			apps, err := ds.GetApps(ctx, &models.AppFilter{PerPage: 100})
+			if err != nil {
+				t.Fatalf("not expecting err %s", err)
+			}
+
+			if len(apps.Items) != 0 {
+				t.Fatalf("expecting 0 results, got %d", len(apps.Items))
+			}
+			if apps.Items == nil {
+				t.Fatalf("response items must not be nil")
+			}
+
 			a1 := h.GivenAppInDb(rp.ValidApp())
 			h.GivenAppInDb(rp.ValidApp())
 
 			// Testing list apps
-			apps, err := ds.GetApps(ctx, &models.AppFilter{PerPage: 100})
+			apps, err = ds.GetApps(ctx, &models.AppFilter{PerPage: 100})
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -1038,6 +1051,9 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			if len(fns.Items) != 0 {
 				t.Fatal("expected result count to be  0")
 			}
+			if fns.Items == nil {
+				t.Fatal("response items must not be nil")
+			}
 		})
 
 		t.Run("basic pagination with funcs", func(t *testing.T) {
@@ -1337,11 +1353,14 @@ func RunTriggersTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			emptyListFilter := &models.TriggerFilter{AppID: "notexist"}
 			triggers, err = ds.GetTriggers(ctx, emptyListFilter)
 			if err != nil {
-				t.Fatalf("Test GetTriggers(zero page triggers), not expecting err %s", err)
+				t.Fatalf("Test GetTriggers(notexist page triggers), not expecting err %s", err)
 			}
 
 			if len(triggers.Items) != 0 {
-				t.Fatalf("Test GetTriggers(negative page triggers), expecting 0 results, got %d", len(triggers.Items))
+				t.Fatalf("Test GetTriggers(notexist page triggers), expecting 0 results, got %d", len(triggers.Items))
+			}
+			if triggers.Items == nil {
+				t.Fatalf("Test GetTriggers(notexist page triggers), response items must not be nil")
 			}
 		})
 

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -28,7 +28,7 @@ func (m *metricds) GetAppByID(ctx context.Context, appID string) (*models.App, e
 	return m.ds.GetAppByID(ctx, appID)
 }
 
-func (m *metricds) GetApps(ctx context.Context, filter *models.AppFilter) ([]*models.App, error) {
+func (m *metricds) GetApps(ctx context.Context, filter *models.AppFilter) (*models.AppList, error) {
 	ctx, span := trace.StartSpan(ctx, "ds_get_apps")
 	defer span.End()
 	return m.ds.GetApps(ctx, filter)
@@ -107,7 +107,7 @@ func (m *metricds) GetTriggerByID(ctx context.Context, triggerID string) (*model
 	return m.ds.GetTriggerByID(ctx, triggerID)
 }
 
-func (m *metricds) GetTriggers(ctx context.Context, filter *models.TriggerFilter) ([]*models.Trigger, error) {
+func (m *metricds) GetTriggers(ctx context.Context, filter *models.TriggerFilter) (*models.TriggerList, error) {
 	ctx, span := trace.StartSpan(ctx, "ds_get_triggers")
 	defer span.End()
 	return m.ds.GetTriggers(ctx, filter)
@@ -125,7 +125,7 @@ func (m *metricds) UpdateFn(ctx context.Context, fn *models.Fn) (*models.Fn, err
 	return m.ds.UpdateFn(ctx, fn)
 }
 
-func (m *metricds) GetFns(ctx context.Context, filter *models.FnFilter) ([]*models.Fn, error) {
+func (m *metricds) GetFns(ctx context.Context, filter *models.FnFilter) (*models.FnList, error) {
 	ctx, span := trace.StartSpan(ctx, "ds_get_funcs")
 	defer span.End()
 	return m.ds.GetFns(ctx, filter)

--- a/api/datastore/internal/datastoreutil/validator.go
+++ b/api/datastore/internal/datastoreutil/validator.go
@@ -31,7 +31,7 @@ func (v *validator) GetAppByID(ctx context.Context, appID string) (*models.App, 
 	return v.Datastore.GetAppByID(ctx, appID)
 }
 
-func (v *validator) GetApps(ctx context.Context, appFilter *models.AppFilter) ([]*models.App, error) {
+func (v *validator) GetApps(ctx context.Context, appFilter *models.AppFilter) (*models.AppList, error) {
 	return v.Datastore.GetApps(ctx, appFilter)
 }
 
@@ -151,7 +151,7 @@ func (v *validator) UpdateTrigger(ctx context.Context, trigger *models.Trigger) 
 	return v.Datastore.UpdateTrigger(ctx, trigger)
 }
 
-func (v *validator) GetTriggers(ctx context.Context, filter *models.TriggerFilter) ([]*models.Trigger, error) {
+func (v *validator) GetTriggers(ctx context.Context, filter *models.TriggerFilter) (*models.TriggerList, error) {
 
 	if filter.AppID == "" {
 		return nil, models.ErrTriggerMissingAppID
@@ -195,7 +195,7 @@ func (v *validator) GetFnByID(ctx context.Context, fnID string) (*models.Fn, err
 	return v.Datastore.GetFnByID(ctx, fnID)
 }
 
-func (v *validator) GetFns(ctx context.Context, filter *models.FnFilter) ([]*models.Fn, error) {
+func (v *validator) GetFns(ctx context.Context, filter *models.FnFilter) (*models.FnList, error) {
 
 	if filter.AppID == "" {
 		return nil, models.ErrFnsMissingAppID

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -84,19 +84,10 @@ func (m *mock) GetApps(ctx context.Context, appFilter *models.AppFilter) ([]*mod
 		if len(apps) == appFilter.PerPage {
 			break
 		}
-		if len(appFilter.NameIn) > 0 {
-			var found bool
-			for _, fn := range appFilter.NameIn {
-				if fn == a.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
+		if strings.Compare(appFilter.Cursor, a.Name) < 0 {
+			if appFilter.Name != "" && appFilter.Name != a.Name {
 				continue
 			}
-		}
-		if strings.Compare(appFilter.Cursor, a.Name) < 0 {
 			apps = append(apps, a.Clone())
 		}
 	}

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -468,7 +468,6 @@ func (m *mock) GetTriggers(ctx context.Context, filter *models.TriggerFilter) (*
 		if err != nil {
 			return nil, err
 		}
-		logrus.Error(s)
 		filter.Cursor = string(s)
 	}
 

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -90,7 +90,7 @@ func (m *mock) GetApps(ctx context.Context, filter *models.AppFilter) (*models.A
 		cursor = string(s)
 	}
 
-	var apps []*models.App
+	apps := []*models.App{}
 	for _, a := range m.Apps {
 		if len(apps) == filter.PerPage {
 			break

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -852,6 +852,14 @@ func (ds *SQLStore) GetFns(ctx context.Context, filter *models.FnFilter) (*model
 		filter = new(models.FnFilter)
 	}
 
+	if filter.Cursor != "" {
+		s, err := base64.RawURLEncoding.DecodeString(filter.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		filter.Cursor = string(s)
+	}
+
 	filterQuery, args := buildFilterFnQuery(filter)
 
 	query := fmt.Sprintf("%s %s", fnSelector, filterQuery)
@@ -1353,7 +1361,6 @@ func (ds *SQLStore) GetTriggers(ctx context.Context, filter *models.TriggerFilte
 		if err != nil {
 			return nil, err
 		}
-		logrus.Error(s)
 		filter.Cursor = string(s)
 	}
 

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -512,6 +512,15 @@ func (ds *SQLStore) GetAppByID(ctx context.Context, appID string) (*models.App, 
 func (ds *SQLStore) GetApps(ctx context.Context, filter *models.AppFilter) (*models.AppList, error) {
 	res := &models.AppList{}
 
+	if filter.Cursor != "" {
+		s, err := base64.RawURLEncoding.DecodeString(filter.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		logrus.Error(s)
+		filter.Cursor = string(s)
+	}
+
 	query, args, err := buildFilterAppQuery(filter)
 	if err != nil {
 		return nil, err

--- a/api/models/annotations.go
+++ b/api/models/annotations.go
@@ -32,6 +32,10 @@ func (m Annotations) Equals(other Annotations) bool {
 	if len(m) != len(other) {
 		return false
 	}
+	return m.Subset(other)
+}
+
+func (m Annotations) Subset(other Annotations) bool {
 	for k1, v1 := range m {
 		v2, _ := other[k1]
 		if v2 == nil {

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -192,8 +192,7 @@ func (e ErrInvalidSyslog) Error() string { return string(e) }
 
 // AppFilter is the filter used for querying apps
 type AppFilter struct {
-	// NameIn will filter by all names in the list (IN query)
-	NameIn  []string
+	Name    string
 	PerPage int
 	Cursor  string
 }

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -135,6 +135,22 @@ func (a1 *App) Equals(a2 *App) bool {
 	return eq
 }
 
+func (a1 *App) EqualsWithAnnotationSubset(a2 *App) bool {
+	// start off equal, check equivalence of each field.
+	// the RHS of && won't eval if eq==false so config checking is lazy
+
+	eq := true
+	eq = eq && a1.ID == a2.ID
+	eq = eq && a1.Name == a2.Name
+	eq = eq && a1.Config.Equals(a2.Config)
+	eq = eq && a1.Annotations.Subset(a2.Annotations)
+	// NOTE: datastore tests are not very fun to write with timestamp checks,
+	// and these are not values the user may set so we kind of don't care.
+	//eq = eq && time.Time(a1.CreatedAt).Equal(time.Time(a2.CreatedAt))
+	//eq = eq && time.Time(a1.UpdatedAt).Equal(time.Time(a2.UpdatedAt))
+	return eq
+}
+
 // Update adds entries from patch to a.Config and a.Annotations, and removes entries with empty values.
 func (a *App) Update(patch *App) {
 	original := a.Clone()

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -198,6 +198,6 @@ type AppFilter struct {
 }
 
 type AppList struct {
-	NextCursor string `json:"next_cursor"`
+	NextCursor string `json:"next_cursor,omitempty"`
 	Items      []*App `json:"items"`
 }

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -196,3 +196,8 @@ type AppFilter struct {
 	PerPage int
 	Cursor  string
 }
+
+type AppList struct {
+	NextCursor string `json:"next_cursor"`
+	Items      []*App `json:"items"`
+}

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -15,9 +15,9 @@ type Datastore interface {
 	// Returns ErrAppsNotFound if no app is found.
 	GetAppID(ctx context.Context, appName string) (string, error)
 
-	// GetApps gets a slice of Apps, optionally filtered by name.
+	// GetApps gets a slice of Apps, optionally filtered by name, and a cursor.
 	// Missing filter or empty name will match all Apps.
-	GetApps(ctx context.Context, filter *AppFilter) ([]*App, error)
+	GetApps(ctx context.Context, filter *AppFilter) (*AppList, error)
 
 	// InsertApp inserts an App. Returns ErrDatastoreEmptyApp when app is nil, and
 	// ErrDatastoreEmptyAppName when app.Name is empty.
@@ -63,8 +63,8 @@ type Datastore interface {
 	// ErrMissingName is func.Name is empty.
 	UpdateFn(ctx context.Context, fn *Fn) (*Fn, error)
 
-	// GetFns returns a list of funcs, applying any additional filters provided.
-	GetFns(ctx context.Context, filter *FnFilter) ([]*Fn, error)
+	// GetFns returns a list of funcs, and a cursor, applying any additional filters provided.
+	GetFns(ctx context.Context, filter *FnFilter) (*FnList, error)
 
 	// GetFnByID returns a function by ID. Returns ErrDatastoreEmptyFnID if fnID is empty.
 	// Returns ErrFnsNotFound if a fn is not found.
@@ -91,7 +91,7 @@ type Datastore interface {
 
 	// GetTriggers gets a list of triggers that match the specified filter
 	// Return ErrDatastoreEmptyAppId if no AppID set in the filter
-	GetTriggers(ctx context.Context, filter *TriggerFilter) ([]*Trigger, error)
+	GetTriggers(ctx context.Context, filter *TriggerFilter) (*TriggerList, error)
 
 	// implements io.Closer to shutdown
 	io.Closer

--- a/api/models/fn.go
+++ b/api/models/fn.go
@@ -301,3 +301,8 @@ type FnFilter struct {
 	Cursor  string
 	PerPage int
 }
+
+type FnList struct {
+	NextCursor string `json:"next_cursor"`
+	Items      []*Fn  `json:"items"`
+}

--- a/api/models/fn.go
+++ b/api/models/fn.go
@@ -303,6 +303,6 @@ type FnFilter struct {
 }
 
 type FnList struct {
-	NextCursor string `json:"next_cursor"`
+	NextCursor string `json:"next_cursor,omitempty"`
 	Items      []*Fn  `json:"items"`
 }

--- a/api/models/fn.go
+++ b/api/models/fn.go
@@ -231,6 +231,28 @@ func (f1 *Fn) Equals(f2 *Fn) bool {
 	return eq
 }
 
+func (f1 *Fn) EqualsWithAnnotationSubset(f2 *Fn) bool {
+	// start off equal, check equivalence of each field.
+	// the RHS of && won't eval if eq==false so config/headers checking is lazy
+
+	eq := true
+	eq = eq && f1.ID == f2.ID
+	eq = eq && f1.Name == f2.Name
+	eq = eq && f1.AppID == f2.AppID
+	eq = eq && f1.Image == f2.Image
+	eq = eq && f1.Memory == f2.Memory
+	eq = eq && f1.Format == f2.Format
+	eq = eq && f1.Timeout == f2.Timeout
+	eq = eq && f1.IdleTimeout == f2.IdleTimeout
+	eq = eq && f1.Config.Equals(f2.Config)
+	eq = eq && f1.Annotations.Subset(f2.Annotations)
+	// NOTE: datastore tests are not very fun to write with timestamp checks,
+	// and these are not values the user may set so we kind of don't care.
+	//eq = eq && time.Time(f1.CreatedAt).Equal(time.Time(f2.CreatedAt))
+	//eq = eq && time.Time(f2.UpdatedAt).Equal(time.Time(f2.UpdatedAt))
+	return eq
+}
+
 // Update updates fields in f with non-zero field values from new, and sets
 // updated_at if any of the fields change. 0-length slice Header values, and
 // empty-string Config values trigger removal of map entry.

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -194,6 +194,6 @@ type TriggerFilter struct {
 }
 
 type TriggerList struct {
-	NextCursor string     `json:"next_cursor"`
+	NextCursor string     `json:"next_cursor,omitempty"`
 	Items      []*Trigger `json:"items"`
 }

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -36,6 +36,20 @@ func (t *Trigger) Equals(t2 *Trigger) bool {
 	return eq
 }
 
+func (t *Trigger) EqualsWithAnnotationSubset(t2 *Trigger) bool {
+	eq := true
+	eq = eq && t.ID == t2.ID
+	eq = eq && t.Name == t2.Name
+	eq = eq && t.AppID == t2.AppID
+	eq = eq && t.FnID == t2.FnID
+
+	eq = eq && t.Type == t2.Type
+	eq = eq && t.Source == t2.Source
+	eq = eq && t.Annotations.Subset(t2.Annotations)
+
+	return eq
+}
+
 var triggerTypes = []string{"http"}
 
 func ValidTriggerTypes() []string {

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -192,3 +192,8 @@ type TriggerFilter struct {
 	Cursor  string
 	PerPage int
 }
+
+type TriggerList struct {
+	NextCursor string     `json:"next_cursor"`
+	Items      []*Trigger `json:"items"`
+}

--- a/api/models/trigger_test.go
+++ b/api/models/trigger_test.go
@@ -26,6 +26,19 @@ func TestTriggerJsonMarshalling(t *testing.T) {
 	}
 }
 
+func TestTriggerListJsonMarshalling(t *testing.T) {
+	emptyList := &TriggerList{Items: []*Trigger{}}
+	expected := "{\"items\":[]}"
+
+	v, err := json.Marshal(emptyList)
+	if err != nil {
+		t.Fatalf("Failed to marshal json into %s: %v", expected, err)
+	}
+	if string(v) != expected {
+		t.Errorf("Invalid trigger value, expected %s, got %s", expected, string(v))
+	}
+}
+
 var httpTrigger = &Trigger{Name: "name", AppID: "foo", FnID: "bar", Type: "http", Source: "baz"}
 var invalidTrigger = &Trigger{Name: "name", AppID: "foo", FnID: "bar", Type: "error", Source: "baz"}
 

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/base64"
 	"net/http"
 
 	"github.com/fnproject/fn/api/models"
@@ -21,11 +20,6 @@ func (s *Server) handleAppList(c *gin.Context) {
 	if err != nil {
 		handleErrorResponse(c, err)
 		return
-	}
-
-	if len(apps.Items) > 0 && len(apps.Items) == filter.PerPage {
-		last := []byte(apps.Items[len(apps.Items)-1].Name)
-		apps.NextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
 	c.JSON(http.StatusOK, apps)

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -13,10 +13,7 @@ func (s *Server) handleAppList(c *gin.Context) {
 
 	filter := &models.AppFilter{}
 	filter.Cursor, filter.PerPage = pageParams(c, true)
-	name := c.Query("name")
-	if name != "" {
-		filter.NameIn = []string{name}
-	}
+	filter.Name = c.Query("name")
 
 	apps, err := s.datastore.GetApps(ctx, filter)
 	if err != nil {

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -27,7 +27,7 @@ func (s *Server) handleAppList(c *gin.Context) {
 		nextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
-	c.JSON(http.StatusOK, appListResponse{
+	c.JSON(http.StatusOK, models.AppList{
 		NextCursor: nextCursor,
 		Items:      apps,
 	})

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -21,14 +21,10 @@ func (s *Server) handleAppList(c *gin.Context) {
 		return
 	}
 
-	var nextCursor string
-	if len(apps) > 0 && len(apps) == filter.PerPage {
-		last := []byte(apps[len(apps)-1].Name)
-		nextCursor = base64.RawURLEncoding.EncodeToString(last)
+	if len(apps.Items) > 0 && len(apps.Items) == filter.PerPage {
+		last := []byte(apps.Items[len(apps.Items)-1].Name)
+		apps.NextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
-	c.JSON(http.StatusOK, models.AppList{
-		NextCursor: nextCursor,
-		Items:      apps,
-	})
+	c.JSON(http.StatusOK, apps)
 }

--- a/api/server/apps_list.go
+++ b/api/server/apps_list.go
@@ -12,7 +12,9 @@ func (s *Server) handleAppList(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	filter := &models.AppFilter{}
-	filter.Cursor, filter.PerPage = pageParams(c, true)
+
+	filter.Cursor, filter.PerPage = pageParamsV2(c)
+
 	filter.Name = c.Query("name")
 
 	apps, err := s.datastore.GetApps(ctx, filter)

--- a/api/server/apps_test.go
+++ b/api/server/apps_test.go
@@ -209,7 +209,7 @@ func TestAppList(t *testing.T) {
 		} else {
 			// normal path
 
-			var resp appListResponse
+			var resp models.AppList
 			err := json.NewDecoder(rec.Body).Decode(&resp)
 			if err != nil {
 				t.Errorf("Test %d: Expected response body to be a valid json object. err: %v", i, err)

--- a/api/server/apps_v1_list.go
+++ b/api/server/apps_v1_list.go
@@ -22,14 +22,14 @@ func (s *Server) handleV1AppList(c *gin.Context) {
 	}
 
 	var nextCursor string
-	if len(apps) > 0 && len(apps) == filter.PerPage {
-		last := []byte(apps[len(apps)-1].Name)
+	if len(apps.Items) > 0 && len(apps.Items) == filter.PerPage {
+		last := []byte(apps.Items[len(apps.Items)-1].Name)
 		nextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
 	c.JSON(http.StatusOK, appsV1Response{
 		Message:    "Successfully listed applications",
 		NextCursor: nextCursor,
-		Apps:       apps,
+		Apps:       apps.Items,
 	})
 }

--- a/api/server/apps_v1_list.go
+++ b/api/server/apps_v1_list.go
@@ -13,7 +13,7 @@ func (s *Server) handleV1AppList(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	filter := &models.AppFilter{}
-	filter.Cursor, filter.PerPage = pageParams(c, true)
+	filter.Cursor, filter.PerPage = pageParamsV2(c)
 
 	apps, err := s.datastore.GetApps(ctx, filter)
 	if err != nil {

--- a/api/server/fns_list.go
+++ b/api/server/fns_list.go
@@ -26,7 +26,7 @@ func (s *Server) handleFnList(c *gin.Context) {
 		nextCursor = fns[len(fns)-1].Name
 	}
 
-	c.JSON(http.StatusOK, fnListResponse{
+	c.JSON(http.StatusOK, models.FnList{
 		NextCursor: nextCursor,
 		Items:      fns,
 	})

--- a/api/server/fns_list.go
+++ b/api/server/fns_list.go
@@ -21,13 +21,5 @@ func (s *Server) handleFnList(c *gin.Context) {
 		return
 	}
 
-	var nextCursor string
-	if len(fns) > 0 && len(fns) == filter.PerPage {
-		nextCursor = fns[len(fns)-1].Name
-	}
-
-	c.JSON(http.StatusOK, models.FnList{
-		NextCursor: nextCursor,
-		Items:      fns,
-	})
+	c.JSON(http.StatusOK, fns)
 }

--- a/api/server/fns_list.go
+++ b/api/server/fns_list.go
@@ -11,7 +11,7 @@ func (s *Server) handleFnList(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var filter models.FnFilter
-	filter.Cursor, filter.PerPage = pageParams(c, false)
+	filter.Cursor, filter.PerPage = pageParamsV2(c)
 	filter.AppID = c.Query("app_id")
 	filter.Name = c.Query("name")
 

--- a/api/server/fns_test.go
+++ b/api/server/fns_test.go
@@ -269,7 +269,7 @@ func TestFnList(t *testing.T) {
 		} else {
 			// normal path
 
-			var resp fnListResponse
+			var resp models.FnList
 			err := json.NewDecoder(rec.Body).Decode(&resp)
 			if err != nil {
 				t.Errorf("Test %d: Expected response body to be a valid json object. err: %v", i, err)

--- a/api/server/fns_test.go
+++ b/api/server/fns_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -233,6 +234,10 @@ func TestFnList(t *testing.T) {
 
 	srv := testServer(ds, &mqs.Mock{}, fnl, rnr, ServerTypeFull)
 
+	fn1b := base64.RawURLEncoding.EncodeToString([]byte(fn1))
+	fn2b := base64.RawURLEncoding.EncodeToString([]byte(fn2))
+	fn3b := base64.RawURLEncoding.EncodeToString([]byte(fn3))
+
 	for i, test := range []struct {
 		path string
 		body string
@@ -244,11 +249,11 @@ func TestFnList(t *testing.T) {
 	}{
 		{"/v2/fns", "", http.StatusBadRequest, models.ErrFnsMissingAppID, 0, ""},
 		{fmt.Sprintf("/v2/fns?app_id=%s", app1.ID), "", http.StatusOK, nil, 3, ""},
-		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1", app1.ID), "", http.StatusOK, nil, 1, fn1},
-		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn1), "", http.StatusOK, nil, 1, fn2},
-		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn2), "", http.StatusOK, nil, 1, fn3},
-		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=100&cursor=%s", app1.ID, fn3), "", http.StatusOK, nil, 0, ""}, // cursor is empty if per_page > len(results)
-		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn3), "", http.StatusOK, nil, 0, ""},   // cursor could point to empty page
+		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1", app1.ID), "", http.StatusOK, nil, 1, fn1b},
+		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn1b), "", http.StatusOK, nil, 1, fn2b},
+		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn2b), "", http.StatusOK, nil, 1, fn3b},
+		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=100&cursor=%s", app1.ID, fn3b), "", http.StatusOK, nil, 0, ""}, // cursor is empty if per_page > len(results)
+		{fmt.Sprintf("/v2/fns?app_id=%s&per_page=1&cursor=%s", app1.ID, fn3b), "", http.StatusOK, nil, 0, ""},   // cursor could point to empty page
 	} {
 		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1046,18 +1046,3 @@ type callsResponse struct {
 	NextCursor string         `json:"next_cursor"`
 	Calls      []*models.Call `json:"calls"`
 }
-
-type appListResponse struct {
-	NextCursor string        `json:"next_cursor"`
-	Items      []*models.App `json:"items"`
-}
-
-type fnListResponse struct {
-	NextCursor string       `json:"next_cursor"`
-	Items      []*models.Fn `json:"items"`
-}
-
-type triggerListResponse struct {
-	NextCursor string            `json:"next_cursor"`
-	Items      []*models.Trigger `json:"items"`
-}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1013,6 +1013,18 @@ func pageParams(c *gin.Context, base64d bool) (cursor string, perPage int) {
 	return cursor, perPage
 }
 
+func pageParamsV2(c *gin.Context) (cursor string, perPage int) {
+	cursor = c.Query("cursor")
+
+	perPage, _ = strconv.Atoi(c.Query("per_page"))
+	if perPage > 100 {
+		perPage = 100
+	} else if perPage <= 0 {
+		perPage = 30
+	}
+	return cursor, perPage
+}
+
 type appResponse struct {
 	Message string      `json:"message"`
 	App     *models.App `json:"app"`

--- a/api/server/trigger_list.go
+++ b/api/server/trigger_list.go
@@ -35,7 +35,7 @@ func (s *Server) handleTriggerList(c *gin.Context) {
 		nextCursor = base64.RawURLEncoding.EncodeToString(last)
 	}
 
-	c.JSON(http.StatusOK, triggerListResponse{
+	c.JSON(http.StatusOK, models.TriggerList{
 		NextCursor: nextCursor,
 		Items:      triggers,
 	})

--- a/api/server/trigger_list.go
+++ b/api/server/trigger_list.go
@@ -11,7 +11,7 @@ func (s *Server) handleTriggerList(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	filter := &models.TriggerFilter{}
-	filter.Cursor, filter.PerPage = pageParams(c, true)
+	filter.Cursor, filter.PerPage = pageParamsV2(c)
 
 	filter.AppID = c.Query("app_id")
 

--- a/api/server/trigger_list.go
+++ b/api/server/trigger_list.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/base64"
 	"net/http"
 
 	"github.com/fnproject/fn/api/models"
@@ -29,14 +28,5 @@ func (s *Server) handleTriggerList(c *gin.Context) {
 		return
 	}
 
-	var nextCursor string
-	if len(triggers) > 0 && len(triggers) == filter.PerPage {
-		last := []byte(triggers[len(triggers)-1].ID)
-		nextCursor = base64.RawURLEncoding.EncodeToString(last)
-	}
-
-	c.JSON(http.StatusOK, models.TriggerList{
-		NextCursor: nextCursor,
-		Items:      triggers,
-	})
+	c.JSON(http.StatusOK, triggers)
 }

--- a/api/server/trigger_test.go
+++ b/api/server/trigger_test.go
@@ -221,6 +221,7 @@ func TestTriggerList(t *testing.T) {
 	}{
 		{"/v2/triggers?per_page", "", http.StatusBadRequest, nil, 0, ""},
 		{"/v2/triggers?app_id=app_id1", "", http.StatusOK, nil, 4, ""},
+		{"/v2/triggers?app_id=app_id2", "", http.StatusOK, nil, 1, ""},
 		{"/v2/triggers?app_id=app_id1&name=trigger1", "", http.StatusOK, nil, 1, ""},
 		{"/v2/triggers?app_id=app_id1&fn_id=fn_id1", "", http.StatusOK, nil, 3, ""},
 		{"/v2/triggers?app_id=app_id1&fn_id=fn_id1&per_page", "", http.StatusOK, nil, 3, ""},

--- a/api/server/trigger_test.go
+++ b/api/server/trigger_test.go
@@ -249,7 +249,7 @@ func TestTriggerList(t *testing.T) {
 		} else {
 			// normal path
 
-			var resp triggerListResponse
+			var resp models.TriggerList
 			err := json.NewDecoder(rec.Body).Decode(&resp)
 			if err != nil {
 				t.Errorf("Test %d: Expected response body to be a valid json object. err: %v", i, err)

--- a/fnext/datastore.go
+++ b/fnext/datastore.go
@@ -130,7 +130,7 @@ func (e *extds) RemoveApp(ctx context.Context, appName string) error {
 	return e.al.AfterAppDelete(ctx, &app)
 }
 
-func (e *extds) GetApps(ctx context.Context, filter *models.AppFilter) ([]*models.App, error) {
+func (e *extds) GetApps(ctx context.Context, filter *models.AppFilter) (*models.AppList, error) {
 	err := e.al.BeforeAppsList(ctx, filter)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (e *extds) GetApps(ctx context.Context, filter *models.AppFilter) ([]*model
 		return nil, err
 	}
 
-	err = e.al.AfterAppsList(ctx, apps)
+	err = e.al.AfterAppsList(ctx, apps.Items)
 	return apps, err
 }
 


### PR DESCRIPTION
Pushes datastore cursor creation and manipulation down into the datastore level, from the api layer. This gives complete freedom to datastore implementations to handle cursors in whatever format they desire.

Also changes the generations of names in the test suite so they aren't created in the same order as the id's, this was hiding the fact that triggers where not in fact being sorted by Name as per spec. This change led to a few edits in older tests.