### PR TITLE
remove agent.call.req field

### DIFF
--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -115,7 +115,7 @@ func TestCallConfigurationRequest(t *testing.T) {
 	req.Header.Add("Content-Length", contentLength)
 	req.Header.Add("FN_PATH", "thewrongroute") // ensures that this doesn't leak out, should be overwritten
 
-	call, err := a.GetCall(
+	call, err := a.GetCall(req.Context(),
 		WithWriter(w), // XXX (reed): order matters [for now]
 		FromRequest(app, route, req),
 	)
@@ -158,9 +158,6 @@ func TestCallConfigurationRequest(t *testing.T) {
 	}
 	if model.Method != method {
 		t.Fatal("method mismatch", model.Method, method)
-	}
-	if model.Payload != "" { // NOTE: this is expected atm
-		t.Fatal("GetCall FromRequest should not fill payload, got non-empty payload", model.Payload)
 	}
 
 	expectedConfig := map[string]string{
@@ -220,6 +217,8 @@ func TestCallConfigurationModel(t *testing.T) {
 		"ROUTE_VAR":   "BAR",
 	}
 
+	ctx := context.Background()
+
 	cm := &models.Call{
 		AppID:       app.ID,
 		AppName:     app.Name,
@@ -243,15 +242,15 @@ func TestCallConfigurationModel(t *testing.T) {
 	a := New(NewDirectCallDataAccess(ls, new(mqs.Mock)))
 	defer checkClose(t, a)
 
-	callI, err := a.GetCall(FromModel(cm))
+	callI, err := a.GetCall(ctx, FromModel(cm))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	req := callI.(*call).req
+	body := callI.(*call).RequestBody()
 
 	var b bytes.Buffer
-	io.Copy(&b, req.Body)
+	io.Copy(&b, body)
 
 	if b.String() != payload {
 		t.Fatal("expected payload to match, but it was a lie")
@@ -309,29 +308,30 @@ func TestAsyncCallHeaders(t *testing.T) {
 		Method:      method,
 	}
 
+	ctx := context.Background()
+
 	// FromModel doesn't need a datastore, for now...
 	ls := logs.NewMock()
 
 	a := New(NewDirectCallDataAccess(ls, new(mqs.Mock)))
 	defer checkClose(t, a)
 
-	callI, err := a.GetCall(FromModel(cm))
+	callI, err := a.GetCall(ctx, FromModel(cm))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// make sure headers seem reasonable
-	req := callI.(*call).req
 
 	// These should be here based on payload length and/or fn_header_* original headers
 	expectedHeaders := make(http.Header)
 	expectedHeaders.Set("Content-Type", contentType)
 	expectedHeaders.Set("Content-Length", strconv.FormatInt(int64(len(payload)), 10))
 
-	checkExpectedHeaders(t, expectedHeaders, req.Header)
+	checkExpectedHeaders(t, expectedHeaders, http.Header(callI.Model().Headers))
+
+	body := callI.(*call).RequestBody()
 
 	var b bytes.Buffer
-	io.Copy(&b, req.Body)
+	io.Copy(&b, body)
 
 	if b.String() != payload {
 		t.Fatal("expected payload to match, but it was a lie")
@@ -451,6 +451,8 @@ func TestSubmitError(t *testing.T) {
 		Method:      method,
 	}
 
+	ctx := context.Background()
+
 	// FromModel doesn't need a datastore, for now...
 	ls := logs.NewMock()
 
@@ -474,12 +476,12 @@ func TestSubmitError(t *testing.T) {
 
 	a.AddCallListener(&testListener{afterCall: afterCall})
 
-	callI, err := a.GetCall(FromModel(cm))
+	callI, err := a.GetCall(ctx, FromModel(cm))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	if err == nil {
 		t.Fatal("expected error but got none")
 	}
@@ -527,15 +529,16 @@ func TestHTTPWithoutContentLengthWorks(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error building request", err)
 	}
+	ctx := req.Context()
 
 	// grab a buffer so we can read what gets written to this guy
 	var out bytes.Buffer
-	callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&out))
+	callI, err := a.GetCall(ctx, FromRequest(app, route, req), WithWriter(&out))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	if err != nil {
 		t.Error("submit should not error:", err)
 	}
@@ -580,7 +583,9 @@ func TestGetCallReturnsResourceImpossibility(t *testing.T) {
 	a := New(NewDirectCallDataAccess(ls, new(mqs.Mock)))
 	defer checkClose(t, a)
 
-	_, err := a.GetCall(FromModel(call))
+	ctx := context.Background()
+
+	_, err := a.GetCall(ctx, FromModel(call))
 	if err != models.ErrCallTimeoutServerBusy {
 		t.Fatal("did not get expected err, got: ", err)
 	}
@@ -619,13 +624,15 @@ func TestTmpFsRW(t *testing.T) {
 		t.Fatal("unexpected error building request", err)
 	}
 
+	ctx := req.Context()
+
 	var out bytes.Buffer
-	callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&out))
+	callI, err := a.GetCall(ctx, FromRequest(app, route, req), WithWriter(&out))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	if err != nil {
 		t.Error("submit should not error:", err)
 	}
@@ -718,13 +725,15 @@ func TestTmpFsSize(t *testing.T) {
 		t.Fatal("unexpected error building request", err)
 	}
 
+	ctx := req.Context()
+
 	var out bytes.Buffer
-	callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&out))
+	callI, err := a.GetCall(ctx, FromRequest(app, route, req), WithWriter(&out))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	if err != nil {
 		t.Error("submit should not error:", err)
 	}
@@ -833,163 +842,6 @@ func testCall() *models.Call {
 	}
 }
 
-func TestPipesAreClear(t *testing.T) {
-	// The basic idea here is to make a call start a hot container, and the
-	// first call has a reader that only reads after a delay, which is beyond
-	// the boundary of the first call's timeout. Then, run a second call
-	// with a different body that also has a slight delay. make sure the second
-	// call gets the correct body.  This ensures the input paths for calls do not
-	// overlap into the same container and they don't block past timeout.
-	// TODO make sure the second call does not get the first call's body if
-	// we write the first call's body in before the second's (it was tested
-	// but not put in stone here, the code is ~same).
-	//
-	// causal (seconds):
-	// T1=start task one, T1TO=task one times out, T2=start task two
-	// T1W=task one writes, T2W=task two writes
-	//
-	//
-	//  1s  2   3    4   5   6
-	// ---------------------------
-	//
-	// T1-------T1TO-T2-T1W--T2W--
-
-	ca := testCall()
-	ca.Type = "sync"
-	ca.Format = "http"
-	ca.IdleTimeout = 60 // keep this bad boy alive
-	ca.Timeout = 4      // short
-	app := &models.App{Name: "myapp", ID: ca.AppID}
-
-	route := &models.Route{
-		Path:        ca.Path,
-		AppID:       ca.AppID,
-		Image:       ca.Image,
-		Type:        ca.Type,
-		Format:      ca.Format,
-		Timeout:     ca.Timeout,
-		IdleTimeout: ca.IdleTimeout,
-		Memory:      ca.Memory,
-	}
-
-	ls := logs.NewMock()
-	a := New(NewDirectCallDataAccess(ls, new(mqs.Mock)))
-	defer checkClose(t, a)
-
-	// test read this body after 5s (after call times out) and make sure we don't get yodawg
-	// TODO could read after 10 seconds, to make sure the 2nd task's input stream isn't blocked
-	// TODO we need to test broken HTTP output from a task should return a useful error
-	bodOne := `{"echoContent":"yodawg"}`
-	delayBodyOne := &delayReader{Reader: strings.NewReader(bodOne), delay: 5 * time.Second}
-
-	req, err := http.NewRequest("GET", ca.URL, delayBodyOne)
-	if err != nil {
-		t.Fatal("unexpected error building request", err)
-	}
-	// NOTE: using chunked here seems to perplex the go http request reading code, so for
-	// the purposes of this test, set this. json also works.
-	req.ContentLength = int64(len(bodOne))
-	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodOne)))
-
-	var outOne bytes.Buffer
-	callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&outOne))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// this will time out after 4s, our reader reads after 5s
-	t.Log("before submit one:", time.Now())
-	err = a.Submit(callI)
-	t.Log("after submit one:", time.Now())
-	if err == nil {
-		t.Error("expected error but got none")
-	}
-	t.Log("first guy err:", err)
-
-	if len(outOne.String()) > 0 {
-		t.Fatal("input should not have been read, producing 0 output, got:", outOne.String())
-	}
-
-	// if we submit another call to the hot container, this can be finicky if the
-	// hot logic simply fails to re-use a container then this will 'just work'
-	// but at one point this failed.
-
-	// only delay this body 2 seconds, so that we read at 6s (first writes at 5s) before time out
-	bodTwo := `{"echoContent":"NODAWG"}`
-	delayBodyTwo := &delayReader{Reader: strings.NewReader(bodTwo), delay: 2 * time.Second}
-
-	req, err = http.NewRequest("GET", ca.URL, delayBodyTwo)
-	if err != nil {
-		t.Fatal("unexpected error building request", err)
-	}
-	req.ContentLength = int64(len(bodTwo))
-	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodTwo)))
-
-	var outTwo bytes.Buffer
-	callI, err = a.GetCall(FromRequest(app, route, req), WithWriter(&outTwo))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Log("before submit two:", time.Now())
-	err = a.Submit(callI)
-	t.Log("after submit two:", time.Now())
-	if err != nil {
-		t.Error("got error from submit when task should succeed", err)
-	}
-
-	body := outTwo.String()
-
-	// we're using http format so this will have written a whole http request
-	res, err := http.ReadResponse(bufio.NewReader(&outTwo), nil)
-	if err != nil {
-		t.Fatalf("error reading body. err: %v body: %s", err, body)
-	}
-	defer res.Body.Close()
-
-	// {"request":{"echoContent":"yodawg"}}
-	var resp struct {
-		R struct {
-			Body string `json:"echoContent"`
-		} `json:"request"`
-	}
-
-	json.NewDecoder(res.Body).Decode(&resp)
-
-	if resp.R.Body != "NODAWG" {
-		t.Fatalf("body from second call was not what we wanted. boo. got wrong body: %v wanted: %v", resp.R.Body, "NODAWG")
-	}
-
-	// NOTE: we need to make sure that 2 containers didn't launch to process
-	// this. this isn't perfect but we really should be able to run 2 tasks
-	// sequentially even if the first times out in the same container, so this
-	// ends up testing hot container management more than anything. i do not like
-	// digging around in the concrete type of ca for state stats but this seems
-	// the best way to ensure 2 containers aren't launched. this does have the
-	// shortcoming that if the first container dies and another launches, we
-	// don't see it and this passes when it should not.  feel free to amend...
-	callConcrete := callI.(*call)
-	var count uint64
-	for _, up := range callConcrete.slots.getStats().containerStates {
-		up += count
-	}
-	if count > 1 {
-		t.Fatalf("multiple containers launched to service this test. this shouldn't be. %d", count)
-	}
-}
-
-type delayReader struct {
-	once  sync.Once
-	delay time.Duration
-
-	io.Reader
-}
-
-func (r *delayReader) Read(b []byte) (int, error) {
-	r.once.Do(func() { time.Sleep(r.delay) })
-	return r.Reader.Read(b)
-}
-
 func TestPipesDontMakeSpuriousCalls(t *testing.T) {
 	// if we swap out the pipes between tasks really fast, we need to ensure that
 	// there are no spurious reads on the container's input that give us a bad
@@ -998,6 +850,7 @@ func TestPipesDontMakeSpuriousCalls(t *testing.T) {
 	// that is finicky since this is a totally normal happy path (run 2 hot tasks
 	// in the same container in a row).
 
+	ctx := context.Background()
 	call := testCall()
 	call.Type = "sync"
 	call.Format = "http"
@@ -1029,14 +882,14 @@ func TestPipesDontMakeSpuriousCalls(t *testing.T) {
 	}
 
 	var outOne bytes.Buffer
-	callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&outOne))
+	callI, err := a.GetCall(ctx, FromRequest(app, route, req), WithWriter(&outOne))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// this will time out after 4s, our reader reads after 5s
 	t.Log("before submit one:", time.Now())
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	t.Log("after submit one:", time.Now())
 	if err != nil {
 		t.Error("got error from submit when task should succeed", err)
@@ -1054,13 +907,13 @@ func TestPipesDontMakeSpuriousCalls(t *testing.T) {
 	}
 
 	var outTwo bytes.Buffer
-	callI, err = a.GetCall(FromRequest(app, route, req), WithWriter(&outTwo))
+	callI, err = a.GetCall(ctx, FromRequest(app, route, req), WithWriter(&outTwo))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Log("before submit two:", time.Now())
-	err = a.Submit(callI)
+	err = a.Submit(ctx, callI)
 	t.Log("after submit two:", time.Now())
 	if err != nil {
 		// don't do a Fatal so that we can read the body to see what really happened
@@ -1135,12 +988,12 @@ func TestNBIOResourceTracker(t *testing.T) {
 			}
 
 			var outOne bytes.Buffer
-			callI, err := a.GetCall(FromRequest(app, route, req), WithWriter(&outOne))
+			callI, err := a.GetCall(req.Context(), FromRequest(app, route, req), WithWriter(&outOne))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = a.Submit(callI)
+			err = a.Submit(req.Context(), callI)
 			errors <- err
 		}(i)
 	}

--- a/api/agent/async.go
+++ b/api/agent/async.go
@@ -103,10 +103,7 @@ func (a *agent) asyncRun(ctx context.Context, model *models.Call) {
 	ctx, span := trace.StartSpan(ctx, "agent_async_run")
 	defer span.End()
 
-	call, err := a.GetCall(
-		FromModel(model),
-		WithContext(ctx), // NOTE: order is important
-	)
+	call, err := a.GetCall(ctx, FromModel(model))
 	if err != nil {
 		logrus.WithError(err).Error("error getting async call")
 		return
@@ -117,7 +114,7 @@ func (a *agent) asyncRun(ctx context.Context, model *models.Call) {
 	// are at least once semantics, which is really preferable to at most
 	// once, so let's do it for now
 
-	err = a.Submit(call)
+	err = a.Submit(ctx, call)
 	if err != nil {
 		// NOTE: these could be errors / timeouts from the call that we're
 		// logging here (i.e. not our fault), but it's likely better to log

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -1,11 +1,8 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
-	"io/ioutil"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -94,18 +91,18 @@ func (a *lbAgent) fireAfterCall(ctx context.Context, call *models.Call) error {
 }
 
 // implements Agent
-func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
+func (a *lbAgent) GetCall(ctx context.Context, opts ...CallOpt) (Call, error) {
 	var c call
 
 	for _, o := range opts {
-		err := o(&c)
+		err := o(ctx, &c)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// TODO typed errors to test
-	if c.req == nil || c.Call == nil {
+	if c.Call == nil {
 		return nil, errors.New("no model or request provided for call")
 	}
 
@@ -118,8 +115,6 @@ func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
 		}
 		c.extensions = ext
 	}
-
-	setupCtx(&c)
 
 	c.isLB = true
 	c.handler = a.cda
@@ -147,13 +142,13 @@ func (a *lbAgent) Close() error {
 }
 
 // implements Agent
-func (a *lbAgent) Submit(callI Call) error {
+func (a *lbAgent) Submit(ctx context.Context, callI Call) error {
 	if !a.shutWg.AddSession(1) {
 		return models.ErrCallTimeoutServerBusy
 	}
 
 	call := callI.(*call)
-	ctx, span := trace.StartSpan(call.req.Context(), "agent_submit")
+	ctx, span := trace.StartSpan(ctx, "agent_submit")
 	defer span.End()
 
 	statsEnqueue(ctx)
@@ -170,70 +165,16 @@ func (a *lbAgent) Submit(callI Call) error {
 
 	statsDequeueAndStart(ctx)
 
-	// pre-read and buffer request body if already not done based
-	// on GetBody presence.
-	buf, err := a.setRequestBody(ctx, call)
-	if buf != nil {
-		defer bufPool.Put(buf)
-	}
-
-	if err != nil {
-		common.Logger(call.req.Context()).WithError(err).Error("Failed to process call body")
-		return a.handleCallEnd(ctx, call, err, true)
-	}
-
 	// WARNING: isStarted (handleCallEnd) semantics
 	// need some consideration here. Similar to runner/agent
 	// we consider isCommitted true if call.Start() succeeds.
 	// isStarted=true means we will call Call.End().
 	err = a.placer.PlaceCall(a.rp, ctx, call)
 	if err != nil {
-		common.Logger(call.req.Context()).WithError(err).Error("Failed to place call")
+		common.Logger(ctx).WithError(err).Error("Failed to place call")
 	}
 
 	return a.handleCallEnd(ctx, call, err, true)
-}
-
-// setRequestGetBody sets GetBody function on the given http.Request if it is missing.  GetBody allows
-// reading from the request body without mutating the state of the request.
-func (a *lbAgent) setRequestBody(ctx context.Context, call *call) (*bytes.Buffer, error) {
-
-	r := call.req
-	if r.Body == nil || r.GetBody != nil {
-		return nil, nil
-	}
-
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-
-	// WARNING: we need to handle IO in a separate go-routine below
-	// to be able to detect a ctx timeout. When we timeout, we
-	// let gin/http-server to unblock the go-routine below.
-	errApp := make(chan error, 1)
-	go func() {
-
-		_, err := buf.ReadFrom(r.Body)
-		if err != nil && err != io.EOF {
-			errApp <- err
-			return
-		}
-
-		r.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
-
-		// GetBody does not mutate the state of the request body
-		r.GetBody = func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
-		}
-
-		close(errApp)
-	}()
-
-	select {
-	case err := <-errApp:
-		return buf, err
-	case <-ctx.Done():
-		return buf, ctx.Err()
-	}
 }
 
 // implements Agent

--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -670,9 +670,7 @@ func (pr *pureRunner) Engage(engagement runner.RunnerProtocol_EngageServer) erro
 func readData(state *callHandle) {
 	dataFeed := state.spawnPipeToFn()
 
-	var i int
 	for {
-		i++
 		dataMsg := state.getDataMsg()
 		if dataMsg == nil {
 			return

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -90,6 +90,7 @@ type Call struct {
 
 	// Payload for the call. This is only used by async calls, to store their input.
 	// TODO should we copy it into here too for debugging sync?
+	// TODO this is hairy, we should remove this in lieu of event struct
 	Payload string `json:"payload,omitempty" db:"-"`
 
 	// Full request url that spawned this invocation.

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -53,7 +53,8 @@ func (s *Server) ServeFnInvoke(c *gin.Context, app *models.App, fn *models.Fn) e
 	}
 	defer bufPool.Put(buf) // TODO need to ensure this is safe with Dispatch?
 
-	call, err := s.agent.GetCall(
+	ctx := c.Request.Context()
+	call, err := s.agent.GetCall(ctx,
 		agent.WithWriter(&writer), // XXX (reed): order matters [for now]
 		agent.FromHTTPFnRequest(app, fn, c.Request),
 	)
@@ -67,7 +68,7 @@ func (s *Server) ServeFnInvoke(c *gin.Context, app *models.App, fn *models.Fn) e
 		c.Request = c.Request.WithContext(ctx)
 	}
 
-	err = s.agent.Submit(call)
+	err = s.agent.Submit(ctx, call)
 	if err != nil {
 		// NOTE if they cancel the request then it will stop the call (kind of cool),
 		// we could filter that error out here too as right now it yells a little

--- a/system_test.sh
+++ b/system_test.sh
@@ -11,6 +11,7 @@ export FN_DB_URL=$(spawn_${DB_NAME} ${CONTEXT})
 # avoid port conflicts with api_test.sh which are run in parallel
 export FN_API_URL="http://localhost:8085"
 export FN_DS_DB_PING_MAX_RETRIES=60
+#export FN_LOG_LEVEL=debug
 
 # pure runner and LB agent required settings below
 export FN_MAX_REQUEST_SIZE=6291456

--- a/test/fn-system-tests/exec_http_trigger_test.go
+++ b/test/fn-system-tests/exec_http_trigger_test.go
@@ -279,7 +279,7 @@ func TestBasicTriggerConcurrentExecution(t *testing.T) {
 
 			echo, err := getEchoContent(output.Bytes())
 			if err != nil || echo != "HelloWorld" {
-				results <- fmt.Errorf("Assertion error.\n\tActual: %v", output.String())
+				results <- fmt.Errorf("Assertion error.\n\tExpected: '%v' Actual: %v", "HelloWorld", output.String())
 				return
 			}
 			if resp.StatusCode != http.StatusOK {

--- a/test/fn-system-tests/exec_route_test.go
+++ b/test/fn-system-tests/exec_route_test.go
@@ -205,7 +205,7 @@ func TestBasicConcurrentExecution(t *testing.T) {
 
 			echo, err := getEchoContent(output.Bytes())
 			if err != nil || echo != "HelloWorld" {
-				results <- fmt.Errorf("Assertion error.\n\tActual: %v", output.String())
+				results <- fmt.Errorf("Assertion error.\n\tExpected: '%v' Actual: %v", "HelloWorld", output.String())
 				return
 			}
 			if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
in order to open the pearly gates of cloud events we need to rip the http
request specific stuff out of the agent's plumbing. this makes less of an
improvement than maybe I would've liked, but at least that part of it is
accomplished. agent.call.RequestBody is the 'standard' way to get a handle on
the request body now, mostly due to lb_agent. this replaces the previous logic
for caching the request body for a call to use when a placer retries with
something that doesn't require an extra goroutine, this should reduce latency
through the lb agent and is in some ways simpler (and others not).
additionally, this requires Submit and GetCall to take a context argument,
which is now plumbed too.

this also extracts a decent chunk from the delta of #1138 
