### PR TITLE
Configure logrus to include nano seconds in log messages

### DIFF
--- a/api/common/logging.go
+++ b/api/common/logging.go
@@ -3,10 +3,11 @@ package common
 import (
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 func SetLogFormat(format string) {
@@ -15,7 +16,7 @@ func SetLogFormat(format string) {
 	}
 
 	if format == "json" {
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 	} else {
 		// show full timestamps
 		formatter := &logrus.TextFormatter{


### PR DESCRIPTION
Currently the default time format, time.RFC3339, is used, which doesn't include any
subsecond resolution information. This makes it hard to understand the
ordering of log messages when viewing in a log aggregator, like
Kibana.

This change sets the TimestampFormat of the logrus JSONFormatter to
time.RFC3339Nano.

