### PR TITLE
Change the syslog format to use app_name instead of app_id

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -750,7 +750,7 @@ func (s *hotSlot) exec(ctx context.Context, call *call) error {
 	defer bufPool.Put(buf1)
 	defer bufPool.Put(buf2)
 
-	sw := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_ERR, s.container.syslogConns, buf1)
+	sw := newSyslogWriter(call.ID, call.Path, call.AppName, syslog.LOG_ERR, s.container.syslogConns, buf1)
 	var syslog io.WriteCloser = &nopCloser{sw}
 	syslog = newLineWriterWithBuffer(buf2, syslog)
 	defer syslog.Close()                            // close syslogger from here, but NOT the call log stderr OR conns
@@ -1084,8 +1084,8 @@ func newHotContainer(ctx context.Context, call *call, cfg *Config) (*container, 
 		bufs = []*bytes.Buffer{buf1, buf2, buf3, buf4}
 
 		// stdout = LOG_INFO, stderr = LOG_ERR -- ONLY for the between writers, normal stdout is a response
-		so := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_INFO, syslogConns, buf1)
-		se := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_ERR, syslogConns, buf2)
+		so := newSyslogWriter(call.ID, call.Path, call.AppName, syslog.LOG_INFO, syslogConns, buf1)
+		se := newSyslogWriter(call.ID, call.Path, call.AppName, syslog.LOG_ERR, syslogConns, buf2)
 
 		// use multiWriteCloser since it ignores errors (io.MultiWriter does not)
 		soc := multiWriteCloser{&nopCloser{so}, &nopCloser{&logWriter{

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -750,7 +750,7 @@ func (s *hotSlot) exec(ctx context.Context, call *call) error {
 	defer bufPool.Put(buf1)
 	defer bufPool.Put(buf2)
 
-	sw := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_ERR, s.container.syslogConns, buf1)
+	sw := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_ERR, s.container.syslogConns, buf1)
 	var syslog io.WriteCloser = &nopCloser{sw}
 	syslog = newLineWriterWithBuffer(buf2, syslog)
 	defer syslog.Close()                            // close syslogger from here, but NOT the call log stderr OR conns
@@ -1084,8 +1084,8 @@ func newHotContainer(ctx context.Context, call *call, cfg *Config) (*container, 
 		bufs = []*bytes.Buffer{buf1, buf2, buf3, buf4}
 
 		// stdout = LOG_INFO, stderr = LOG_ERR -- ONLY for the between writers, normal stdout is a response
-		so := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_INFO, syslogConns, buf1)
-		se := newSyslogWriter(call.ID, call.Path, call.AppID, syslog.LOG_ERR, syslogConns, buf2)
+		so := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_INFO, syslogConns, buf1)
+		se := newSyslogWriter(call.ID, call.Path, call.AppID, call.AppName, syslog.LOG_ERR, syslogConns, buf2)
 
 		// use multiWriteCloser since it ignores errors (io.MultiWriter does not)
 		soc := multiWriteCloser{&nopCloser{so}, &nopCloser{&logWriter{

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -222,6 +222,7 @@ func TestCallConfigurationModel(t *testing.T) {
 
 	cm := &models.Call{
 		AppID:       app.ID,
+		AppName:     app.Name,
 		Config:      cfg,
 		Path:        path,
 		Image:       image,
@@ -292,6 +293,7 @@ func TestAsyncCallHeaders(t *testing.T) {
 
 	cm := &models.Call{
 		AppID:       app.ID,
+		AppName:     app.Name,
 		Config:      config,
 		Headers:     headers,
 		Path:        path,
@@ -434,6 +436,7 @@ func TestSubmitError(t *testing.T) {
 
 	cm := &models.Call{
 		AppID:       app.ID,
+		AppName:     app.Name,
 		Config:      config,
 		Path:        path,
 		Image:       image,
@@ -563,6 +566,7 @@ func TestHTTPWithoutContentLengthWorks(t *testing.T) {
 func TestGetCallReturnsResourceImpossibility(t *testing.T) {
 	call := &models.Call{
 		AppID:       id.New().String(),
+		AppName:     "appName",
 		Path:        "/yoyo",
 		Image:       "fnproject/fn-test-utils",
 		Type:        "sync",
@@ -812,6 +816,7 @@ func testCall() *models.Call {
 
 	return &models.Call{
 		AppID:       app.ID,
+		AppName:     app.Name,
 		Config:      config,
 		Headers:     headers,
 		Path:        path,

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -123,6 +123,7 @@ func FromRequest(app *models.App, route *models.Route, req *http.Request) CallOp
 			URL:         reqURL(req),
 			Method:      req.Method,
 			AppID:       app.ID,
+			AppName:     app.Name,
 			SyslogURL:   syslogURL,
 		}
 
@@ -192,6 +193,7 @@ func FromHTTPTriggerRequest(app *models.App, fn *models.Fn, trigger *models.Trig
 			URL:         reqURL(req),
 			Method:      req.Method,
 			AppID:       app.ID,
+			AppName:     app.Name,
 			FnID:        fn.ID,
 			TriggerID:   trigger.ID,
 			SyslogURL:   syslogURL,

--- a/api/agent/syslog.go
+++ b/api/agent/syslog.go
@@ -107,7 +107,7 @@ type syslogWriter struct {
 const severityMask = 0x07
 const facilityMask = 0xf8
 
-func newSyslogWriter(call, function, app string, severity syslog.Priority, wc io.Writer, buf *bytes.Buffer) *syslogWriter {
+func newSyslogWriter(call, function, appID, appName string, severity syslog.Priority, wc io.Writer, buf *bytes.Buffer) *syslogWriter {
 	// Facility = LOG_USER
 	pr := (syslog.LOG_USER & facilityMask) | (severity & severityMask)
 
@@ -121,7 +121,7 @@ func newSyslogWriter(call, function, app string, severity syslog.Priority, wc io
 	// TODO we could use json for structured data and do that whole thing. up to whoever.
 	return &syslogWriter{
 		pres:   []byte(fmt.Sprintf(`<%d>2`, pr)),
-		post:   []byte(fmt.Sprintf(`fn - - - - call_id=%s func_name=%s app_id=%s `, call, function, app)),
+		post:   []byte(fmt.Sprintf(`fn - - - - call_id=%s func_name=%s app_id=%s app_name=%s `, call, function, appID, appName)),
 		b:      buf,
 		Writer: wc,
 		clock:  time.Now,

--- a/api/agent/syslog.go
+++ b/api/agent/syslog.go
@@ -107,21 +107,21 @@ type syslogWriter struct {
 const severityMask = 0x07
 const facilityMask = 0xf8
 
-func newSyslogWriter(call, function, appID, appName string, severity syslog.Priority, wc io.Writer, buf *bytes.Buffer) *syslogWriter {
+func newSyslogWriter(call, function, appName string, severity syslog.Priority, wc io.Writer, buf *bytes.Buffer) *syslogWriter {
 	// Facility = LOG_USER
 	pr := (syslog.LOG_USER & facilityMask) | (severity & severityMask)
 
 	// <priority>VERSION ISOTIMESTAMP HOSTNAME APPLICATION PID      MESSAGEID STRUCTURED-DATA MSG
 	//
 	// and for us:
-	// <22>2             ISOTIMESTAMP fn       appID       funcName callID    -               MSG
+	// <22>2             ISOTIMESTAMP fn       appName       funcName callID    -               MSG
 	// ex:
 	//<11>2 2018-02-31T07:42:21Z Fn - - - -  call_id=123 func_name=rdallman/yodawg app_id=123 loggo hereo
 
 	// TODO we could use json for structured data and do that whole thing. up to whoever.
 	return &syslogWriter{
 		pres:   []byte(fmt.Sprintf(`<%d>2`, pr)),
-		post:   []byte(fmt.Sprintf(`fn - - - - call_id=%s func_name=%s app_id=%s app_name=%s `, call, function, appID, appName)),
+		post:   []byte(fmt.Sprintf(`fn - - - - call_id=%s func_name=%s app_name=%s `, call, function, appName)),
 		b:      buf,
 		Writer: wc,
 		clock:  time.Now,

--- a/api/agent/syslog_test.go
+++ b/api/agent/syslog_test.go
@@ -13,15 +13,16 @@ func TestSyslogFormat(t *testing.T) {
 
 	call := "12345"
 	fn := "yo/dawg"
-	app := "sup"
+	appID := "sup"
+	appName := "myapp"
 	now := time.Date(1982, 6, 25, 12, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
 
-	writer := newSyslogWriter(call, fn, app, syslog.LOG_ERR, &nopCloser{&b1}, &b2)
+	writer := newSyslogWriter(call, fn, appID, appName, syslog.LOG_ERR, &nopCloser{&b1}, &b2)
 	writer.clock = clock
 	writer.Write([]byte("yo"))
 
-	gold := `<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/dawg app_id=sup yo`
+	gold := `<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/dawg app_id=sup app_name=myapp yo`
 
 	if b1.String() != gold {
 		t.Fatal("syslog was not what we expected: ", b1.String())

--- a/api/agent/syslog_test.go
+++ b/api/agent/syslog_test.go
@@ -13,16 +13,15 @@ func TestSyslogFormat(t *testing.T) {
 
 	call := "12345"
 	fn := "yo/dawg"
-	appID := "sup"
 	appName := "myapp"
 	now := time.Date(1982, 6, 25, 12, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
 
-	writer := newSyslogWriter(call, fn, appID, appName, syslog.LOG_ERR, &nopCloser{&b1}, &b2)
+	writer := newSyslogWriter(call, fn, appName, syslog.LOG_ERR, &nopCloser{&b1}, &b2)
 	writer.clock = clock
 	writer.Write([]byte("yo"))
 
-	gold := `<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/dawg app_id=sup app_name=myapp yo`
+	gold := `<11>2 1982-06-25T12:00:00Z fn - - - - call_id=12345 func_name=yo/dawg app_name=myapp yo`
 
 	if b1.String() != gold {
 		t.Fatal("syslog was not what we expected: ", b1.String())

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -150,6 +150,9 @@ type Call struct {
 	// App this call belongs to.
 	AppID string `json:"app_id" db:"app_id"`
 
+	// Name of the app.
+	AppName string `json:"app_name" db:"app_name"`
+
 	// Trigger this call belongs to.
 	TriggerID string `json:"trigger_id" db:"trigger_id"`
 


### PR DESCRIPTION
This fixes #1146. 

I added the AppName to models.Call in order to be able to write it out in the logs.

Verified by running unit tests and manually setting the app sys-log and verifying correct logs are being sent to papertrail. 