### PR TITLE
Make Docker an optional component at compile time.

### DIFF
--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/fnproject/fn/api/agent/drivers/docker"
 	"github.com/fnproject/fn/api/id"
 	"github.com/fnproject/fn/api/logs"
 	"github.com/fnproject/fn/api/models"

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -646,3 +646,9 @@ func (w *waitResult) wait(ctx context.Context) (status string, err error) {
 }
 
 var _ drivers.Driver = &DockerDriver{}
+
+func init() {
+	drivers.Register("docker", func(config drivers.Config) (drivers.Driver, error) {
+		return NewDocker(config), nil
+	})
+}

--- a/api/agent/drivers/register.go
+++ b/api/agent/drivers/register.go
@@ -1,0 +1,26 @@
+package drivers
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+)
+
+type DriverFunc func(config Config) (Driver, error)
+
+var drivers = make(map[string]DriverFunc)
+
+// Register adds  a container driver by name to this process
+func Register(name string, driverFunc DriverFunc) {
+	logrus.Infof("Registering container driver '%s'", name)
+	drivers[name] = driverFunc
+}
+
+// New Instantiates a driver by name
+func New(driverName string, config Config) (Driver, error) {
+	driverFunc, ok := drivers[driverName]
+
+	if !ok {
+		return nil, fmt.Errorf("agent driver \"%s\" is not registered", driverName)
+	}
+	return driverFunc(config)
+}

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -44,8 +44,8 @@ type Provider interface {
 
 var providers []Provider
 
-// AddProvider globally registers a data store provider
-func AddProvider(provider Provider) {
-	logrus.Infof("Adding DataStore provider %s", provider)
+// Register globally registers a data store provider
+func Register(provider Provider) {
+	logrus.Infof("Registering data store provider '%s'", provider)
 	providers = append(providers, provider)
 }

--- a/api/datastore/sql/dbhelper/dbhelper.go
+++ b/api/datastore/sql/dbhelper/dbhelper.go
@@ -10,9 +10,9 @@ import (
 
 var sqlHelpers []Helper
 
-//Add registers a new SQL helper
-func Add(helper Helper) {
-	logrus.Infof("Registering DB helper %s", helper)
+//Register registers a new SQL helper
+func Register(helper Helper) {
+	logrus.Infof("Registering sql helper '%s'", helper)
 	sqlHelpers = append(sqlHelpers, helper)
 }
 

--- a/api/datastore/sql/mysql/mysql.go
+++ b/api/datastore/sql/mysql/mysql.go
@@ -57,5 +57,5 @@ func (mysqlHelper) IsDuplicateKeyError(err error) bool {
 }
 
 func init() {
-	dbhelper.Add(mysqlHelper(0))
+	dbhelper.Register(mysqlHelper(0))
 }

--- a/api/datastore/sql/postgres/postgres.go
+++ b/api/datastore/sql/postgres/postgres.go
@@ -59,5 +59,5 @@ func (postgresHelper) IsDuplicateKeyError(err error) bool {
 }
 
 func init() {
-	dbhelper.Add(postgresHelper(0))
+	dbhelper.Register(postgresHelper(0))
 }

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -1443,6 +1443,6 @@ func (ds *SQLStore) Close() error {
 }
 
 func init() {
-	datastore.AddProvider(sqlDsProvider(0))
-	logs.AddProvider(sqlLogsProvider(0))
+	datastore.Register(sqlDsProvider(0))
+	logs.Register(sqlLogsProvider(0))
 }

--- a/api/datastore/sql/sqlite/sqlite.go
+++ b/api/datastore/sql/sqlite/sqlite.go
@@ -70,5 +70,5 @@ func (sqliteHelper) IsDuplicateKeyError(err error) bool {
 }
 
 func init() {
-	dbhelper.Add(sqliteHelper(0))
+	dbhelper.Register(sqliteHelper(0))
 }

--- a/api/logs/log.go
+++ b/api/logs/log.go
@@ -24,9 +24,9 @@ type Provider interface {
 
 var providers []Provider
 
-// AddProvider globally registers a new LogStore provider
-func AddProvider(pf Provider) {
-	logrus.Infof("Adding log provider %s", pf)
+// Register globally registers a new LogStore provider
+func Register(pf Provider) {
+	logrus.Infof("Registering log provider '%s'", pf)
 	providers = append(providers, pf)
 }
 

--- a/api/logs/s3/s3.go
+++ b/api/logs/s3/s3.go
@@ -469,5 +469,5 @@ func makeKeys(names []string) []tag.Key {
 }
 
 func init() {
-	logs.AddProvider(s3StoreProvider(0))
+	logs.Register(s3StoreProvider(0))
 }

--- a/api/server/defaultexts/defaultexts.go
+++ b/api/server/defaultexts/defaultexts.go
@@ -5,6 +5,7 @@ package defaultexts
 
 import (
 	// import all datastore/log/mq modules for runtime config
+	_ "github.com/fnproject/fn/api/agent/drivers/docker"
 	_ "github.com/fnproject/fn/api/datastore/sql"
 	_ "github.com/fnproject/fn/api/datastore/sql/mysql"
 	_ "github.com/fnproject/fn/api/datastore/sql/postgres"

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/fnproject/fn/api/agent"
+	_ "github.com/fnproject/fn/api/agent/drivers/docker"
 	"github.com/fnproject/fn/api/datastore"
 	"github.com/fnproject/fn/api/datastore/sql"
 	_ "github.com/fnproject/fn/api/datastore/sql/sqlite"

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -259,8 +259,12 @@ func SetUpPureRunnerNode(ctx context.Context, nodeNum int) (*server.Server, erro
 	}
 
 	// customer driver that overrides generic docker driver
+	d, err := agent.NewDockerDriver(cfg)
+	if err != nil {
+		return nil, err
+	}
 	drv := &customDriver{
-		drv: agent.NewDockerDriver(cfg),
+		drv: d,
 	}
 
 	// inner agent for pure-runners


### PR DESCRIPTION
This makes agent drivers run-time resolved to enable people to build an API or LB service binary that omits docker dependencies. 