### PR TITLE
support configuration-based relative dirs (host and agent) for iofs

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	DisableReadOnlyRootFs   bool          `json:"disable_readonly_rootfs"`
 	DisableTini             bool          `json:"disable_tini"`
 	DisableDebugUserLogs    bool          `json:"disable_debug_user_logs"`
-	IOFSPath                string        `json:"iofs_path"`
+	IOFSAgentPath           string        `json:"iofs_path"`
 	IOFSMountRoot           string        `json:"iofs_mount_root"`
 	IOFSOpts                string        `json:"iofs_opts"`
 }
@@ -89,8 +89,8 @@ const (
 
 	// EnvIOFSPath is the path within fn server container of a directory to configure for unix socket files for each container
 	EnvIOFSPath = "FN_IOFS_PATH"
-	// EnvIOFSMountRoot determines the relative location on the docker host where iofs mounts should be prefixed with
-	EnvIOFSMountRoot = "FN_IOFS_MOUNT_ROOT"
+	// EnvIOFSDockerPath determines the relative location on the docker host where iofs mounts should be prefixed with
+	EnvIOFSDockerPath = "FN_IOFS_DOCKER_PATH"
 
 	// EnvIOFSOpts are the options to set when mounting the iofs directory for unix socket files
 	EnvIOFSOpts = "FN_IOFS_OPTS"
@@ -134,8 +134,8 @@ func NewConfig() (*Config, error) {
 	err = setEnvStr(err, EnvDockerNetworks, &cfg.DockerNetworks)
 	err = setEnvStr(err, EnvDockerLoadFile, &cfg.DockerLoadFile)
 	err = setEnvUint(err, EnvMaxTmpFsInodes, &cfg.MaxTmpFsInodes)
-	err = setEnvStr(err, EnvIOFSPath, &cfg.IOFSPath)
-	err = setEnvStr(err, EnvIOFSMountRoot, &cfg.IOFSMountRoot)
+	err = setEnvStr(err, EnvIOFSPath, &cfg.IOFSAgentPath)
+	err = setEnvStr(err, EnvIOFSDockerPath, &cfg.IOFSMountRoot)
 	err = setEnvStr(err, EnvIOFSOpts, &cfg.IOFSOpts)
 
 	if err != nil {

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	DisableTini             bool          `json:"disable_tini"`
 	DisableDebugUserLogs    bool          `json:"disable_debug_user_logs"`
 	IOFSPath                string        `json:"iofs_path"`
+	IOFSMountRoot           string        `json:"iofs_mount_root"`
 	IOFSOpts                string        `json:"iofs_opts"`
 }
 
@@ -85,8 +86,12 @@ const (
 	EnvDisableTini = "FN_DISABLE_TINI"
 	// EnvDisableDebugUserLogs disables user function logs being logged at level debug. wise to enable for production.
 	EnvDisableDebugUserLogs = "FN_DISABLE_DEBUG_USER_LOGS"
-	// EnvIOFSPath is the path of a directory to configure for unix socket files for each container
+
+	// EnvIOFSPath is the path within fn server container of a directory to configure for unix socket files for each container
 	EnvIOFSPath = "FN_IOFS_PATH"
+	// EnvIOFSMountRoot determines the relative location on the docker host where iofs mounts should be prefixed with
+	EnvIOFSMountRoot = "FN_IOFS_MOUNT_ROOT"
+
 	// EnvIOFSOpts are the options to set when mounting the iofs directory for unix socket files
 	EnvIOFSOpts = "FN_IOFS_OPTS"
 
@@ -130,6 +135,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvStr(err, EnvDockerLoadFile, &cfg.DockerLoadFile)
 	err = setEnvUint(err, EnvMaxTmpFsInodes, &cfg.MaxTmpFsInodes)
 	err = setEnvStr(err, EnvIOFSPath, &cfg.IOFSPath)
+	err = setEnvStr(err, EnvIOFSMountRoot, &cfg.IOFSMountRoot)
 	err = setEnvStr(err, EnvIOFSOpts, &cfg.IOFSOpts)
 
 	if err != nil {
@@ -163,6 +169,20 @@ func setEnvStr(err error, name string, dst *string) error {
 	}
 	if tmp, ok := os.LookupEnv(name); ok {
 		*dst = tmp
+	}
+	return nil
+}
+
+func setEnvBool(err error, name string, dst *bool) error {
+	if err != nil {
+		return err
+	}
+	if tmp, ok := os.LookupEnv(name); ok {
+		val, err := strconv.ParseBool(tmp)
+		if err != nil {
+			return err
+		}
+		*dst = val
 	}
 	return nil
 }

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -106,7 +106,7 @@ func (c *cookie) configureTmpFs(log logrus.FieldLogger) {
 }
 
 func (c *cookie) configureIOFs(log logrus.FieldLogger) {
-	path := c.task.UDSPath()
+	path := c.task.UDSPathHost()
 	if path == "" {
 		// TODO this should be required soon-ish
 		return

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -106,7 +106,7 @@ func (c *cookie) configureTmpFs(log logrus.FieldLogger) {
 }
 
 func (c *cookie) configureIOFs(log logrus.FieldLogger) {
-	path := c.task.UDSPathHost()
+	path := c.task.UDSDockerPath()
 	if path == "" {
 		// TODO this should be required soon-ish
 		return

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -73,7 +73,8 @@ func (c *poolTask) TmpFsSize() uint64                                { return 0 
 func (c *poolTask) Extensions() map[string]string                    { return nil }
 func (c *poolTask) LoggerConfig() drivers.LoggerConfig               { return drivers.LoggerConfig{} }
 func (c *poolTask) WriteStat(ctx context.Context, stat drivers.Stat) {}
-func (c *poolTask) UDSPath() string                                  { return "" }
+func (c *poolTask) UDSPathLocal() string                             { return "" }
+func (c *poolTask) UDSPathHost() string                              { return "" }
 
 type dockerPoolItem struct {
 	id     string

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -73,8 +73,8 @@ func (c *poolTask) TmpFsSize() uint64                                { return 0 
 func (c *poolTask) Extensions() map[string]string                    { return nil }
 func (c *poolTask) LoggerConfig() drivers.LoggerConfig               { return drivers.LoggerConfig{} }
 func (c *poolTask) WriteStat(ctx context.Context, stat drivers.Stat) {}
-func (c *poolTask) UDSPathLocal() string                             { return "" }
-func (c *poolTask) UDSPathHost() string                              { return "" }
+func (c *poolTask) UDSAgentPath() string                             { return "" }
+func (c *poolTask) UDSDockerPath() string                            { return "" }
 
 type dockerPoolItem struct {
 	id     string

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -38,7 +38,8 @@ func (f *taskDockerTest) Close()                                  {}
 func (f *taskDockerTest) Input() io.Reader                        { return f.input }
 func (f *taskDockerTest) Extensions() map[string]string           { return nil }
 func (f *taskDockerTest) LoggerConfig() drivers.LoggerConfig      { return drivers.LoggerConfig{} }
-func (f *taskDockerTest) UDSPath() string                         { return "" }
+func (f *taskDockerTest) UDSPathLocal() string                    { return "" }
+func (f *taskDockerTest) UDSPathHost() string                     { return "" }
 
 func TestRunnerDocker(t *testing.T) {
 	dkr := NewDocker(drivers.Config{})

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -38,8 +38,8 @@ func (f *taskDockerTest) Close()                                  {}
 func (f *taskDockerTest) Input() io.Reader                        { return f.input }
 func (f *taskDockerTest) Extensions() map[string]string           { return nil }
 func (f *taskDockerTest) LoggerConfig() drivers.LoggerConfig      { return drivers.LoggerConfig{} }
-func (f *taskDockerTest) UDSPathLocal() string                    { return "" }
-func (f *taskDockerTest) UDSPathHost() string                     { return "" }
+func (f *taskDockerTest) UDSAgentPath() string                    { return "" }
+func (f *taskDockerTest) UDSDockerPath() string                   { return "" }
 
 func TestRunnerDocker(t *testing.T) {
 	dkr := NewDocker(drivers.Config{})

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -162,9 +162,14 @@ type ContainerTask interface {
 	// more specific but it's easier to be lazy.
 	Extensions() map[string]string
 
-	// UDSPath to use to configure the unix domain socket. the drivers
+	// UDSPathLocal to use to configure the unix domain socket. the drivers
+	// This is the mount point relative to the agent
 	// abstractions have leaked so bad at this point it's a monsoon.
-	UDSPath() string
+	UDSPathLocal() string
+
+	// UDSPathHost to use to configure the unix domain socket. the drivers
+	// This is the mount point relative to the docker host
+	UDSPathHost() string
 }
 
 // Stat is a bucket of stats from a driver at a point in time for a certain task.

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -162,14 +162,14 @@ type ContainerTask interface {
 	// more specific but it's easier to be lazy.
 	Extensions() map[string]string
 
-	// UDSPathLocal to use to configure the unix domain socket. the drivers
+	// UDSAgentPath to use to configure the unix domain socket.
 	// This is the mount point relative to the agent
 	// abstractions have leaked so bad at this point it's a monsoon.
-	UDSPathLocal() string
+	UDSAgentPath() string
 
-	// UDSPathHost to use to configure the unix domain socket. the drivers
-	// This is the mount point relative to the docker host
-	UDSPathHost() string
+	// UDSDockerPath to use to configure the unix domain socket. the drivers
+	// This is the mount point relative to the docker host.
+	UDSDockerPath() string
 }
 
 // Stat is a bucket of stats from a driver at a point in time for a certain task.


### PR DESCRIPTION
I noticed  that http-stream doesn't work on docker4mac - this is because docker mounts volumes relative to the OSX host, not the docker VM. 

This change allows two directory roots for IOFS mounts one with respect to the docker host, one with respect to the agent itself.  The behaviour is conditional on both FN_IOFS_PATH and FN_IOFS_MOUNT_ROOT. 

I've also added the specified headers to the contract (proper HTTP versions rather than the old FN_DEADLINE) as dups , this makes java happy

```
docker run -v $(pwd)/maciofs:/iofs -eFN_LOG_LEVEL=debug  -e FN_IOFS_PATH=/iofs -e FN_IOFS_MOUNT_ROOT=$(pwd)/maciofs  --privileged -v /var/run/docker.sock:/var/run/docker.sock   -p8080:8080  --name fnserver --rm  fnproject/fnserver
```