### PR TITLE
fn: handle client connection close errors

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -18,6 +18,11 @@ var (
 		code:  http.StatusBadRequest,
 		error: errors.New("Invalid JSON"),
 	}
+	ErrClientCancel = err{
+		// The special custom error code to close connection without any response
+		code:  444,
+		error: errors.New("Client cancelled context"),
+	}
 	ErrCallTimeout = err{
 		code:  http.StatusGatewayTimeout,
 		error: errors.New("Timed out"),

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -28,12 +28,15 @@ func simpleError(err error) *models.Error {
 // TODO delete me !
 func handleV1ErrorResponse(ctx *gin.Context, err error) {
 	log := common.Logger(ctx)
-	if ctx.Request.Context().Err() == context.Canceled {
-		log.Info("request canceled")
+
+	w := ctx.Writer
+
+	if ctx.Err() == context.Canceled {
+		log.Info("client context cancelled")
+		w.WriteHeader(models.ErrClientCancel.Code())
 		return
 	}
 
-	w := ctx.Writer
 	var statuscode int
 	if e, ok := err.(models.APIError); ok {
 		if e.Code() >= 500 {
@@ -71,8 +74,10 @@ func writeV1Error(ctx context.Context, w http.ResponseWriter, statuscode int, er
 // HandleErrorResponse used to handle response errors in the same way.
 func HandleErrorResponse(ctx context.Context, w http.ResponseWriter, err error) {
 	log := common.Logger(ctx)
+
 	if ctx.Err() == context.Canceled {
-		log.Info("request canceled")
+		log.Info("client context cancelled")
+		w.WriteHeader(models.ErrClientCancel.Code())
 		return
 	}
 


### PR DESCRIPTION
Handle context Cancel (client closed connection) with special error code HTTP 444. We merely set the status code in this case to make sure stats/metrics record the error code.