### PR TITLE
fn: tests for private repo auth and rename DOCKER_AUTH

### DIFF
--- a/docs/operating/private_registries.md
+++ b/docs/operating/private_registries.md
@@ -4,10 +4,10 @@ For local development, or a team that wishes to keep their images off of the pub
 registry may be useful. This can be hosted on your own server or local machine. See the Docker docs [here](https://docs.docker.com/registry/) for information on setting this up. A registry on localhost may greatly speed up iterative development in environments where the network is constrained.
 
 To set up your fn service with authentication for any registry, you must
-provide fn with `DOCKER_AUTH` env var:
+provide fn with `FN_DOCKER_AUTH` env var:
 
 ```
-DOCKER_AUTH='{"auths":{"http://my.registry.com:80":{"auth":"yourauthbase64here"}}}'
+FN_DOCKER_AUTH='{"auths":{"http://my.registry.com:80":{"auth":"yourauthbase64here"}}}'
 ```
 
 You may provide multiple auths in this way, it's also possible to run the `fn`


### PR DESCRIPTION
Renamed DOCKER_AUTH with FN_ prefix to clarify the purpose. Docker
does not use this variable.

New tests to clarify the repo/auth-config behavior.
