### PR TITLE
Fix filtering by name when getting list of funcs

### DIFF
--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -734,9 +734,8 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			}
 			if len(fns.Items) != 1 {
 				t.Fatalf("expected result count to be 1, got %d", len(fns.Items))
-			} else if !gendFns[0].EqualsWithAnnotationSubset(fns.Items[0]) {
-				// t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", gendFns[0].Name, fns.Items[0].Name)
-				t.Fatalf("expected function list to contain function %s, got %#v", f1.Name, fns)
+			} else if !f1.EqualsWithAnnotationSubset(fns.Items[0]) {
+				t.Fatalf("expected function list to contain function %s, got %#v", f1.Name, fns.Items[0].Name)
 			}
 		})
 

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -727,6 +727,17 @@ func RunFnsTest(t *testing.T, dsf DataStoreFunc, rp ResourceProvider) {
 			} else if !gendFns[2].EqualsWithAnnotationSubset(fns.Items[1]) {
 				t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", gendFns[2], fns.Items[1])
 			}
+
+			fns, err = ds.GetFns(ctx, &models.FnFilter{AppID: testApp.ID, Name: f1.Name})
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if len(fns.Items) != 1 {
+				t.Fatalf("expected result count to be 1, got %d", len(fns.Items))
+			} else if !gendFns[0].EqualsWithAnnotationSubset(fns.Items[0]) {
+				// t.Fatalf("expected `func.Name` to be `%#v` but it was `%#v`", gendFns[0].Name, fns.Items[0].Name)
+				t.Fatalf("expected function list to contain function %s, got %#v", f1.Name, fns)
+			}
 		})
 
 		t.Run("delete with empty fn name", func(t *testing.T) {

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -934,6 +934,9 @@ func buildFilterFnQuery(filter *models.FnFilter) (string, []interface{}, error) 
 		}
 		args = where(&b, args, "name>?", string(s))
 	}
+	if filter.Name != "" {
+		args = where(&b, args, "name=?", filter.Name)
+	}
 
 	fmt.Fprintf(&b, ` ORDER BY name ASC`)
 	if filter.PerPage > 0 {


### PR DESCRIPTION
- Link to issue this resolves
#1294 

- What I did
Fixed buildFilterFnQuery in local datastore code to respect 'Name' filter.

- How to verify it
Use 'name' parameter on v2/fns GET endpoint to filter function list by name. E.g. `curl "localhost:8080/v2/fns?app_id=MYAPPID&name=MYFUNC1"` 

- One line description for the changelog
Fixed filtering by name when getting function list

