### PR TITLE
clean up hardcoded lsnr.sock refs, move iofs to /tmp

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -903,7 +903,6 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 	udsAwait := make(chan error)
 	if call.Format == models.FormatHTTPStream {
 		// start our listener before starting the container, so we don't miss the pretty things whispered in our ears
-		// XXX(reed): figure out cleaner way to carry around the directory and expose the lsnr.sock file
 		go inotifyUDS(ctx, container.UDSAgentPath(), udsAwait)
 
 		udsClient = http.Client{
@@ -911,7 +910,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 				// XXX(reed): other settings ?
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					var d net.Dialer
-					return d.DialContext(ctx, "unix", filepath.Join(container.UDSAgentPath(), "lsnr.sock")) // XXX(reed): hardcoded lsnr.sock
+					return d.DialContext(ctx, "unix", filepath.Join(container.UDSAgentPath(), udsFilename))
 				},
 			},
 		}
@@ -1039,8 +1038,7 @@ func inotifyAwait(ctx context.Context, iofsDir string) error {
 			return fmt.Errorf("error watching for iofs: %v", err)
 		case event := <-fsWatcher.Events:
 			common.Logger(ctx).WithField("event", event).Debug("fsnotify event")
-			if event.Op&fsnotify.Create == fsnotify.Create && event.Name == iofsDir+"/lsnr.sock" {
-				// XXX(reed): hardcoded /lsnr.sock path
+			if event.Op&fsnotify.Create == fsnotify.Create && event.Name == filepath.Join(iofsDir, udsFilename) {
 				// wait until the socket file is created by the container
 				return nil
 			}
@@ -1313,6 +1311,7 @@ func (c *container) Extensions() map[string]string      { return c.extensions }
 func (c *container) LoggerConfig() drivers.LoggerConfig { return c.logCfg }
 func (c *container) UDSAgentPath() string               { return c.iofs.AgentPath() }
 func (c *container) UDSDockerPath() string              { return c.iofs.DockerPath() }
+func (c *container) UDSDockerDest() string              { return iofsDockerMountDest }
 
 // WriteStat publishes each metric in the specified Stats structure as a histogram metric
 func (c *container) WriteStat(ctx context.Context, stat drivers.Stat) {

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -204,7 +205,7 @@ func buildConfig(app *models.App, fn *models.Fn, path string) models.Config {
 
 	conf["FN_FORMAT"] = fn.Format
 	if fn.Format == models.FormatHTTPStream { // TODO should be always soon...
-		conf["FN_LISTENER"] = "unix:/iofs/lsnr.sock" // XXX(reed): hardcoding this is ok right? it's a contract
+		conf["FN_LISTENER"] = "unix:" + filepath.Join(iofsDockerMountDest, udsFilename)
 	}
 	conf["FN_APP_NAME"] = app.Name
 	conf["FN_PATH"] = path

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -104,6 +104,14 @@ const (
 
 	// DefaultHotPoll is the default value for EnvHotPoll
 	DefaultHotPoll = 200 * time.Millisecond
+
+	// TODO(reed): none of these consts above or below should be exported yo
+
+	// iofsDockerMountDest is the mount path for inside of the container to use for the iofs path
+	iofsDockerMountDest = "/tmp/iofs"
+
+	// udsFilename is the file name for the uds socket
+	udsFilename = "lsnr.sock"
 )
 
 // NewConfig returns a config set from env vars, plus defaults

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -112,7 +112,7 @@ func (c *cookie) configureIOFS(log logrus.FieldLogger) {
 		return
 	}
 
-	bind := fmt.Sprintf("%s:/iofs", path)
+	bind := fmt.Sprintf("%s:%s", path, c.task.UDSDockerDest())
 	c.opts.HostConfig.Binds = append(c.opts.HostConfig.Binds, bind)
 }
 

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -75,6 +75,7 @@ func (c *poolTask) LoggerConfig() drivers.LoggerConfig               { return dr
 func (c *poolTask) WriteStat(ctx context.Context, stat drivers.Stat) {}
 func (c *poolTask) UDSAgentPath() string                             { return "" }
 func (c *poolTask) UDSDockerPath() string                            { return "" }
+func (c *poolTask) UDSDockerDest() string                            { return "" }
 
 type dockerPoolItem struct {
 	id     string

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -40,6 +40,7 @@ func (f *taskDockerTest) Extensions() map[string]string           { return nil }
 func (f *taskDockerTest) LoggerConfig() drivers.LoggerConfig      { return drivers.LoggerConfig{} }
 func (f *taskDockerTest) UDSAgentPath() string                    { return "" }
 func (f *taskDockerTest) UDSDockerPath() string                   { return "" }
+func (f *taskDockerTest) UDSDockerDest() string                   { return "" }
 
 func TestRunnerDocker(t *testing.T) {
 	dkr := NewDocker(drivers.Config{})

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -170,6 +170,10 @@ type ContainerTask interface {
 	// UDSDockerPath to use to configure the unix domain socket. the drivers
 	// This is the mount point relative to the docker host.
 	UDSDockerPath() string
+
+	// UDSDockerDest is the destination mount point for uds path. it is the path
+	// of the directory where the sock file resides inside of the container.
+	UDSDockerDest() string
 }
 
 // Stat is a bucket of stats from a driver at a point in time for a certain task.


### PR DESCRIPTION
because what drivers.ContainerTask needs is another method, and we all know it

atoning for my sins the first time around. and yes, i refuse to use a cross
package exported constant (just think of the dep graphs)

this also uses `/tmp` inside the container