### PR TITLE
fn: add http.Server options for web/admin/grpc services in server

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -155,7 +155,7 @@ func apiMetricsWrap(s *Server) {
 
 	r := s.Router
 	r.Use(measure(r))
-	if s.webListenPort != s.adminListenPort {
+	if s.svcConfigs[WebServer].Addr != s.svcConfigs[AdminServer].Addr {
 		a := s.AdminRouter
 		a.Use(measure(a))
 	}


### PR DESCRIPTION
This allows to time limit slow/malicious clients when
reading HTTP headers. In GetBody() buffering, same timeout
can be used to time limit to give consistent I/O wait
limits for the service in addition to per handler
imposed limits we already have.
