### PR TITLE
fn: adjusting LB retry view buckets

### DIFF
--- a/api/runnerpool/placer_stats.go
+++ b/api/runnerpool/placer_stats.go
@@ -88,7 +88,7 @@ func createView(measure stats.Measure, agg *view.Aggregation, tagKeys []string) 
 
 func RegisterPlacerViews(tagKeys []string) {
 	err := view.Register(
-		createView(attemptCountMeasure, view.Distribution(0, 1, 2, 4, 8, 32, 64, 256), tagKeys),
+		createView(attemptCountMeasure, view.Distribution(0, 2, 3, 4, 8, 16, 32, 64, 128, 256), tagKeys),
 		createView(errorPoolCountMeasure, view.Count(), tagKeys),
 		createView(emptyPoolCountMeasure, view.Count(), tagKeys),
 		createView(cancelCountMeasure, view.Count(), tagKeys),


### PR DESCRIPTION
[0, 2, 3, 4, 8, 16, 32, 64, 128, 256] gives us:

s >= 0
s >= 2
s >= 3

and so on for better observability.