### PR TITLE
fn: check context timeout when waiting for non-blocking attach

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -373,6 +373,7 @@ func (drv *DockerDriver) run(ctx context.Context, container string, task drivers
 		InputStream:  task.Input(),
 		OutputStream: mwOut,
 		ErrorStream:  mwErr,
+		Success:      make(chan struct{}),
 		Stream:       true,
 		Stdout:       true,
 		Stderr:       true,


### PR DESCRIPTION
With this change, we no longer allow docker client AttachToContainerNonBlocking
to block on Success channel more than our context deadline/timeout.

