### PR TITLE
fn: default fnserver tag keys and api key adjustment

### DIFF
--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -105,8 +105,10 @@ func RegisterAPIViews(tagKeys []string, dist []float64) {
 	// add extra tags if not already in default tags for req/resp
 	for _, key := range tagKeys {
 		if key != "path" && key != "method" && key != "status" {
-			reqTags = append(reqTags, common.MakeKey(key))
 			respTags = append(respTags, common.MakeKey(key))
+		}
+		if key != "path" && key != "method" {
+			reqTags = append(reqTags, common.MakeKey(key))
 		}
 	}
 
@@ -133,7 +135,6 @@ func DefaultAPIViewsGetPath(routes gin.RoutesInfo, c *gin.Context) string {
 }
 
 func apiMetricsWrap(s *Server) {
-
 	measure := func(engine *gin.Engine) func(*gin.Context) {
 		var routes gin.RoutesInfo
 		return func(c *gin.Context) {
@@ -169,7 +170,6 @@ func apiMetricsWrap(s *Server) {
 		a := s.AdminRouter
 		a.Use(measure(a))
 	}
-
 }
 
 func panicWrap(c *gin.Context) {

--- a/cmd/fnserver/main.go
+++ b/cmd/fnserver/main.go
@@ -25,7 +25,7 @@ func main() {
 }
 
 func registerViews() {
-	keys := []string{"fn_appname", "fn_path"}
+	keys := []string{}
 
 	latencyDist := []float64{1, 10, 50, 100, 250, 500, 1000, 10000, 60000, 120000}
 
@@ -50,5 +50,5 @@ func registerViews() {
 	// Register s3 log views
 	s3.RegisterViews(keys, latencyDist)
 
-	server.RegisterAPIViews([]string{}, latencyDist)
+	server.RegisterAPIViews(keys, latencyDist)
 }


### PR DESCRIPTION
Default fn server keys should be minimal (empty) since not
all stats have associated app name, fn id, etc.

API tags for requests should not include "status" as this is
part of responses.

