### PR TITLE
fn: fix math error in calculating msecs in container states

### DIFF
--- a/api/agent/state_trackers.go
+++ b/api/agent/state_trackers.go
@@ -142,7 +142,7 @@ func (c *containerState) UpdateState(ctx context.Context, newState ContainerStat
 
 	timeKey := containerTimeKeys[oldState]
 	if timeKey != "" {
-		stats.Record(ctx, containerTimeMeasures[oldState].M(int64(now.Sub(before).Round(time.Millisecond))))
+		stats.Record(ctx, containerTimeMeasures[oldState].M(int64(now.Sub(before)/time.Millisecond)))
 	}
 
 	// update new state stats


### PR DESCRIPTION
Round still leaves the unit as duration. This PR fixes this to ensure msec conversion.
