### PR TITLE
fn: cleanup of docker private registry code

### DIFF
--- a/api/agent/drivers/docker/registry.go
+++ b/api/agent/drivers/docker/registry.go
@@ -2,26 +2,96 @@ package docker
 
 import (
 	"net/url"
+	"os"
 	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
 )
 
-const hubURL = "https://registry.hub.docker.com"
+var (
+	defaultPrivateRegistries = []string{"hub.docker.com", "index.docker.io"}
+)
 
-func registryURL(addr string) (string, error) {
-	if addr == "" || strings.Contains(addr, "hub.docker.com") || strings.Contains(addr, "index.docker.io") {
-		return hubURL, nil
+func registryFromEnv() (map[string]driverAuthConfig, error) {
+	drvAuths := make(map[string]driverAuthConfig)
+
+	var auths *docker.AuthConfigurations
+	var err error
+	if reg := os.Getenv("DOCKER_AUTH"); reg != "" {
+		// TODO docker does not use this itself, we should get rid of env docker config (nor is this documented..)
+		auths, err = docker.NewAuthConfigurations(strings.NewReader(reg))
+	} else {
+		auths, err = docker.NewAuthConfigurationsFromDockerCfg()
 	}
 
-	uri, err := url.Parse(addr)
 	if err != nil {
-		return "", err
+		logrus.WithError(err).Info("no docker auths from config files found (this is fine)")
+		return drvAuths, nil
 	}
 
-	if uri.Scheme == "" {
-		uri.Scheme = "https"
+	for key, v := range auths.Configs {
+
+		u, err := url.Parse(v.ServerAddress)
+		if err != nil {
+			return drvAuths, err
+		}
+
+		drvAuths[key] = driverAuthConfig{
+			auth:       v,
+			subdomains: getSubdomains(u.Hostname()),
+		}
 	}
-	uri.Path = strings.TrimSuffix(uri.Path, "/")
-	uri.Path = strings.TrimPrefix(uri.Path, "/v2")
-	uri.Path = strings.TrimPrefix(uri.Path, "/v1") // just try this, if it fails it fails, not supporting v1
-	return uri.String(), nil
+
+	return drvAuths, nil
+}
+
+func getSubdomains(hostname string) map[string]bool {
+
+	subdomains := make(map[string]bool)
+	tokens := strings.Split(hostname, ".")
+
+	if len(tokens) <= 2 {
+		subdomains[hostname] = true
+	} else {
+		for i := 0; i <= len(tokens)-2; i++ {
+			joined := strings.Join(tokens[i:], ".")
+			subdomains[joined] = true
+		}
+	}
+
+	return subdomains
+}
+
+func findRegistryConfig(reg string, configs map[string]driverAuthConfig) *docker.AuthConfiguration {
+	var config docker.AuthConfiguration
+
+	if reg != "" {
+		res := lookupRegistryConfig(reg, configs)
+		if res != nil {
+			return res
+		}
+	} else {
+		for _, reg := range defaultPrivateRegistries {
+			res := lookupRegistryConfig(reg, configs)
+			if res != nil {
+				return res
+			}
+		}
+	}
+
+	return &config
+}
+
+func lookupRegistryConfig(reg string, configs map[string]driverAuthConfig) *docker.AuthConfiguration {
+
+	// if any configured host auths match task registry, try them (task docker auth can override)
+	for _, v := range configs {
+		_, ok := v.subdomains[reg]
+		if ok {
+			return &v.auth
+		}
+	}
+
+	return nil
 }

--- a/api/agent/drivers/docker/registry.go
+++ b/api/agent/drivers/docker/registry.go
@@ -39,7 +39,7 @@ func registryFromEnv() (map[string]driverAuthConfig, error) {
 
 		drvAuths[key] = driverAuthConfig{
 			auth:       v,
-			subdomains: getSubdomains(u.Hostname()),
+			subdomains: getSubdomains(u.Host),
 		}
 	}
 

--- a/api/agent/drivers/docker/registry_test.go
+++ b/api/agent/drivers/docker/registry_test.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"testing"
+)
+
+func verify(expected []string, checks map[string]bool) bool {
+	if len(expected) != len(checks) {
+		return false
+	}
+	for _, v := range expected {
+		_, ok := checks[v]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRegistrySubDomains(t *testing.T) {
+	var exp []string
+	var res map[string]bool
+
+	exp = []string{"google.com"}
+	res = getSubdomains("google.com")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+
+	exp = []string{"top.google.com", "google.com"}
+	res = getSubdomains("top.google.com")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+
+	exp = []string{"top.top.google.com", "top.google.com", "google.com"}
+	res = getSubdomains("top.top.google.com")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+
+	exp = []string{"docker"}
+	res = getSubdomains("docker")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+
+	exp = []string{""}
+	res = getSubdomains("")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+}

--- a/api/agent/drivers/docker/registry_test.go
+++ b/api/agent/drivers/docker/registry_test.go
@@ -33,6 +33,12 @@ func TestRegistrySubDomains(t *testing.T) {
 		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
 	}
 
+	exp = []string{"top.google.com:443", "google.com:443"}
+	res = getSubdomains("top.google.com:443")
+	if !verify(exp, res) {
+		t.Fatalf("subdomain results failed expected[%+v] != results[%+v]", exp, res)
+	}
+
 	exp = []string{"top.top.google.com", "top.google.com", "google.com"}
 	res = getSubdomains("top.top.google.com")
 	if !verify(exp, res) {


### PR DESCRIPTION
Start using URL parsed ServerAddress and its subdomains
for easier image ensure/pull in docker driver. Previous
code to lookup substrings was faulty without proper
URL parse and hostname tokenization. When searching
for a registry config, if image name does not contain
a registry and if there's a private registry configured,
then search for hub.docker.com and index.docker.io. This
is similar to previous code but with correct subdomain
matching.
