### PR TITLE
Add annotation to trigger on create if endpoints are enabled

### DIFF
--- a/api/server/trigger_create.go
+++ b/api/server/trigger_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
 )
@@ -11,6 +12,7 @@ import (
 func (s *Server) handleTriggerCreate(c *gin.Context) {
 	ctx := c.Request.Context()
 	trigger := &models.Trigger{}
+	log := common.Logger(ctx)
 
 	err := c.BindJSON(trigger)
 	if err != nil {
@@ -28,19 +30,19 @@ func (s *Server) handleTriggerCreate(c *gin.Context) {
 		return
 	}
 
-	if !s.noHTTTPTriggerEndpoint {
-		app, err := s.datastore.GetAppByID(ctx, triggerCreated.AppID)
-		if err != nil {
-			handleErrorResponse(c, fmt.Errorf("unexpected error - trigger app not available: %s", err))
-			return
-		}
-
-		triggerCreated, err = s.triggerAnnotator.AnnotateTrigger(c, app, triggerCreated)
-		if err != nil {
-			handleErrorResponse(c, err)
-			return
-		}
+	app, err := s.datastore.GetAppByID(ctx, triggerCreated.AppID)
+	if err != nil {
+		log.Debugln(fmt.Errorf("unexpected error - trigger app not available: %s", err))
+		c.JSON(http.StatusOK, triggerCreated)
+		return
 	}
 
-	c.JSON(http.StatusOK, triggerCreated)
+	triggerAnnotated, err := s.triggerAnnotator.AnnotateTrigger(c, app, triggerCreated)
+	if err != nil {
+		log.Debugln("Failed to annotate trigger on cration")
+		c.JSON(http.StatusOK, triggerCreated)
+		return
+	}
+
+	c.JSON(http.StatusOK, triggerAnnotated)
 }

--- a/api/server/trigger_create.go
+++ b/api/server/trigger_create.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/fnproject/fn/api/models"
@@ -25,6 +26,20 @@ func (s *Server) handleTriggerCreate(c *gin.Context) {
 	if err != nil {
 		handleErrorResponse(c, err)
 		return
+	}
+
+	if !s.noHTTTPTriggerEndpoint {
+		app, err := s.datastore.GetAppByID(ctx, triggerCreated.AppID)
+		if err != nil {
+			handleErrorResponse(c, fmt.Errorf("unexpected error - trigger app not available: %s", err))
+			return
+		}
+
+		triggerCreated, err = s.triggerAnnotator.AnnotateTrigger(c, app, triggerCreated)
+		if err != nil {
+			handleErrorResponse(c, err)
+			return
+		}
 	}
 
 	c.JSON(http.StatusOK, triggerCreated)


### PR DESCRIPTION
- What I did
Add trigger annotation so that you do not have to get the trigger to have its http endpoint

- How I did it
Called the annotator from trigger create

- How to verify it
Create a trigger and check annotations for the http endpoint

- One line description for the changelog
Annotate httpendpoint to trigger on create

- One moving picture involving robots (not mandatory but encouraged)
https://giphy.com/embed/CgfteGy1ZPYPu

Fixes #1178 