### PR TITLE
Support _FILE postfixes for environment variables

### DIFF
--- a/api/server/init.go
+++ b/api/server/init.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"os/signal"
-	"io/ioutil"
-	"strings"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/fnproject/fn/api/common"

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"io/ioutil"
+	"strings"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -21,6 +23,11 @@ func init() {
 func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
+	} else if value, ok := os.LookupEnv(key + "_FILE"); ok {
+		dat, err := ioutil.ReadFile(value)
+		if err == nil {
+			return string(dat)
+		}
 	}
 	return fallback
 }
@@ -34,6 +41,16 @@ func getEnvInt(key string, fallback int) int {
 			panic(err) // not sure how to handle this
 		}
 		return i
+	} else if value, ok := os.LookupEnv(key + "_FILE"); ok {
+		dat, err := ioutil.ReadFile(value)
+		if err == nil {
+			var err error
+			var i int
+			if i, err = strconv.Atoi(strings.TrimSpace(string(dat))); err != nil {
+				panic(err) // not sure how to handle this
+			}
+			return i
+		}
 	}
 	return fallback
 }

--- a/docs/operating/options.md
+++ b/docs/operating/options.md
@@ -19,6 +19,14 @@ docker run.  For example:
 docker run -e VAR_NAME=VALUE ...
 ```
 
+Additionally you may desire to load the environment variables from files, for example if you are using Docker Secrets, in that case you may append
+`_FILE` to the end of any variable name and specify the file location.  The variable will be filled with the file's contents.  For example:
+
+```sh
+docker run -e VAR_NAME_FILE=/path/to/secret ...
+```
+
+
 | Env Variables | Description | Default values |
 | --------------|-------------|----------------|
 | `FN_DB_URL` | The database URL to use in URL format. See [Databases](databases/README.md) for more information. | sqlite3:///app/data/fn.db |


### PR DESCRIPTION
- Link to issue this resolves
https://github.com/fnproject/fn/issues/1141

- What I did
`getEnv` and `getEnvInt` now test to see if `{key}_FILE` is set after testing `{key}`.  If it is set it reads the value from the specified file.

- How I did it
I searched for the point where the environment variables were loaded and added a small feature to it.

- How to verify it
Build the docker image as usual, then
```sh
echo 8081 > /tmp/test_var
docker run -v /tmp/test_var:/run/secrets/test_var -v /var/run/docker.sock:/var/run/docker.sock -e FN_PORT_FILE=/run/secrets/test_var -i {image}
```
You should see Fn server running on port 8081

- One line description for the changelog

Support `_FILE` postfixes for environment variables to be loaded from file.

- One moving picture involving robots (not mandatory but encouraged)

![](https://media.giphy.com/media/UWpfAsp7klhw4/giphy.gif)
