### PR TITLE
fn: freezer/evictor adjustments

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -984,9 +984,6 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 		return
 	}
 
-	// container is running
-	state.UpdateState(ctx, ContainerStateIdle, call.slots)
-
 	// buffered, in case someone has slot when waiter returns but isn't yet listening
 	errC := make(chan error, 1)
 
@@ -1096,43 +1093,26 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 
 	var err error
 	isFrozen := false
-	isEvictable := false
+	isEvictEvent := false
 
 	freezeTimer := time.NewTimer(a.cfg.FreezeIdle)
 	idleTimer := time.NewTimer(time.Duration(call.IdleTimeout) * time.Second)
+	evictor := a.evictor.GetEvictor(call.ID, call.slotHashId, call.Memory+uint64(call.TmpFsSize), uint64(call.CPUs))
 
-	defer freezeTimer.Stop()
-	defer idleTimer.Stop()
-
-	// log if any error is encountered
 	defer func() {
+		a.evictor.UnregisterEvictor(evictor)
+		freezeTimer.Stop()
+		idleTimer.Stop()
+		// log if any error is encountered
 		if err != nil {
 			logger.WithError(err).Error("hot function failure")
 		}
 	}()
 
-	evictor := a.evictor.GetEvictor(call.ID, call.slotHashId, call.Memory+uint64(call.TmpFsSize), uint64(call.CPUs))
+	a.evictor.RegisterEvictor(evictor)
+	state.UpdateState(ctx, ContainerStateIdle, call.slots)
 
-	// if an immediate freeze is requested, freeze first before enqueuing at all.
-	if a.cfg.FreezeIdle == time.Duration(0) && !isFrozen {
-		err = cookie.Freeze(ctx)
-		if err != nil {
-			return false
-		}
-		isFrozen = true
-		state.UpdateState(ctx, ContainerStatePaused, call.slots)
-		if !isEvictable {
-			isEvictable = true
-			a.evictor.RegisterEvictor(evictor)
-		}
-	}
-
-	if !isFrozen {
-		state.UpdateState(ctx, ContainerStateIdle, call.slots)
-	}
 	s := call.slots.queueSlot(slot)
-
-	isEvictEvent := false
 
 	for {
 		select {
@@ -1148,10 +1128,6 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 				}
 				isFrozen = true
 				state.UpdateState(ctx, ContainerStatePaused, call.slots)
-				if !isEvictable {
-					isEvictable = true
-					a.evictor.RegisterEvictor(evictor)
-				}
 			}
 			continue
 		case <-evictor.C:
@@ -1161,9 +1137,7 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 		break
 	}
 
-	if isEvictable {
-		a.evictor.UnregisterEvictor(evictor)
-	}
+	a.evictor.UnregisterEvictor(evictor)
 
 	// if we can acquire token, that means we are here due to
 	// abort/shutdown/timeout, attempt to acquire and terminate,


### PR DESCRIPTION
*) removed faulty Idle state setter in runHot() since with
UDS wait, we need to wait until we can determine if a container
is idle. This is now moved to runHotReq().
*) evictor now more aggresive and no longer tied to pause
timer/configuration.
*) removed unnecessary optimization on timer=0 case for immediate
pause.
