### PR TITLE
Limit connection pool size on UDS: we should only need one per container

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -964,6 +964,8 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 
 		udsClient = http.Client{
 			Transport: &http.Transport{
+				MaxIdleConns:        1,
+				MaxIdleConnsPerHost: 1,
 				// XXX(reed): other settings ?
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					var d net.Dialer


### PR DESCRIPTION
Each container running http-stream functions has a UDS through which requests are piped, but only one request at a time. 
Therefore, the Transport for that socket should not maintain a large connection pool: it is not needed at all. This change reduces the idle connections to 1. Hopefully this reduces File Descriptors usage even further.