### PR TITLE
Log failure to close fsnotify handle

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1067,7 +1067,11 @@ func inotifyAwait(ctx context.Context, iofsDir string) error {
 	if err != nil {
 		return fmt.Errorf("error getting fsnotify watcher: %v", err)
 	}
-	defer fsWatcher.Close()
+	defer func() {
+		if err := fsWatcher.Close(); err != nil {
+			common.Logger(ctx).WithError(err).Error("Failed to close inotify watcher")
+		}
+	}()
 
 	err = fsWatcher.Add(iofsDir)
 	if err != nil {


### PR DESCRIPTION
I think this is the bare minimum we should be doing if we're unable to close this. Possibly worth a retry too?
