### PR TITLE
Initial Refactor

### DIFF
--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -76,7 +76,6 @@ func (s *Server) handleFnInvokeCall2(c *gin.Context) error {
 }
 
 func (s *Server) ServeFnInvoke(c *gin.Context, app *models.App, fn *models.Fn) error {
-	// TODO: we should combine this logic with trigger, which just wraps this block with some headers wizardry
 	// TODO: we should get rid of the buffers, and stream back (saves memory (+splice), faster (splice), allows streaming, don't have to cap resp size)
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
@@ -86,7 +85,6 @@ func (s *Server) ServeFnInvoke(c *gin.Context, app *models.App, fn *models.Fn) e
 		Buffer:  buf,
 		Headers: c.Writer.Header(),
 	}
-	defer bufPool.Put(buf) // TODO need to ensure this is safe with Dispatch?
 
 	return s.FnInvoke(c, app, fn, writer,
 		agent.WithWriter(writer), // XXX (reed): order matters [for now]
@@ -144,7 +142,6 @@ func (s *Server) FnInvoke(c *gin.Context, app *models.App, fn *models.Fn, writer
 		c.Writer.WriteHeader(writer.Status())
 	}
 
-	c.Writer.Header()
 	io.Copy(c.Writer, writer)
 
 	return nil

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -44,10 +44,10 @@ type syncResponseWriter struct {
 func (s *syncResponseWriter) Header() http.Header { return s.headers }
 
 // By storing the status here, we effectively buffer the response
-func (s *syncResponseWriter) WriteHeader(code int)     { s.status = code }
-func (s *syncResponseWriter) Status() int              { return s.status }
-func (s *syncResponseWriter) GetBuffer() *bytes.Buffer { return s.Buffer }
-func (s *syncResponseWriter) SetBuffer(buf *bytes.Buffer) { s.Buffer = buf}
+func (s *syncResponseWriter) WriteHeader(code int)        { s.status = code }
+func (s *syncResponseWriter) Status() int                 { return s.status }
+func (s *syncResponseWriter) GetBuffer() *bytes.Buffer    { return s.Buffer }
+func (s *syncResponseWriter) SetBuffer(buf *bytes.Buffer) { s.Buffer = buf }
 
 // handleFnInvokeCall executes the function, for router handlers
 func (s *Server) handleFnInvokeCall(c *gin.Context) {
@@ -98,8 +98,8 @@ func (s *Server) fnInvoke(c *gin.Context, app *models.App, fn *models.Fn, writer
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	var submitErr error
-	defer func(){
-		if buf.Len() == 0 && submitErr == nil{
+	defer func() {
+		if buf.Len() == 0 && submitErr == nil {
 			bufPool.Put(buf) // TODO need to ensure this is safe with Dispatch?
 		}
 	}()

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -117,13 +117,8 @@ func (trw *triggerResponseWriter) WriteHeader(statusCode int) {
 //ServeHTTPTr	igger serves an HTTP trigger for a given app/fn/trigger  based on the current request
 // This is exported to allow extensions to handle their own trigger naming and publishing
 func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn, trigger *models.Trigger) error {
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer bufPool.Put(buf) // TODO need to ensure this is safe with Dispatch?
-
 	triggerWriter := &triggerResponseWriter{
 		syncResponseWriter{
-			Buffer:  buf,
 			headers: c.Writer.Header()},
 		false,
 	}
@@ -140,5 +135,5 @@ func (s *Server) ServeHTTPTrigger(c *gin.Context, app *models.App, fn *models.Fn
 	if err != nil {
 		return err
 	}
-	return s.FnInvoke(c, app, fn, triggerWriter, call)
+	return s.fnInvoke(c, app, fn, triggerWriter, call)
 }

--- a/api/server/runner_httptrigger.go
+++ b/api/server/runner_httptrigger.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"net/http"
 	"strconv"
 

--- a/test/fn-system-tests/exec_fn_test.go
+++ b/test/fn-system-tests/exec_fn_test.go
@@ -256,7 +256,7 @@ func TestBasicConcurrentExecution(t *testing.T) {
 
 	results := make(chan error)
 	latch := make(chan struct{})
-	concurrentFuncs := 100
+	concurrentFuncs := 10
 	for i := 0; i < concurrentFuncs; i++ {
 		go func() {
 			body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`

--- a/test/fn-system-tests/exec_fn_test.go
+++ b/test/fn-system-tests/exec_fn_test.go
@@ -255,12 +255,14 @@ func TestBasicConcurrentExecution(t *testing.T) {
 	u.Path = path.Join(u.Path, "invoke", fn.ID)
 
 	results := make(chan error)
-	concurrentFuncs := 10
+	latch := make(chan struct{})
+	concurrentFuncs := 100
 	for i := 0; i < concurrentFuncs; i++ {
 		go func() {
 			body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`
 			content := bytes.NewBuffer([]byte(body))
 			output := &bytes.Buffer{}
+			<-latch
 			resp, err := callFN(ctx, u.String(), content, output)
 			if err != nil {
 				results <- fmt.Errorf("Got unexpected error: %v", err)
@@ -280,6 +282,7 @@ func TestBasicConcurrentExecution(t *testing.T) {
 			results <- nil
 		}()
 	}
+	close(latch)
 	for i := 0; i < concurrentFuncs; i++ {
 		err := <-results
 		if err != nil {


### PR DESCRIPTION
Removing the repeated logic exposed some problems with the reponse
writers.

Currently, the trigger writer was overlaid on part of the header
writing. The main invoke blog writing into the different levels of the
overlays at different points in the logic.

Instead, by extending the types and embedded structs, the writer is
more transparent. So, at the end of the flow it goes over all the
headers available and removes our prefixes. This lets the invoke logic
just write to the top level.

Going to continue after lunch to try and remove some of the layers and
param passing.