### PR TITLE
fn: cleanup of docker timeouts and docker health check

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -775,7 +775,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 		return
 	}
 
-	defer cookie.Close(ctx)
+	defer cookie.Close(common.BackgroundContext(ctx))
 
 	err = a.driver.PrepareCookie(ctx, cookie)
 	if err != nil {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	removeTimeout = 10 * time.Minute // docker remove
-	pauseTimeout  = 5 * time.Second  // docker pause/unpause
+	pauseTimeout = 5 * time.Second // docker pause/unpause
 )
 
 // TODO we should prob store async calls in db immediately since we're returning id (will 404 until post-execution)
@@ -781,11 +780,8 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 		return
 	}
 
-	defer func() {
-		ctx, cancel := context.WithTimeout(common.BackgroundContext(ctx), removeTimeout)
-		cookie.Close(ctx)
-		cancel()
-	}()
+	// WARNING: we wait forever.
+	defer cookie.Close(common.BackgroundContext(ctx))
 
 	err = a.driver.PrepareCookie(ctx, cookie)
 	if err != nil {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	removeTimeout = 10 * time.Minute // docker remove
-	prepTimeout   = 10 * time.Minute // docker create+pull
 	pauseTimeout  = 5 * time.Second  // docker pause/unpause
 )
 
@@ -773,7 +772,7 @@ func (a *agent) runHot(ctx context.Context, call *call, tok ResourceToken, state
 	logger := logrus.WithFields(logrus.Fields{"id": container.id, "app_id": call.AppID, "fn_id": call.FnID, "image": call.Image, "memory": call.Memory, "cpus": call.CPUs, "idle_timeout": call.IdleTimeout})
 	ctx = common.WithLogger(ctx, logger)
 
-	ctx, cancel := context.WithTimeout(common.BackgroundContext(ctx), prepTimeout)
+	ctx, cancel := context.WithTimeout(common.BackgroundContext(ctx), a.cfg.HotStartTimeout)
 	defer cancel()
 
 	cookie, err := a.driver.CreateCookie(ctx, container)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	removeTimeout = 1 * time.Minute // docker remove
-	prepTimeout   = 2 * time.Minute // docker create+pull
-	pauseTimeout  = 5 * time.Second // docker pause/unpause
+	removeTimeout = 10 * time.Minute // docker remove
+	prepTimeout   = 10 * time.Minute // docker create+pull
+	pauseTimeout  = 5 * time.Second  // docker pause/unpause
 )
 
 // TODO we should prob store async calls in db immediately since we're returning id (will 404 until post-execution)

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	FreezeIdle              time.Duration `json:"freeze_idle_msecs"`
 	HotPoll                 time.Duration `json:"hot_poll_msecs"`
 	HotLauncherTimeout      time.Duration `json:"hot_launcher_timeout_msecs"`
+	HotStartTimeout         time.Duration `json:"hot_start_timeout_msecs"`
 	AsyncChewPoll           time.Duration `json:"async_chew_poll_msecs"`
 	MaxResponseSize         uint64        `json:"max_response_size_bytes"`
 	MaxLogSize              uint64        `json:"max_log_size_bytes"`
@@ -48,8 +49,10 @@ const (
 	// EnvHotPoll is the interval to ping for a slot manager thread to check if a container should be
 	// launched for a given function
 	EnvHotPoll = "FN_HOT_POLL_MSECS"
-	// EnvHotLauncherTimeout is the timeout for a hot container to become available for use
+	// EnvHotLauncherTimeout is the timeout for a hot container queue to persist if idle
 	EnvHotLauncherTimeout = "FN_HOT_LAUNCHER_TIMEOUT_MSECS"
+	// EnvHotStartTimeout is the timeout for a hot container to become available for use including docker-pull
+	EnvHotStartTimeout = "FN_HOT_START_TIMEOUT_MSECS"
 	// EnvAsyncChewPoll is the interval to poll the queue that contains async function invocations
 	EnvAsyncChewPoll = "FN_ASYNC_CHEW_POLL_MSECS"
 	// EnvMaxResponseSize is the maximum number of bytes that a function may return from an invocation
@@ -125,6 +128,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvMsecs(err, EnvFreezeIdle, &cfg.FreezeIdle, 50*time.Millisecond)
 	err = setEnvMsecs(err, EnvHotPoll, &cfg.HotPoll, DefaultHotPoll)
 	err = setEnvMsecs(err, EnvHotLauncherTimeout, &cfg.HotLauncherTimeout, time.Duration(60)*time.Minute)
+	err = setEnvMsecs(err, EnvHotStartTimeout, &cfg.HotStartTimeout, time.Duration(10)*time.Minute)
 	err = setEnvMsecs(err, EnvAsyncChewPoll, &cfg.AsyncChewPoll, time.Duration(60)*time.Second)
 	err = setEnvUint(err, EnvMaxResponseSize, &cfg.MaxResponseSize)
 	err = setEnvUint(err, EnvMaxLogSize, &cfg.MaxLogSize)

--- a/api/agent/drivers/docker/docker_client.go
+++ b/api/agent/drivers/docker/docker_client.go
@@ -386,10 +386,7 @@ func (d *dockerWrap) PullImage(opts docker.PullImageOptions, auth docker.AuthCon
 }
 
 func (d *dockerWrap) RemoveContainer(opts docker.RemoveContainerOptions) (err error) {
-	// extract the span, but do not keep the context, since the enclosing context
-	// may be timed out, and we still want to remove the container. TODO in caller? who cares?
-	ctx := common.BackgroundContext(opts.Context)
-	ctx, closer := makeTracker(ctx, "docker_remove_container")
+	ctx, closer := makeTracker(opts.Context, "docker_remove_container")
 	defer closer()
 
 	ctx, cancel := context.WithTimeout(ctx, retryTimeout)

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -45,7 +45,8 @@ const (
 	LimitPerSec = 10
 	LimitBurst  = 20
 
-	ShutdownTimeout = time.Duration(1) * time.Second
+	ShutdownTimeout   = time.Duration(1) * time.Second
+	InitializeTimeout = time.Duration(30) * time.Second
 )
 
 type poolTask struct {
@@ -165,6 +166,9 @@ func (pool *dockerPool) Close() error {
 func (pool *dockerPool) performInitState(ctx context.Context, driver *DockerDriver, task *poolTask) {
 
 	log := common.Logger(ctx).WithFields(logrus.Fields{"id": task.Id(), "net": task.netMode})
+
+	ctx, cancel := context.WithTimeout(ctx, InitializeTimeout)
+	defer cancel()
 
 	err := driver.ensureImage(ctx, task)
 	if err != nil {


### PR DESCRIPTION
    Moving the timeout management of various docker operations
    to agent. This allows for finer control over what operation
    should use. For instance, for pause/unpause our tolerance
    is very low to avoid resource issues. For docker remove,
    the consequences of failure will lead to potential agent
    failure and therefore we wait up to 10 minute.
    For cookie create/prepare (which includes docker-pull)
    we cap this at 10 minutes by default.
    
    With new UDS/FDK contract, health check is now obsoleted
    as container advertise health using UDS availibility.
