### PR TITLE
Adds key existence check to config equality

### DIFF
--- a/api/models/config.go
+++ b/api/models/config.go
@@ -20,8 +20,7 @@ func (c1 Config) Equals(c2 Config) bool {
 		return false
 	}
 	for k1, v1 := range c1 {
-		v2, _ := c2[k1]
-		if v1 != v2 {
+		if v2, ok := c2[k1]; !ok || v1 != v2 {
 			return false
 		}
 	}


### PR DESCRIPTION
The config equality test doesn't check that keys exist between config
maps. Meaning that when two maps, both with a single, yet differing
key, with the lefts value being "", the default string, are compared they are
considered equal.

This change uses the two value assignment version of the map get,
allowing it to test for key existence.