### PR TITLE
fn: paused and evicted container stats

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -945,12 +945,17 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 			return false
 		}
 		isFrozen = true
+		state.UpdateState(ctx, ContainerStatePaused, call.slots)
 	}
 
 	evictor := a.evictor.GetEvictor(call.ID, call.slotHashId, call.Memory+uint64(call.TmpFsSize), uint64(call.CPUs))
 
-	state.UpdateState(ctx, ContainerStateIdle, call.slots)
+	if !isFrozen {
+		state.UpdateState(ctx, ContainerStateIdle, call.slots)
+	}
 	s := call.slots.queueSlot(slot)
+
+	isEvictEvent := false
 
 	for {
 		select {
@@ -965,10 +970,12 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 					return false
 				}
 				isFrozen = true
+				state.UpdateState(ctx, ContainerStatePaused, call.slots)
 			}
 			continue
 		case <-evictor.C:
 			logger.Debug("attempting hot function eject")
+			isEvictEvent = true
 		case <-ejectTimer.C:
 			// we've been idle too long, now we are ejectable
 			a.evictor.RegisterEvictor(evictor)
@@ -987,6 +994,9 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 	// otherwise continue processing the request
 	if call.slots.acquireSlot(s) {
 		slot.Close(ctx)
+		if isEvictEvent {
+			statsContainerEvicted(ctx)
+		}
 		return false
 	}
 

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -163,6 +163,7 @@ func (a *slotQueue) isIdle() bool {
 		a.stats.containerStates[ContainerStateWait] == 0 &&
 		a.stats.containerStates[ContainerStateStart] == 0 &&
 		a.stats.containerStates[ContainerStateIdle] == 0 &&
+		a.stats.containerStates[ContainerStatePaused] == 0 &&
 		a.stats.containerStates[ContainerStateBusy] == 0
 
 	a.statsLock.Unlock()
@@ -180,7 +181,7 @@ func (a *slotQueue) getStats() slotQueueStats {
 
 func isNewContainerNeeded(cur *slotQueueStats) bool {
 
-	idleWorkers := cur.containerStates[ContainerStateIdle]
+	idleWorkers := cur.containerStates[ContainerStateIdle] + cur.containerStates[ContainerStatePaused]
 	starters := cur.containerStates[ContainerStateStart]
 	startWaiters := cur.containerStates[ContainerStateWait]
 


### PR DESCRIPTION
With this change, now stats reports paused state
as well as incidents of container exit due to evictions.

