### PR TITLE
#1180 Provides pluggable option to modify HTTP headers of a function call

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -206,10 +206,13 @@ var (
 		code:  http.StatusBadRequest,
 		error: fmt.Errorf("Invalid annotation change, new key(s) exceed maximum permitted number of annotations keys (%d)", maxAnnotationsKeys),
 	}
-
 	ErrAsyncUnsupported = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Async functions are not supported on this server"),
+	}
+	ErrCopyResponseFromBufferFailed = err{
+		code:  http.StatusInternalServerError,
+		error: errors.New("Failed to process buffered response"),
 	}
 )
 

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -142,15 +142,6 @@ type syncResponseWriter struct {
 func (s *syncResponseWriter) Header() http.Header  { return s.headers }
 func (s *syncResponseWriter) WriteHeader(code int) { s.status = code }
 
-// FunctionResponseModifier is a function that allows the HTTP response
-// from a function invocation to be modified
-type FunctionResponseModifier interface {
-	// ModifyResponse provides the ability to mutate the headers of the
-	// HTTP response from a function. The same mechanism could be used
-	// to mutate the body in the future if necessary.
-	ModifyHeaders(rw http.Header)
-}
-
 func (s *Server) writeBufferedResponse(bw *syncResponseWriter, rw http.ResponseWriter) error {
 	// first modify the header via the option, prior to computing Content-Length or
 	// further sanitization

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -2,9 +2,6 @@ package server
 
 import (
 	"bytes"
-	"io"
-	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/fnproject/fn/api"
@@ -79,26 +76,5 @@ func (s *Server) ServeFnInvoke(c *gin.Context, app *models.App, fn *models.Fn) e
 		return err
 	}
 
-	// if they don't set a content-type - detect it
-	if writer.Header().Get("Content-Type") == "" {
-		// see http.DetectContentType, the go server is supposed to do this for us but doesn't appear to?
-		var contentType string
-		jsonPrefix := [1]byte{'{'} // stack allocated
-		if bytes.HasPrefix(buf.Bytes(), jsonPrefix[:]) {
-			// try to detect json, since DetectContentType isn't a hipster.
-			contentType = "application/json; charset=utf-8"
-		} else {
-			contentType = http.DetectContentType(buf.Bytes())
-		}
-		writer.Header().Set("Content-Type", contentType)
-	}
-
-	writer.Header().Set("Content-Length", strconv.Itoa(int(buf.Len())))
-
-	if writer.status > 0 {
-		c.Writer.WriteHeader(writer.status)
-	}
-	io.Copy(c.Writer, &writer)
-
-	return nil
+	return s.writeBufferedResponse(&writer, c.Writer)
 }

--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -431,3 +431,50 @@ func TestInvokeRunnerMinimalConcurrentHotSync(t *testing.T) {
 		}
 	}
 }
+
+func TestInvokeRunnerWithResponseModifier(t *testing.T) {
+	buf := setLogBuffer()
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	httpFn := &models.Fn{ID: "fn_id", Name: "http", AppID: app.ID, Format: "http", Image: "fnproject/fn-test-utils", ResourceConfig: models.ResourceConfig{Memory: 128, Timeout: 4, IdleTimeout: 30}}
+
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Fn{httpFn},
+	)
+
+	rnr, cancel := testRunner(t, ds)
+	defer cancel()
+	logDB := logs.NewMock()
+	srv := testServer(ds, &mqs.Mock{}, logDB, rnr, ServerTypeFull, WithFunctionResponseModifier(&resModifier{}))
+
+	for i, test := range []struct {
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{"/invoke/fn_id", "", http.StatusOK, nil},
+	} {
+		_, rec := routerRequest(t, srv.Router, "POST", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Fatalf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
+		}
+
+		if rec.Header().Get("xxx-foo") != "bar" {
+			t.Fatalf("Expected header to be set by function response modifier")
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`, but got `%s`",
+					i, test.expectedError.Error(), resp.Message)
+			}
+		}
+	}
+}

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -620,3 +620,60 @@ func TestTriggerRunnerMinimalConcurrentHotSync(t *testing.T) {
 		}
 	}
 }
+
+type resModifier struct {
+}
+
+func (r *resModifier) ModifyHeaders(rw http.Header) {
+	rw.Add("xxx-foo", "bar")
+}
+
+func TestTriggerRunnerWithResponseModifier(t *testing.T) {
+	buf := setLogBuffer()
+	app := &models.App{ID: "app_id", Name: "myapp", Config: models.Config{}}
+	httpFn := &models.Fn{ID: "cold", Name: "http", AppID: app.ID, Format: "http", Image: "fnproject/fn-test-utils", ResourceConfig: models.ResourceConfig{Memory: 128, Timeout: 4, IdleTimeout: 30}}
+
+	ds := datastore.NewMockInit(
+		[]*models.App{app},
+		[]*models.Fn{httpFn},
+		[]*models.Trigger{
+			{ID: "1", Name: "1", Source: "/hot", Type: "http", AppID: app.ID, FnID: httpFn.ID},
+		},
+	)
+
+	rnr, cancel := testRunner(t, ds)
+	defer cancel()
+	logDB := logs.NewMock()
+	srv := testServer(ds, &mqs.Mock{}, logDB, rnr, ServerTypeFull, WithFunctionResponseModifier(&resModifier{}))
+
+	for i, test := range []struct {
+		path          string
+		body          string
+		expectedCode  int
+		expectedError error
+	}{
+		{"/t/myapp/hot", "", http.StatusOK, nil},
+	} {
+		_, rec := routerRequest(t, srv.Router, "GET", test.path, nil)
+
+		if rec.Code != test.expectedCode {
+			t.Log(buf.String())
+			t.Fatalf("Test %d: Expected status code for path %s to be %d but was %d",
+				i, test.path, test.expectedCode, rec.Code)
+		}
+
+		if rec.Header().Get("xxx-foo") != "bar" {
+			t.Fatalf("Expected header to be set by function response modifier")
+		}
+
+		if test.expectedError != nil {
+			resp := getErrorResponse(t, rec)
+
+			if !strings.Contains(resp.Message, test.expectedError.Error()) {
+				t.Log(buf.String())
+				t.Errorf("Test %d: Expected error message to have `%s`, but got `%s`",
+					i, test.expectedError.Error(), resp.Message)
+			}
+		}
+	}
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -592,14 +592,6 @@ func WithFnAnnotator(provider FnAnnotator) Option {
 	}
 }
 
-// WithFunctionResponseModifier adds a function that can modify
-func WithFunctionResponseModifier(modifier FunctionResponseModifier) Option {
-	return func(ctx context.Context, s *Server) error {
-		s.responseModifier = modifier
-		return nil
-	}
-}
-
 // WithAdminServer starts the admin server on the specified port.
 func WithAdminServer(port int) Option {
 	return func(ctx context.Context, s *Server) error {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -206,6 +206,7 @@ type Server struct {
 	promExporter           *prometheus.Exporter
 	triggerAnnotator       TriggerAnnotator
 	fnAnnotator            FnAnnotator
+	responseModifier       FunctionResponseModifier
 	// Extensions can append to this list of contexts so that cancellations are properly handled.
 	extraCtxs []context.Context
 }
@@ -587,6 +588,14 @@ func WithTriggerAnnotator(provider TriggerAnnotator) Option {
 func WithFnAnnotator(provider FnAnnotator) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.fnAnnotator = provider
+		return nil
+	}
+}
+
+// WithFunctionResponseModifier adds a function that can modify
+func WithFunctionResponseModifier(modifier FunctionResponseModifier) Option {
+	return func(ctx context.Context, s *Server) error {
+		s.responseModifier = modifier
 		return nil
 	}
 }

--- a/api/server/server_options.go
+++ b/api/server/server_options.go
@@ -86,3 +86,20 @@ func (e errTooBig) Code() int { return http.StatusRequestEntityTooLarge }
 func (e errTooBig) Error() string {
 	return fmt.Sprintf("Content-Length too large for this server, %d > max %d", e.n, e.max)
 }
+
+// FunctionResponseModifier is a function that allows the HTTP response
+// from a function invocation to be modified
+type FunctionResponseModifier interface {
+	// ModifyResponse provides the ability to mutate the headers of the
+	// HTTP response from a function. The same mechanism could be used
+	// to mutate the body in the future if necessary.
+	ModifyHeaders(rw http.Header)
+}
+
+// WithFunctionResponseModifier adds a function that can modify
+func WithFunctionResponseModifier(modifier FunctionResponseModifier) Option {
+	return func(ctx context.Context, s *Server) error {
+		s.responseModifier = modifier
+		return nil
+	}
+}


### PR DESCRIPTION
- Link to issue this resolves
#1180 

- What I did
I added a server option that provides access to headers so they can be added/removed prior to committing a response. See `WithFunctionResponseModifier`.

- How to verify it
I added tests that use the above option for triggers, fn invoke and route calls.

- One line description for the changelog
Provides pluggable option to modify HTTP headers of a function call
