### PR TITLE
disable user function logs at debug level configuration

### DIFF
--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -342,7 +342,7 @@ func TestLoggerIsStringerAndWorks(t *testing.T) {
 	// TODO test limit writer, logrus writer, etc etc
 
 	var call models.Call
-	logger := setupLogger(context.Background(), 1*1024*1024, &call)
+	logger := setupLogger(context.Background(), 1*1024*1024, true, &call)
 
 	if _, ok := logger.(fmt.Stringer); !ok {
 		// NOTE: if you are reading, maybe what you've done is ok, but be aware we were relying on this for optimization...
@@ -366,7 +366,7 @@ func TestLoggerIsStringerAndWorks(t *testing.T) {
 func TestLoggerTooBig(t *testing.T) {
 
 	var call models.Call
-	logger := setupLogger(context.Background(), 10, &call)
+	logger := setupLogger(context.Background(), 10, true, &call)
 
 	str := fmt.Sprintf("0 line\n1 l\n-----max log size 10 bytes exceeded, truncating log-----\n")
 

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -431,7 +431,7 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 
 	c.handler = a.da
 	c.ct = a
-	c.stderr = setupLogger(c.req.Context(), a.cfg.MaxLogSize, c.Call)
+	c.stderr = setupLogger(c.req.Context(), a.cfg.MaxLogSize, !a.cfg.DisableDebugUserLogs, c.Call)
 	if c.w == nil {
 		// send STDOUT to logs if no writer given (async...)
 		// TODO we could/should probably make this explicit to GetCall, ala 'WithLogger', but it's dupe code (who cares?)

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	EnableNBResourceTracker bool          `json:"enable_nb_resource_tracker"`
 	MaxTmpFsInodes          uint64        `json:"max_tmpfs_inodes"`
 	DisableReadOnlyRootFs   bool          `json:"disable_readonly_rootfs"`
+	DisableDebugUserLogs    bool          `json:"disable_debug_user_logs"`
 }
 
 const (
@@ -83,6 +84,8 @@ const (
 	EnvMaxTmpFsInodes = "FN_MAX_TMPFS_INODES"
 	// EnvDisableReadOnlyRootFs makes the root fs for a container have rw permissions, by default it is read only
 	EnvDisableReadOnlyRootFs = "FN_DISABLE_READONLY_ROOTFS"
+	// EnvDisableDebugUserLogs disables user function logs being logged at level debug. wise to enable for production.
+	EnvDisableDebugUserLogs = "FN_DISABLE_DEBUG_USER_LOGS"
 
 	// MaxMsDisabled is used to determine whether mr freeze is lying in wait. TODO remove this manuever
 	MaxMsDisabled = time.Duration(math.MaxInt64)
@@ -136,6 +139,9 @@ func NewConfig() (*Config, error) {
 	}
 	if _, ok := os.LookupEnv(EnvDisableReadOnlyRootFs); ok {
 		cfg.DisableReadOnlyRootFs = true
+	}
+	if _, ok := os.LookupEnv(EnvDisableDebugUserLogs); ok {
+		cfg.DisableDebugUserLogs = true
 	}
 
 	if cfg.EjectIdle == time.Duration(0) {


### PR DESCRIPTION
- Link to issue this resolves

closes #1147 

- What I did

added an env var FN_DISABLE_DEBUG_USER_LOGS to keep user logs from being logged at debug level. whether they're being logged to stderr is dependent on log level, even if it's info this will be a speedup, and if the level is in debug, it's likely a production installation will not want to be able to access these (yet still want debug logs for the system). 

- How to verify it

start it up

- One line description for the changelog

add ability to disable user function logs to debug logs
