### PR TITLE
Changes README hello world example to use invoke in the absence of ro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,8 @@ fn deploy --app myapp --local
 Now you can call your function:
 
 ```sh
-curl http://localhost:8080/r/myapp/hello
-# or:
-fn call myapp /hello
+fn invoke myapp hello
 ```
-
-Or in a browser: [http://localhost:8080/r/myapp/hello](http://localhost:8080/r/myapp/hello)
 
 That's it! You just deployed your first function and called it. Try updating the function code in `func.go` then deploy it again to see the change.
 


### PR DESCRIPTION
Hello world example is broken because a default route is not created when creating an app/function with the latest CLI. Instead, `fn invoke` should be used to call the function.