### PR TITLE
Upgrade compose version from 3 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
-version: '3'
+version: '3.5'
+
+# network static name required for FN_DOCKER_NETWORKS
 networks:
   fn-network:
     name: fn-network
+    driver: bridge
+
 services:
   logstore:
     hostname: logstore


### PR DESCRIPTION
 v3.5 allows network static name binding which allows successfully bypass docker network name through FN_DOCKERS_NETWORK

Note, API upgrade is required per the following discussion: https://github.com/docker/compose/issues/6113

- What I did

compose version changed from 3 to 3.5

- How to verify it

```bash
docker-compose up -d
docker network | grep "fn-network"
docker inspect fn-network
docker-compose down
```

- One line description for the changelog

Compose network static name binding via API upgrade from 3 to 3.5

- One moving picture involving robots (not mandatory but encouraged)
![dance with me](https://media.giphy.com/media/WkgXvCt5Q2jAI/giphy.gif)