### PR TITLE
Add a 'top' anchor to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a id="top"></a>
 ![Fn Project](http://fnproject.io/images/fn-300x125.png)
 
 **[Quickstart](https://github.com/fnproject/fn#quickstart)&nbsp; | &nbsp;[Tutorials](https://fnproject.io/tutorials)&nbsp; |  &nbsp;[Docs](https://github.com/fnproject/docs)&nbsp; | &nbsp;[API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/fnproject/fn/master/docs/swagger_v2.yml)&nbsp; | &nbsp;[Operating](https://github.com/fnproject/docs/blob/master/fn/README.md#for-operators)&nbsp; | &nbsp;[Flow](https://github.com/fnproject/flow)&nbsp; | &nbsp;[UI](https://github.com/fnproject/ui)**


### PR DESCRIPTION
- Link to issue this resolves

Allows other Fn site links to jump to the top of the README rather than the gihub list of files.

- What I did

Added an anchor:  `<a id="top"></a>`
- How I did it

Edited

- How to verify it

Doublechecked with a GitHub Wiki page. It works.

- One line description for the changelog

Add a 'top' anchor to landing page

- One moving picture involving robots (not mandatory but encouraged)

![Akecheta rides the Top of the ridge.](https://media.giphy.com/media/2sZB3r4AdJUFPsxVId/giphy.gif)
Akecheta rides the Top of the ridge.
