### PR TITLE
Fix missing context on request sent through UDS

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -716,6 +716,9 @@ func callToHTTPRequest(ctx context.Context, call *call) (*http.Request, error) {
 	if err != nil {
 		return req, err
 	}
+	// Set the context on the request to make sure transport and client handle
+	// it properly and close connections at the end, e.g. when using UDS.
+	req = req.WithContext(ctx)
 
 	req.Header = make(http.Header)
 	for k, vs := range call.req.Header {


### PR DESCRIPTION
Fixed the fact that the http.Request sent through UDS in http-stream does not have a Context.

Old dispatch methods use CallInfo and provide the original request (which has a Context), but the new dispatch method for http-stream through UDS creates a new request and does not set the context there. I have merely added a `WithContext` call.
