### PR TITLE
Use registry auth token from Call extensions to pull images

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -36,7 +36,7 @@ type Auther interface {
 	// certain restrictions on images or if credentials must be acquired right
 	// before runtime and there's an error doing so. If these credentials don't
 	// work, the docker pull will fail and the task will be set to error status.
-	DockerAuth() (docker.AuthConfiguration, error)
+	DockerAuth() (*docker.AuthConfiguration, error)
 }
 
 type runResult struct {
@@ -310,7 +310,9 @@ func (drv *DockerDriver) ensureImage(ctx context.Context, task drivers.Container
 		if err != nil {
 			return err
 		}
-		config = &authConfig
+		if authConfig != nil {
+			config = authConfig
+		}
 	}
 
 	globalRepo := path.Join(reg, repo)


### PR DESCRIPTION
- What I did
When pulling docker images to run the function, check if the Call has 'FN_REGISTRY_TOKEN' extension and use that token in the call to registry.

- How I did it
fnLB Call override will add the auth token as extension if the image is from a registry that needs authentication. The token is then sent to runner as Call extension. Runner uses it to pull image for the Call