### PR TITLE
WIP: Copy 'logs' and 'calls' across from swagger v1 to swagger v2.

### DIFF
--- a/api/agent/data_access.go
+++ b/api/agent/data_access.go
@@ -192,7 +192,7 @@ func (da *directDataAccess) Finish(ctx context.Context, mCall *models.Call, stde
 		// note: Not returning err here since the job could have already finished successfully.
 	}
 
-	if err := da.ls.InsertLog(ctx, mCall.AppID, mCall.ID, stderr); err != nil {
+	if err := da.ls.InsertLog(ctx, mCall.AppID, mCall.FnID, mCall.ID, stderr); err != nil {
 		common.Logger(ctx).WithError(err).Error("error uploading log")
 		// note: Not returning err here since the job could have already finished successfully.
 	}

--- a/api/const.go
+++ b/api/const.go
@@ -17,7 +17,7 @@ const (
 	// ParamTriggerID is the url path parameter for trigger id
 	ParamTriggerID string = "triggerID"
 	// ParamCallID is the url path parameter for call id
-	ParamCallID string = "call"
+	ParamCallID string = "callID"
 	// ParamFnID is the url path parameter for fn id
 	ParamFnID string = "fnID"
 	// ParamTriggerSource is the triggers source parameter

--- a/api/datastore/sql/migrations/18_add_fnid_call.go
+++ b/api/datastore/sql/migrations/18_add_fnid_call.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up18(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE calls ADD fn_id string;")
+
+	return err
+}
+
+func down18(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE calls DROP COLUMN fn_id;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(18),
+		UpFunc:      up18,
+		DownFunc:    down18,
+	})
+}

--- a/api/datastore/sql/migrations/19_add_callid_log.go
+++ b/api/datastore/sql/migrations/19_add_callid_log.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up19(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE logs ADD call_id string;")
+
+	return err
+}
+
+func down19(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE logs DROP COLUMN call_id;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(19),
+		UpFunc:      up19,
+		DownFunc:    down19,
+	})
+}

--- a/api/datastore/sql/migrations/20_add_fnid_logs.go
+++ b/api/datastore/sql/migrations/20_add_fnid_logs.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up20(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE logs ADD fn_id string;")
+
+	return err
+}
+
+func down20(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE logs DROP COLUMN fn_id;")
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(20),
+		UpFunc:      up20,
+		DownFunc:    down20,
+	})
+}

--- a/api/logs/metrics/metrics.go
+++ b/api/logs/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/fnproject/fn/api/models"
@@ -22,28 +23,29 @@ func (m *metricls) InsertCall(ctx context.Context, call *models.Call) error {
 	return m.ls.InsertCall(ctx, call)
 }
 
-func (m *metricls) GetCall(ctx context.Context, appName, callID string) (*models.Call, error) {
+func (m *metricls) GetCall(ctx context.Context, callID string) (*models.Call, error) {
 	ctx, span := trace.StartSpan(ctx, "ls_get_call")
 	defer span.End()
-	return m.ls.GetCall(ctx, appName, callID)
+	return m.ls.GetCall(ctx, callID)
 }
 
-func (m *metricls) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*models.Call, error) {
+func (m *metricls) GetCalls(ctx context.Context, filter *models.CallFilter) (*models.CallList, error) {
 	ctx, span := trace.StartSpan(ctx, "ls_get_calls")
 	defer span.End()
 	return m.ls.GetCalls(ctx, filter)
 }
 
-func (m *metricls) InsertLog(ctx context.Context, appName, callID string, callLog io.Reader) error {
+func (m *metricls) InsertLog(ctx context.Context, appName, fnName, callID string, callLog io.Reader) error {
 	ctx, span := trace.StartSpan(ctx, "ls_insert_log")
 	defer span.End()
-	return m.ls.InsertLog(ctx, appName, callID, callLog)
+	return m.ls.InsertLog(ctx, appName, fnName, callID, callLog)
 }
 
-func (m *metricls) GetLog(ctx context.Context, appName, callID string) (io.Reader, error) {
+func (m *metricls) GetLog(ctx context.Context, callID string) (io.Reader, error) {
+	fmt.Println("Get Log1 ")
 	ctx, span := trace.StartSpan(ctx, "ls_get_log")
 	defer span.End()
-	return m.ls.GetLog(ctx, appName, callID)
+	return m.ls.GetLog(ctx, callID)
 }
 
 func (m *metricls) Close() error {

--- a/api/logs/testing/test.go
+++ b/api/logs/testing/test.go
@@ -153,11 +153,11 @@ func Test(t *testing.T, fnl models.LogStore) {
 		call.ID = id.New().String()
 		logText := "test"
 		log := strings.NewReader(logText)
-		err := fnl.InsertLog(ctx, call.AppID, call.ID, log)
+		err := fnl.InsertLog(ctx, call.AppID, call.FnID, call.ID, log)
 		if err != nil {
 			t.Fatalf("Test InsertLog(ctx, call.ID, logText): unexpected error during inserting log `%v`", err)
 		}
-		logEntry, err := fnl.GetLog(ctx, call.AppID, call.ID)
+		logEntry, err := fnl.GetLog(ctx, call.ID)
 		var b bytes.Buffer
 		io.Copy(&b, logEntry)
 		if !strings.Contains(b.String(), logText) {
@@ -168,7 +168,7 @@ func Test(t *testing.T, fnl models.LogStore) {
 
 	t.Run("call-log-not-found", func(t *testing.T) {
 		call.ID = id.New().String()
-		_, err := fnl.GetLog(ctx, call.AppID, call.ID)
+		_, err := fnl.GetLog(ctx, call.AppID, call.FnID, call.ID)
 		if err != models.ErrCallLogNotFound {
 			t.Fatal("GetLog should return not found, but got:", err)
 		}

--- a/api/logs/validator/validator.go
+++ b/api/logs/validator/validator.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/fnproject/fn/api/models"
@@ -16,25 +17,26 @@ type validator struct {
 }
 
 // callID or appID will never be empty.
-func (v *validator) InsertLog(ctx context.Context, appID, callID string, callLog io.Reader) error {
+func (v *validator) InsertLog(ctx context.Context, appID, fnID, callID string, callLog io.Reader) error {
 	if callID == "" {
 		return models.ErrDatastoreEmptyCallID
 	}
 	if appID == "" {
 		return models.ErrMissingAppID
 	}
-	return v.LogStore.InsertLog(ctx, appID, callID, callLog)
+	if fnID == "" {
+		return models.ErrMissingFnID
+	}
+	fmt.Println("Inserting log")
+	return v.LogStore.InsertLog(ctx, appID, fnID, callID, callLog)
 }
 
 // callID or appID will never be empty.
-func (v *validator) GetLog(ctx context.Context, appID, callID string) (io.Reader, error) {
+func (v *validator) GetLog(ctx context.Context, callID string) (io.Reader, error) {
 	if callID == "" {
 		return nil, models.ErrDatastoreEmptyCallID
 	}
-	if appID == "" {
-		return nil, models.ErrMissingAppID
-	}
-	return v.LogStore.GetLog(ctx, appID, callID)
+	return v.LogStore.GetLog(ctx, callID)
 }
 
 // callID or appID will never be empty.
@@ -45,16 +47,16 @@ func (v *validator) InsertCall(ctx context.Context, call *models.Call) error {
 	if call.AppID == "" {
 		return models.ErrMissingAppID
 	}
+	if call.FnID == "" {
+		return models.ErrMissingFnID
+	}
 	return v.LogStore.InsertCall(ctx, call)
 }
 
 // callID or appID will never be empty.
-func (v *validator) GetCall(ctx context.Context, appID, callID string) (*models.Call, error) {
+func (v *validator) GetCall(ctx context.Context, callID string) (*models.Call, error) {
 	if callID == "" {
 		return nil, models.ErrDatastoreEmptyCallID
 	}
-	if appID == "" {
-		return nil, models.ErrMissingAppID
-	}
-	return v.LogStore.GetCall(ctx, appID, callID)
+	return v.LogStore.GetCall(ctx, callID)
 }

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -163,8 +163,14 @@ type Call struct {
 type CallFilter struct {
 	Path     string // match
 	AppID    string // match
+	FnID     string // match
 	FromTime common.DateTime
 	ToTime   common.DateTime
 	Cursor   string
 	PerPage  int
+}
+
+type CallList struct {
+	NextCursor string  `json:"next_cursor, omitempty"`
+	Items      []*Call `json:"items"`
 }

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -47,6 +47,10 @@ var (
 		code:  http.StatusBadRequest,
 		error: errors.New("Missing Name")}
 
+	ErrMissingFnID = err{
+		code:  http.StatusBadRequest,
+		error: errors.New("Missing Fn ID")}
+
 	ErrCreatedAtProvided = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Trigger Created At Provided for Create")}

--- a/api/models/logs.go
+++ b/api/models/logs.go
@@ -8,11 +8,11 @@ import (
 type LogStore interface {
 	// InsertLog will insert the log at callID, overwriting if it previously
 	// existed.
-	InsertLog(ctx context.Context, appID, callID string, callLog io.Reader) error
+	InsertLog(ctx context.Context, appID, fnID, callID string, callLog io.Reader) error
 
 	// GetLog will return the log at callID, an error will be returned if the log
 	// cannot be found.
-	GetLog(ctx context.Context, appID, callID string) (io.Reader, error)
+	GetLog(ctx context.Context, callID string) (io.Reader, error)
 
 	// TODO we should probably allow deletion of a range of logs (also calls)?
 	// common cases for deletion will be:
@@ -25,11 +25,12 @@ type LogStore interface {
 	InsertCall(ctx context.Context, call *Call) error
 
 	// GetCall returns a call at a certain id and app name.
-	GetCall(ctx context.Context, appId, callID string) (*Call, error)
+
+	GetCall(ctx context.Context, callID string) (*Call, error)
 
 	// GetCalls returns a list of calls that satisfy the given CallFilter. If no
 	// calls exist, an empty list and a nil error are returned.
-	GetCalls(ctx context.Context, filter *CallFilter) ([]*Call, error)
+	GetCalls(ctx context.Context, filter *CallFilter) (*CallList, error)
 
 	// Close will close any underlying connections as needed.
 	// Close is not safe to be called from multiple threads.

--- a/api/server/call_get.go
+++ b/api/server/call_get.go
@@ -11,13 +11,12 @@ func (s *Server) handleCallGet(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	callID := c.Param(api.ParamCallID)
-	appID := c.MustGet(api.AppID).(string)
 
-	callObj, err := s.logstore.GetCall(ctx, appID, callID)
+	callObj, err := s.logstore.GetCall(ctx, callID)
 	if err != nil {
-		handleV1ErrorResponse(c, err)
+		handleErrorResponse(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, callResponse{"Successfully loaded call", callObj})
+	c.JSON(http.StatusOK, callObj)
 }

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -7,12 +7,13 @@ import (
 
 	"errors"
 	"fmt"
+	"net/http"
+	"path"
+
 	"github.com/fnproject/fn/api"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"path"
 )
 
 func (s *Server) handleRunnerEnqueue(c *gin.Context) {
@@ -171,7 +172,9 @@ func (s *Server) handleRunnerFinish(c *gin.Context) {
 		// note: Not returning err here since the job could have already finished successfully.
 	}
 
-	if err := s.logstore.InsertLog(ctx, call.AppID, call.ID, strings.NewReader(body.Log)); err != nil {
+	fmt.Println("Body log: ", body.Log)
+
+	if err := s.logstore.InsertLog(ctx, call.AppID, call.FnID, call.ID, strings.NewReader(body.Log)); err != nil {
 		common.Logger(ctx).WithError(err).Error("error uploading log")
 		// note: Not returning err here since the job could have already finished successfully.
 	}

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -17,6 +17,7 @@ import (
 
 // handleFnInvokeCall executes the function, for router handlers
 func (s *Server) handleFnInvokeCall(c *gin.Context) {
+	//ap := c.Param(api.AppID)
 	fnID := c.Param(api.ParamFnID)
 	ctx, _ := common.LoggerWithFields(c.Request.Context(), logrus.Fields{"fnID": fnID})
 	c.Request = c.Request.WithContext(ctx)

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -57,7 +57,7 @@ func testRunner(_ *testing.T, args ...interface{}) (agent.Agent, context.CancelF
 
 func checkLogs(t *testing.T, tnum int, ds models.LogStore, callID string, expected []string) bool {
 
-	logReader, err := ds.GetLog(context.Background(), "myapp", callID)
+	logReader, err := ds.GetLog(context.Background(), "myapp", "myfunc", callID)
 	if err != nil {
 		t.Errorf("Test %d: GetLog for call_id:%s returned err %s",
 			tnum, callID, err.Error())

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1113,6 +1113,11 @@ func (s *Server) bindHandlers(ctx context.Context) {
 			v2.GET("/triggers/:triggerID", s.handleTriggerGet)
 			v2.PUT("/triggers/:triggerID", s.handleTriggerUpdate)
 			v2.DELETE("/triggers/:triggerID", s.handleTriggerDelete)
+
+			v2.GET("/calls", s.handleCallList)
+			v2.GET("/calls/:callID", s.handleCallGet)
+
+			v2.GET("/log", s.handleCallLogGet)
 		}
 
 		if !s.noHybridAPI { // Hybrid API - this should only be enabled on API servers

--- a/docs/swagger_v2.yml
+++ b/docs/swagger_v2.yml
@@ -145,6 +145,75 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /log:
+    get:
+      operationId: "GetCallLogs"
+      summary: "Get Call Logs For An Application."
+      description: "Returns the call logs for a specific Call."
+      tags:
+        - Call
+        - Log
+      parameters:
+        - $ref: '#/parameters/CallIDQuery'
+      responses:
+        200:
+          description: Log found
+          schema:
+            $ref:  '#/definitions/Log'
+        404:
+          description: Log not found.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /calls:
+    get:
+      summary: Get app-bound calls.
+      description: Get app-bound calls can filter to route-bound calls, results returned in created_at, descending order (newest first).
+      tags:
+        - Call
+      parameters:
+        - $ref: '#/parameters/AppIDQuery'
+        - $ref: '#/parameters/FnIDQuery'
+        - $ref: '#/parameters/cursor'
+        - $ref: '#/parameters/perPage'
+        - name: from_time
+          description: Unix timestamp in seconds, of call.created_at to begin the results at, default 0.
+          required: false
+          type: integer
+          in: query
+        - name: to_time
+          description: Unix timestamp in seconds, of call.created_at to end the results at, defaults to latest.
+          required: false
+          type: integer
+          in: query
+      responses:
+        200:
+          description: "List of Calls"
+          schema:
+            $ref:  '#/definitions/CallList'
+        404:
+          description: "Calls not found"
+          schema:
+            $ref: '#/definitions/Error'
+
+  /calls/{callID}:
+    get:
+      summary: Get call information
+      description: Get call information
+      tags:
+        - Call
+      parameters:
+        - $ref: '#/parameters/CallID'
+      responses:
+        200:
+          description: Call found
+          schema:
+            $ref:  '#/definitions/Call'
+        404:
+          description: Call not found.
+          schema:
+            $ref: '#/definitions/Error'
+
   /fns:
     get:
       operationId: "ListFns"
@@ -527,6 +596,7 @@ definitions:
         items:
           $ref: '#/definitions/Fn'
 
+
   Trigger:
     type: object
     properties:
@@ -581,7 +651,156 @@ definitions:
         items:
           $ref: '#/definitions/Trigger'
 
+  # CallsWrapper:
+  #   type: object
+  #   required:
+  #     - calls
+  #   properties:
+  #     next_cursor:
+  #       type: string
+  #       description: cursor to send with subsequent request to receive the next page, if non-empty
+  #       readOnly: true
+  #     calls:
+  #       type: array
+  #       items:
+  #         $ref: '#/definitions/Call'
+  #     error:
+  #       $ref: '#/definitions/ErrorBody'
+
+  # CallWrapper:
+  #   type: object
+  #   required:
+  #     - call
+  #   properties:
+  #     call:
+  #       $ref: '#/definitions/Call'
+  #       description: "Call object."
+
+  # LogWrapper:
+  #   type: object
+  #   required:
+  #     - log
+  #   properties:
+  #     log:
+  #       $ref: '#/definitions/Log'
+  #       description: "Call log entry."
+
+  Log:
+    type: object
+    properties:
+      call_id:
+        type: string
+        description: Call ID
+      log:
+        type: string # maybe bytes, long logs wouldn't fit into string type
+
+  Call:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Call ID.
+        readOnly: true
+      status:
+        type: string
+        description: Call execution status.
+        readOnly: true
+      error:
+        type: string
+        description: Call execution error, if status is 'error'.
+        readOnly: true
+      app_id:
+        type: string
+        description: App ID that is assigned to a route that is being executed.
+        readOnly: true
+      path:
+        type: string
+        description: App route that is being executed.
+        readOnly: true
+      created_at:
+        type: string
+        format: date-time
+        description: Time when call was submitted. Always in UTC.
+        readOnly: true
+      started_at:
+        type: string
+        format: date-time
+        description: Time when call started execution. Always in UTC.
+        readOnly: true
+      completed_at:
+        type: string
+        format: date-time
+        description: Time when call completed, whether it was successul or failed. Always in UTC.
+        readOnly: true
+      stats:
+        type: array
+        items:
+          $ref: '#/definitions/Stat'
+        description: A histogram of stats for a call, each is a snapshot of a calls state at the timestamp.
+        readOnly: true
+
+  CallList:
+    type: object
+    required:
+      - items
+    properties:
+      next_cursor:
+        type: string
+        description: "Cursor to send with subsequent request to recieve next page, if non-empty."
+        readOnly: true
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/Call'
+
+  Stat:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        format: date-time
+      metrics:
+        type: object
+        properties:
+          net_rx:
+            type: integer
+            format: int64
+          net_tx:
+            type: integer
+            format: int64
+          mem_limit:
+            type: integer
+            format: int64
+          mem_usage:
+            type: integer
+            format: int64
+          disk_read:
+            type: integer
+            format: int64
+          disk_write:
+            type: integer
+            format: int64
+          cpu_user:
+            type: integer
+            format: int64
+          cpu_total:
+            type: integer
+            format: int64
+          cpu_kernel:
+            type: integer
+            format: int64
+
   Error:
+    type: object
+    properties:
+      message:
+        type: string
+        readOnly: true
+      fields:
+        type: string
+        readOnly: true
+
+  ErrorBody:
     type: object
     properties:
       message:
@@ -623,6 +842,13 @@ parameters:
     description: "Opaque, unique Trigger ID."
     required: true
     type: string
+  CallID:
+    name: callID
+    in: path
+    description: "Opaque, unique Call ID."
+    required: true
+    type: string
+
 
   FnIDQuery:
     name: fn_id
@@ -634,5 +860,11 @@ parameters:
     name: app_id
     in: query
     description: "Application ID."
+    required: false
+    type: string
+  CallIDQuery:
+    name: call_id
+    in: query
+    description: "Call ID."
     required: false
     type: string


### PR DESCRIPTION
Copied across the 'logs' and 'calls' from swagger v1 to swagger v2 so they are still supported when we remove swagger v1.