### PR TITLE
Equality methods on app should include syslogurl field

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -127,6 +127,7 @@ func (a1 *App) Equals(a2 *App) bool {
 	eq = eq && a1.ID == a2.ID
 	eq = eq && a1.Name == a2.Name
 	eq = eq && a1.Config.Equals(a2.Config)
+	eq = eq && a1.SyslogURL == a2.SyslogURL
 	eq = eq && a1.Annotations.Equals(a2.Annotations)
 	// NOTE: datastore tests are not very fun to write with timestamp checks,
 	// and these are not values the user may set so we kind of don't care.
@@ -143,6 +144,7 @@ func (a1 *App) EqualsWithAnnotationSubset(a2 *App) bool {
 	eq = eq && a1.ID == a2.ID
 	eq = eq && a1.Name == a2.Name
 	eq = eq && a1.Config.Equals(a2.Config)
+	eq = eq && a1.SyslogURL == a2.SyslogURL
 	eq = eq && a1.Annotations.Subset(a2.Annotations)
 	// NOTE: datastore tests are not very fun to write with timestamp checks,
 	// and these are not values the user may set so we kind of don't care.


### PR DESCRIPTION
Trivial one-line fix to make `App.Equals()` compare SyslogURL too.