### PR TITLE
Pass right context in call to datastore.UpdateTrigger

### DIFF
--- a/api/server/trigger_update.go
+++ b/api/server/trigger_update.go
@@ -31,7 +31,8 @@ func (s *Server) handleTriggerUpdate(c *gin.Context) {
 		}
 	}
 
-	triggerUpdated, err := s.datastore.UpdateTrigger(c, trigger)
+	ctx := c.Request.Context()
+	triggerUpdated, err := s.datastore.UpdateTrigger(ctx, trigger)
 	if err != nil {
 		handleErrorResponse(c, err)
 		return


### PR DESCRIPTION
- Link to issue this resolves
NA

- What I did
Code fix to preserve right context when call is made to datastore.UpdateTrigger.

- How I did it
One line fix

- How to verify it
Create a middleware to set some value in context.
Create app, fn, trigger
Update trigger
Before fix: verify that the value is not present in context when seen in UpdateTrigger method.
After fix: verify that the value is present in context.

- One line description for the changelog
Pass the right context object in call to datastore.UpdateTrigger

- One moving picture involving robots (not mandatory but encouraged)