### PR TITLE
Play nicely with private DockerHub registries

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -319,6 +319,16 @@ func (drv *DockerDriver) ensureImage(ctx context.Context, task drivers.Container
 			config = v
 			break
 		}
+
+		if reg != "" {
+			continue
+		}
+
+		// reg is empty, so we want to auth agains dockerhub
+		if url, _ := registryURL(v.ServerAddress); url == hubURL {
+			config = v
+			break
+		}
 	}
 
 	if task, ok := task.(Auther); ok {


### PR DESCRIPTION
**The problem**

`Fn` looks for domain name in the image itself. And then checks if there is a **suffix** with that domain in the auth config file: https://github.com/fnproject/fn/blob/5dc5740a541cb5a3aba4316ef0295e9eefe3b936/api/agent/drivers/docker/docker.go#L318

So to make it work I ended up to name my images like so `docker.io/<myorg>/<myimage>:<tag>`

Then in my auth I made a change of my registry URL from `https://index.docker.io/v2/` to the domain which ends with `docker.io`, like so

```{"auths":{"https://index.docker.io":{"auth":"yourauthbase64here"}}}```

***

**So to sum it up**

1. `Fn` doesn't know how to work with dockerhub private registries out of the box
2. To validate domain against image name, it uses `Suffix` check, which not always ends with domain name.

This PR should fix both problems.