### PR TITLE
small tweaks to dispatch

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -728,10 +728,11 @@ var removeHeaders = map[string]bool{
 	"authorization":     true,
 }
 
-func callToHTTPRequest(ctx context.Context, call *call) (*http.Request, error) {
+func callToHTTPRequest(ctx context.Context, call *call) *http.Request {
 	req, err := http.NewRequest("POST", "http://localhost/call", call.req.Body)
 	if err != nil {
-		return req, err
+		common.Logger(ctx).WithError(err).Error("somebody put a bad url in the call http request. 10 lashes.")
+		panic(err)
 	}
 	// Set the context on the request to make sure transport and client handle
 	// it properly and close connections at the end, e.g. when using UDS.
@@ -757,30 +758,24 @@ func callToHTTPRequest(ctx context.Context, call *call) (*http.Request, error) {
 		req.Header.Set("FN_DEADLINE", deadlineStr)
 	}
 
-	return req, err
+	return req
 }
 
 func (s *hotSlot) dispatch(ctx context.Context, call *call) chan error {
-	ctx, span := trace.StartSpan(ctx, "agent_dispatch_httpstream")
-	defer span.End()
-
 	// TODO we can't trust that resp.Write doesn't timeout, even if the http
 	// client should respect the request context (right?) so we still need this (right?)
 	errApp := make(chan error, 1)
 
-	req, err := callToHTTPRequest(ctx, call)
-
-	if err != nil {
-		errApp <- err
-		return errApp
-	}
-
 	go func() {
+		ctx, span := trace.StartSpan(ctx, "agent_dispatch_httpstream")
+		defer span.End()
+
 		// TODO it's possible we can get rid of this (after getting rid of logs API) - may need for call id/debug mode still
 		// TODO there's a timeout race for swapping this back if the container doesn't get killed for timing out, and don't you forget it
 		swapBack := s.container.swap(nil, call.stderr, call.stderr, &call.Stats)
 		defer swapBack()
 
+		req := callToHTTPRequest(ctx, call)
 		resp, err := s.udsClient.Do(req)
 		if err != nil {
 			common.Logger(ctx).WithError(err).Error("Got error from UDS socket")


### PR DESCRIPTION
* the dispatch span actually encloses dispatch and gives an accurate span now
* turning a call into an http request can't fail unless it's our fault, if
tests don't catch this, we don't deserve money
* moved http req creation inside of dispatch goroutine

there's further work to do cleaning up dispatch... removing the old formats
will make this slightly more clear, waiting for that. this was bugging me
anyway after seeing something else and was easy to fix up.