### PR TITLE
Support Fn Calls on V2 api

### DIFF
--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -363,7 +363,6 @@ func (m *mock) GetFns(ctx context.Context, filter *models.FnFilter) (*models.FnL
 			(filter.Name == "" || filter.Name == f.Name) {
 			funcs = append(funcs, f)
 		}
-
 	}
 
 	var nextCursor string

--- a/api/datastore/sql/migratex/migrate.go
+++ b/api/datastore/sql/migratex/migrate.go
@@ -27,6 +27,7 @@ func migrateErr(version int64, up bool, err error) ErrMigration {
 	dir := "up"
 	if !up {
 		dir = "down"
+		version++
 	}
 	return ErrMigration(fmt.Sprintf("error running migration. version: %v direction: %v err: %v", version, dir, err))
 }
@@ -185,7 +186,6 @@ func run(ctx context.Context, tx *sqlx.Tx, m Migration, up bool) error {
 			return fmt.Errorf("non-contiguous migration attempted down: %v != %v", m.Version(), curVersion)
 		}
 
-		// TODO is this robust enough? we could check
 		version := m.Version()
 		if !up {
 			version = m.Version() - 1

--- a/api/datastore/sql/migrations/18_add_fnid_calls.go
+++ b/api/datastore/sql/migrations/18_add_fnid_calls.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/datastore/sql/migratex"
+	"github.com/jmoiron/sqlx"
+)
+
+func up18(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE calls ADD fn_id varchar(256);")
+
+	switch tx.DriverName() {
+	case "mysql":
+		_, err := tx.ExecContext(ctx, "ALTER TABLE calls MODIFY app_id varchar(256) NULL;")
+		return err
+	case "postgres", "pgx":
+		_, err = tx.ExecContext(ctx, "ALTER TABLE calls ALTER COLUMN app_id DROP NOT NULL;")
+		return err
+	}
+
+	return err
+}
+
+func down18(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, "ALTER TABLE calls DROP COLUMN fn_id;")
+
+	switch tx.DriverName() {
+	case "mysql":
+		_, err := tx.ExecContext(ctx, "ALTER TABLE calls MODIFY app_id varchar(256) NOT NULL;")
+		return err
+	case "postgres", "pgx":
+		_, err = tx.ExecContext(ctx, "ALTER TABLE calls ALTER COLUMN app_id SET NOT NULL;")
+		return err
+	}
+
+	return err
+}
+
+func init() {
+	Migrations = append(Migrations, &migratex.MigFields{
+		VersionFunc: vfunc(18),
+		UpFunc:      up18,
+		DownFunc:    down18,
+	})
+}

--- a/api/logs/metrics/metrics.go
+++ b/api/logs/metrics/metrics.go
@@ -22,13 +22,25 @@ func (m *metricls) InsertCall(ctx context.Context, call *models.Call) error {
 	return m.ls.InsertCall(ctx, call)
 }
 
-func (m *metricls) GetCall(ctx context.Context, appName, callID string) (*models.Call, error) {
+func (m *metricls) GetCall1(ctx context.Context, appName, callID string) (*models.Call, error) {
 	ctx, span := trace.StartSpan(ctx, "ls_get_call")
 	defer span.End()
-	return m.ls.GetCall(ctx, appName, callID)
+	return m.ls.GetCall1(ctx, appName, callID)
 }
 
-func (m *metricls) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*models.Call, error) {
+func (m *metricls) GetCall(ctx context.Context, fnID, callID string) (*models.Call, error) {
+	ctx, span := trace.StartSpan(ctx, "ls_get_call")
+	defer span.End()
+	return m.ls.GetCall(ctx, fnID, callID)
+}
+
+func (m *metricls) GetCalls1(ctx context.Context, filter *models.CallFilter) ([]*models.Call, error) {
+	ctx, span := trace.StartSpan(ctx, "ls_get_calls")
+	defer span.End()
+	return m.ls.GetCalls1(ctx, filter)
+}
+
+func (m *metricls) GetCalls(ctx context.Context, filter *models.CallFilter) (*models.CallList, error) {
 	ctx, span := trace.StartSpan(ctx, "ls_get_calls")
 	defer span.End()
 	return m.ls.GetCalls(ctx, filter)

--- a/api/logs/mock.go
+++ b/api/logs/mock.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"io/ioutil"
 	"sort"
@@ -50,9 +51,20 @@ func (m *mock) InsertCall(ctx context.Context, call *models.Call) error {
 	return nil
 }
 
-func (m *mock) GetCall(ctx context.Context, appID, callID string) (*models.Call, error) {
+func (m *mock) GetCall1(ctx context.Context, appID, callID string) (*models.Call, error) {
 	for _, t := range m.Calls {
 		if t.ID == callID && t.AppID == appID {
+			return t, nil
+		}
+	}
+
+	return nil, models.ErrCallNotFound
+}
+
+func (m *mock) GetCall(ctx context.Context, fnID, callID string) (*models.Call, error) {
+	for _, t := range m.Calls {
+		if t.ID == callID &&
+			t.FnID == fnID {
 			return t, nil
 		}
 	}
@@ -66,7 +78,7 @@ func (s sortC) Len() int           { return len(s) }
 func (s sortC) Less(i, j int) bool { return strings.Compare(s[i].ID, s[j].ID) < 0 }
 func (s sortC) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-func (m *mock) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*models.Call, error) {
+func (m *mock) GetCalls1(ctx context.Context, filter *models.CallFilter) ([]*models.Call, error) {
 	// sort them all first for cursoring (this is for testing, n is small & mock is not concurrent..)
 	// calls are in DESC order so use sort.Reverse
 	sort.Sort(sort.Reverse(sortC(m.Calls)))
@@ -88,6 +100,48 @@ func (m *mock) GetCalls(ctx context.Context, filter *models.CallFilter) ([]*mode
 	}
 
 	return calls, nil
+}
+
+func (m *mock) GetCalls(ctx context.Context, filter *models.CallFilter) (*models.CallList, error) {
+	// sort them all first for cursoring (this is for testing, n is small & mock is not concurrent..)
+	// calls are in DESC order so use sort.Reverse
+	sort.Sort(sort.Reverse(sortC(m.Calls)))
+
+	var calls []*models.Call
+
+	var cursor = ""
+	if filter.Cursor != "" {
+		s, err := base64.RawURLEncoding.DecodeString(filter.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		cursor = string(s)
+	}
+
+	for _, c := range m.Calls {
+		if filter.PerPage > 0 && len(calls) == filter.PerPage {
+			break
+		}
+
+		if (cursor == "" || strings.Compare(cursor, c.ID) > 0) &&
+			(filter.FnID == "" || c.FnID == filter.FnID) &&
+			(time.Time(filter.FromTime).IsZero() || time.Time(filter.FromTime).Before(time.Time(c.CreatedAt))) &&
+			(time.Time(filter.ToTime).IsZero() || time.Time(c.CreatedAt).Before(time.Time(filter.ToTime))) {
+
+			calls = append(calls, c)
+		}
+	}
+
+	var nextCursor string
+	if len(calls) > 0 && len(calls) == filter.PerPage {
+		last := []byte(calls[len(calls)-1].ID)
+		nextCursor = base64.RawURLEncoding.EncodeToString(last)
+	}
+
+	return &models.CallList{
+		NextCursor: nextCursor,
+		Items:      calls,
+	}, nil
 }
 
 func (m *mock) Close() error {

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -163,8 +163,14 @@ type Call struct {
 type CallFilter struct {
 	Path     string // match
 	AppID    string // match
+	FnID     string //match
 	FromTime common.DateTime
 	ToTime   common.DateTime
 	Cursor   string
 	PerPage  int
+}
+
+type CallList struct {
+	NextCursor string  `json:"next_cursor,omitempty"`
+	Items      []*Call `json:"items"`
 }

--- a/api/models/logs.go
+++ b/api/models/logs.go
@@ -25,11 +25,18 @@ type LogStore interface {
 	InsertCall(ctx context.Context, call *Call) error
 
 	// GetCall returns a call at a certain id and app name.
-	GetCall(ctx context.Context, appId, callID string) (*Call, error)
+	GetCall1(ctx context.Context, appId, callID string) (*Call, error)
+
+	// GetCall2 returns a call at a certain id
+	GetCall(ctx context.Context, fnID, callID string) (*Call, error)
 
 	// GetCalls returns a list of calls that satisfy the given CallFilter. If no
 	// calls exist, an empty list and a nil error are returned.
-	GetCalls(ctx context.Context, filter *CallFilter) ([]*Call, error)
+	GetCalls1(ctx context.Context, filter *CallFilter) ([]*Call, error)
+
+	// GetCalls returns a list of calls that satisfy the given CallFilter. If no
+	// calls exist, an empty list and a nil error are returned.
+	GetCalls(ctx context.Context, filter *CallFilter) (*CallList, error)
 
 	// Close will close any underlying connections as needed.
 	// Close is not safe to be called from multiple threads.

--- a/api/server/call_get.go
+++ b/api/server/call_get.go
@@ -7,13 +7,28 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) handleCallGet(c *gin.Context) {
+func (s *Server) handleCallGet1(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	callID := c.Param(api.ParamCallID)
 	appID := c.MustGet(api.AppID).(string)
 
-	callObj, err := s.logstore.GetCall(ctx, appID, callID)
+	callObj, err := s.logstore.GetCall1(ctx, appID, callID)
+	if err != nil {
+		handleV1ErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, callResponse{"Successfully loaded call", callObj})
+}
+
+func (s *Server) handleCallGet(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	fnID := c.Param(api.ParamFnID)
+	callID := c.Param(api.ParamCallID)
+
+	callObj, err := s.logstore.GetCall(ctx, fnID, callID)
 	if err != nil {
 		handleV1ErrorResponse(c, err)
 		return

--- a/docs/swagger_v2.yml
+++ b/docs/swagger_v2.yml
@@ -404,6 +404,77 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /fns/{fnID}/calls:
+    get:
+      summary: Get a fns calls.
+      description: Get a functions calls, results returned in created_at, descending order (newest first).
+      tags:
+        - Call
+      parameters:
+        - $ref: '#/parameters/FnID'
+        - $ref: '#/parameters/cursor'
+        - $ref: '#/parameters/perPage'
+        - name: from_time
+          description: Unix timestamp in seconds, of call.created_at to begin the results at, default 0.
+          required: false
+          type: integer
+          in: query
+        - name: to_time
+          description: Unix timestamp in seconds, of call.created_at to end the results at, defaults to latest.
+          required: false
+          type: integer
+          in: query
+      responses:
+        200:
+          description: "List of Calls"
+          schema:
+            $ref:  '#/definitions/CallList'
+        404:
+          description: "Calls not found"
+          schema:
+            $ref: '#/definitions/Error'
+
+  /fns/{fnID}/calls/{callID}:
+    get:
+      summary: Get call information
+      description: Get call information
+      tags:
+        - Call
+      parameters:
+        - $ref: '#/parameters/FnID'
+        - $ref: '#/parameters/CallID'
+      responses:
+        200:
+          description: Call found.
+          schema:
+            $ref:  '#/definitions/Call'
+        404:
+          description: Call not found.
+          schema:
+            $ref: '#/definitions/Error'
+
+  # Implementing next
+  # /fns/{fnID}/calls/{callID}/log:
+  #   get:
+  #     operationId: "GetCallLogs"
+  #     summary: "Get logs for a call."
+  #     description: "Get logs for a call."
+  #     tags:
+  #       - Call
+  #       - Log
+  #     parameters:
+  #       - $ref: '#/parameters/FnIDQuery'
+  #       - $ref: '#/parameters/CallID'
+  #     responses:
+  #       200:
+  #         description: Log found.
+  #         schema:
+  #           $ref:  '#/definitions/Log'
+  #       404:
+  #         description: Log not found.
+  #         schema:
+  #           $ref: '#/definitions/Error'
+
 definitions:
   App:
     type: object
@@ -591,6 +662,102 @@ definitions:
         type: string
         readOnly: true
 
+  Call:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Call ID.
+        readOnly: true
+      status:
+        type: string
+        description: Call execution status.
+        readOnly: true
+      error:
+        type: string
+        description: Call execution error, if status is 'error'.
+        readOnly: true
+      app_id:
+        type: string
+        description: App ID of fn that executed this call.
+        readOnly: true
+      fn_id:
+        type: string
+        description: Fn ID of fn that executed this call.
+        readOnly: true
+      created_at:
+        type: string
+        format: date-time
+        description: Time when call was submitted. Always in UTC.
+        readOnly: true
+      started_at:
+        type: string
+        format: date-time
+        description: Time when call started execution. Always in UTC.
+        readOnly: true
+      completed_at:
+        type: string
+        format: date-time
+        description: Time when call completed, whether it was successul or failed. Always in UTC.
+        readOnly: true
+      stats:
+        type: array
+        items:
+          $ref: '#/definitions/Stat'
+        description: A histogram of stats for a call, each is a snapshot of a calls state at the timestamp.
+        readOnly: true
+
+  CallList:
+    type: object
+    required:
+      - items
+    properties:
+      next_cursor:
+        type: string
+        description: "Cursor to send with subsequent request to recieve next page, if non-empty."
+        readOnly: true
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/Call'
+
+  Stat:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        format: date-time
+      metrics:
+        type: object
+        properties:
+          net_rx:
+            type: integer
+            format: int64
+          net_tx:
+            type: integer
+            format: int64
+          mem_limit:
+            type: integer
+            format: int64
+          mem_usage:
+            type: integer
+            format: int64
+          disk_read:
+            type: integer
+            format: int64
+          disk_write:
+            type: integer
+            format: int64
+          cpu_user:
+            type: integer
+            format: int64
+          cpu_total:
+            type: integer
+            format: int64
+          cpu_kernel:
+            type: integer
+            format: int64
+
 parameters:
   cursor:
     name: cursor
@@ -621,6 +788,12 @@ parameters:
     name: triggerID
     in: path
     description: "Opaque, unique Trigger ID."
+    required: true
+    type: string
+  CallID:
+    name: callID
+    in: path
+    description: "Opaque, unique Call ID."
     required: true
     type: string
 


### PR DESCRIPTION
The V2 Calls api endpoints have been added beneath fns:

  /fns/{fnID}/calls
  /fns/{fnID}/calls/{callID}

The S3 implementation forces our hand as we if we want to list Calls
under a Fn, we have to use the FnID as a prefix on the object names,
which mean we need it to look up any Call. It also makes sense in
terms of resource hierarchy.

These endpoints can optionally be disabled (as other endpoints), if a
service provider needs to provide this functionality via other means.

The 'calls' test has been fully migrated to fn calls. This has been
done to reduce the copy pasta a bit, and on balance is ok as the
routes calls will be removed soon.
