### PR TITLE
use tini to run every container

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -219,6 +219,7 @@ func NewDockerDriver(cfg *Config) (drivers.Driver, error) {
 		PreForkNetworks:      cfg.PreForkNetworks,
 		MaxTmpFsInodes:       cfg.MaxTmpFsInodes,
 		EnableReadOnlyRootFs: !cfg.DisableReadOnlyRootFs,
+		EnableTini:           !cfg.DisableTini,
 	})
 }
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	EnableNBResourceTracker bool          `json:"enable_nb_resource_tracker"`
 	MaxTmpFsInodes          uint64        `json:"max_tmpfs_inodes"`
 	DisableReadOnlyRootFs   bool          `json:"disable_readonly_rootfs"`
+	DisableTini             bool          `json:"disable_tini"`
 	DisableDebugUserLogs    bool          `json:"disable_debug_user_logs"`
 }
 
@@ -84,6 +85,8 @@ const (
 	EnvMaxTmpFsInodes = "FN_MAX_TMPFS_INODES"
 	// EnvDisableReadOnlyRootFs makes the root fs for a container have rw permissions, by default it is read only
 	EnvDisableReadOnlyRootFs = "FN_DISABLE_READONLY_ROOTFS"
+	// EnvDisableTini runs containers without using the --init option, for tini pid 1 action
+	EnvDisableTini = "FN_DISABLE_TINI"
 	// EnvDisableDebugUserLogs disables user function logs being logged at level debug. wise to enable for production.
 	EnvDisableDebugUserLogs = "FN_DISABLE_DEBUG_USER_LOGS"
 

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -223,6 +223,7 @@ func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.Containe
 		},
 		HostConfig: &docker.HostConfig{
 			ReadonlyRootfs: drv.conf.EnableReadOnlyRootFs,
+			Init:           drv.conf.EnableTini,
 		},
 		Context: ctx,
 	}

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -224,6 +224,8 @@ const (
 )
 
 type Config struct {
+	// TODO this should all be driver-specific config and not in the
+	// driver package itself. fix if we ever one day try something else
 	Docker               string `json:"docker"`
 	DockerNetworks       string `json:"docker_networks"`
 	DockerLoadFile       string `json:"docker_load_file"`
@@ -235,6 +237,7 @@ type Config struct {
 	PreForkNetworks      string `json:"pre_fork_networks"`
 	MaxTmpFsInodes       uint64 `json:"max_tmpfs_inodes"`
 	EnableReadOnlyRootFs bool   `json:"enable_readonly_rootfs"`
+	EnableTini           bool   `json:"enable_tini"`
 }
 
 func average(samples []Stat) (Stat, bool) {


### PR DESCRIPTION
fixes #1101

additional context:

* this was introduced in docker 1.13 (1/2017), we require docker 17.10
(10/2017), this should not have any issues dependency-wise, as `docker-init`
is in the docker install from that point in time. unless explicitly removed,
it should be in the dind container we use as well...
* the PR that introduced this to docker is
https://github.com/moby/moby/pull/26061 for additional context
* it may be wise to put this through some paces, if anybody has any...
interesting... function containers. the tests seem to work fine, however, and
this shouldn't be something users have to think about (?) at all, just
something that we are doing. this isn't the default in docker for
compatibility reasons, which is maybe a yellow flag but I am not sure tbh
* i've defaulted this to 'on' with the config bit to turn it off, in case it runs into
issues it should be easy to flip it back off without having to deal with a build, etc.
__we need to test on osx and win__ and we can default it to 'off' and turn it on
for any 'serious' deployments if there are issues to keep the out of the box xp working,
it does seem to work on osx (per linked issue above), but i haven't tested that or win myself.
it seems to add about 50ms to the start time, which seems worth it. 
