### PR TITLE
Add APIErrorWrapper so that underlying errors can be logged

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -194,3 +194,26 @@ type ErrorWrapper struct {
 func (m *ErrorWrapper) Validate() error {
 	return nil
 }
+
+// APIErrorWrapper wraps an error with an APIError such that the APIError
+// governs the HTTP response but the root error remains accessible.
+type APIErrorWrapper interface {
+	APIError
+	RootError() error
+}
+
+type apiErrorWrapper struct {
+	APIError
+	root error
+}
+
+func (w apiErrorWrapper) RootError() error {
+	return w.root
+}
+
+func NewAPIErrorWrapper(apiErr APIError, rootErr error) APIErrorWrapper {
+	return &apiErrorWrapper{
+		APIError: apiErr,
+		root:     rootErr,
+	}
+}

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -27,6 +27,9 @@ func handleErrorResponse(c *gin.Context, err error) {
 // HandleErrorResponse used to handle response errors in the same way.
 func HandleErrorResponse(ctx context.Context, w http.ResponseWriter, err error) {
 	log := common.Logger(ctx)
+	if w, ok := err.(models.APIErrorWrapper); ok {
+		log = log.WithField("root_error", w.RootError())
+	}
 
 	if ctx.Err() == context.Canceled {
 		log.Info("client context cancelled")


### PR DESCRIPTION
Loggable errors have a separate message that is logged only but is not part of the response.