### PR TITLE
fn: cookie and driver api changes

### DIFF
--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -55,9 +55,20 @@ func TestRunnerDocker(t *testing.T) {
 
 	defer cookie.Close(ctx)
 
-	err = dkr.PrepareCookie(ctx, cookie)
+	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil {
-		t.Fatal("Couldn't prepare task test")
+		t.Fatal("Couldn't validate image test")
+	}
+	if shouldPull {
+		err = cookie.PullImage(ctx)
+		if err != nil {
+			t.Fatal("Couldn't pull image test")
+		}
+	}
+
+	err = cookie.CreateContainer(ctx)
+	if err != nil {
+		t.Fatal("Couldn't create container test")
 	}
 
 	waiter, err := cookie.Run(ctx)
@@ -95,22 +106,11 @@ func TestRunnerDockerNetworks(t *testing.T) {
 
 	defer cookie1.Close(ctx)
 
-	err = dkr.PrepareCookie(ctx, cookie1)
-	if err != nil {
-		t.Fatal("Couldn't prepare task1 test")
-	}
-
 	cookie2, err := dkr.CreateCookie(ctx, task2)
 	if err != nil {
 		t.Fatal("Couldn't create task2 cookie")
 	}
 
-	defer cookie2.Close(ctx)
-
-	err = dkr.PrepareCookie(ctx, cookie2)
-	if err != nil {
-		t.Fatal("Couldn't prepare task2 test")
-	}
 	defer cookie2.Close(ctx)
 
 	c1 := cookie1.(*cookie)
@@ -167,9 +167,19 @@ func TestRunnerDockerStdout(t *testing.T) {
 
 	defer cookie.Close(ctx)
 
-	err = dkr.PrepareCookie(ctx, cookie)
+	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil {
-		t.Fatal("Couldn't prepare task test")
+		t.Fatal("Couldn't validate image test")
+	}
+	if shouldPull {
+		err = cookie.PullImage(ctx)
+		if err != nil {
+			t.Fatal("Couldn't pull image test")
+		}
+	}
+	err = cookie.CreateContainer(ctx)
+	if err != nil {
+		t.Fatal("Couldn't create container test")
 	}
 
 	waiter, err := cookie.Run(ctx)

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -41,6 +41,16 @@ type Cookie interface {
 	// Unfreeze a frozen container to unpause frozen processes
 	Unfreeze(ctx context.Context) error
 
+	// Validate/Inspect and Authenticate image. Returns true if the image needs
+	// to be pulled and non-nil error if validation/auth/inspection fails.
+	ValidateImage(ctx context.Context) (bool, error)
+
+	// Pull the image.
+	PullImage(ctx context.Context) error
+
+	// Create container which can be Run() later
+	CreateContainer(ctx context.Context) error
+
 	// Fetch driver specific container configuration. Use this to
 	// access the container create options. If Driver.Prepare() is not
 	// yet called with the cookie, then this can be used to modify container
@@ -61,14 +71,7 @@ type Driver interface {
 	// Callers should Close the cookie regardless of whether they prepare or run it.
 	CreateCookie(ctx context.Context, task ContainerTask) (Cookie, error)
 
-	// PrepareCookie can be used in order to do any preparation that a specific driver
-	// may need to do before running the task, and can be useful to put
-	// preparation that the task can recover from into (i.e. if pulling an image
-	// fails because a registry is down, the task doesn't need to be failed).  It
-	// returns a cookie that can be used to execute the task.
-	// Callers should Close the cookie regardless of whether they run it.
-	//
-	// The returned cookie should respect the task's timeout when it is run.
+	// Obsoleted. No-Op
 	PrepareCookie(ctx context.Context, cookie Cookie) error
 
 	// close & shutdown the driver

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -43,9 +43,25 @@ func (c *cookie) Unfreeze(context.Context) error {
 	return nil
 }
 
-func (c *cookie) Close(context.Context) error { return nil }
+func (c *cookie) ValidateImage(context.Context) (bool, error) {
+	return false, nil
+}
 
-func (c *cookie) ContainerOptions() interface{} { return nil }
+func (c *cookie) PullImage(context.Context) error {
+	return nil
+}
+
+func (c *cookie) CreateContainer(context.Context) error {
+	return nil
+}
+
+func (c *cookie) Close(context.Context) error {
+	return nil
+}
+
+func (c *cookie) ContainerOptions() interface{} {
+	return nil
+}
 
 func (c *cookie) Run(ctx context.Context) (drivers.WaitResult, error) {
 	c.m.count++


### PR DESCRIPTION
Now obsoleted driver.PrepareCookie() call handled image and
container creation. In agent, going forward we will need finer
grained control over the timeouts implied by the contexts.
For this reason, with this change, we split PrepareCookie()
into Validate/Pull/Create calls under Cookie interface.
