### PR TITLE
Fix broken link to Function File doc

### DIFF
--- a/docs/developers/configs.md
+++ b/docs/developers/configs.md
@@ -11,7 +11,7 @@ fn config app myapp LOG_LEVEL debug
 
 ## 2. Function configuration from func.yaml
 
-See [Function file](func-file.md) for more info. 
+See [Function file](func-file.md) for more info.
 
 ## 3. Route level configuration
 

--- a/docs/developers/configs.md
+++ b/docs/developers/configs.md
@@ -11,7 +11,7 @@ fn config app myapp LOG_LEVEL debug
 
 ## 2. Function configuration from func.yaml
 
-See [Function file](function-file.md) for more info.
+See [Function file](func-file.md) for more info.
 
 ## 3. Route level configuration
 

--- a/docs/developers/configs.md
+++ b/docs/developers/configs.md
@@ -11,7 +11,7 @@ fn config app myapp LOG_LEVEL debug
 
 ## 2. Function configuration from func.yaml
 
-See [Function file](func-file.md) for more info.
+See [Function file](func-file.md) for more info. 
 
 ## 3. Route level configuration
 


### PR DESCRIPTION
Link was pointing to function-file.md
Corrected to func-file.md

- Link to issue this resolves

- What I did
Fixed broken link to Function File

- How I did it
Fixed reference in file config.md from 'function-file.md' to 'func-file.md'

- How to verify it
Click on the fixed link and verify it navigates to expected page

- One line description for the changelog
Fixed broken link to Function File

- One moving picture involving robots (not mandatory but encouraged)
