### PR TITLE
fn: add container state to eviction stats

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1010,7 +1010,7 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 	if call.slots.acquireSlot(s) {
 		slot.Close()
 		if isEvictEvent {
-			statsContainerEvicted(ctx)
+			statsContainerEvicted(ctx, state.GetState())
 		}
 		return false
 	}


### PR DESCRIPTION
Prep work for future evictor enhancements. This PR adds state tag
to eviction stats.