### PR TITLE
fn: enforce container/FDK contract in dispatch

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -134,7 +134,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvMsecs(err, EnvHotPoll, &cfg.HotPoll, DefaultHotPoll)
 	err = setEnvMsecs(err, EnvHotLauncherTimeout, &cfg.HotLauncherTimeout, time.Duration(60)*time.Minute)
 	err = setEnvMsecs(err, EnvHotPullTimeout, &cfg.HotPullTimeout, time.Duration(10)*time.Minute)
-	err = setEnvMsecs(err, EnvHotStartTimeout, &cfg.HotStartTimeout, time.Duration(10)*time.Second)
+	err = setEnvMsecs(err, EnvHotStartTimeout, &cfg.HotStartTimeout, time.Duration(5)*time.Second)
 	err = setEnvMsecs(err, EnvAsyncChewPoll, &cfg.AsyncChewPoll, time.Duration(60)*time.Second)
 	err = setEnvMsecs(err, EnvDetachedHeadroom, &cfg.DetachedHeadRoom, time.Duration(360)*time.Second)
 	err = setEnvUint(err, EnvMaxResponseSize, &cfg.MaxResponseSize)

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -220,7 +220,7 @@ func (a *lbAgent) Submit(callI Call) error {
 
 func (a *lbAgent) placeDetachCall(ctx context.Context, call *call) error {
 	errPlace := make(chan error, 1)
-	rw := call.w.(*DetachedResponseWriter)
+	rw := call.respWriter.(*DetachedResponseWriter)
 	go a.spawnPlaceCall(ctx, call, errPlace)
 	select {
 	case err := <-errPlace:

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -138,6 +138,14 @@ var (
 		code:  http.StatusBadGateway,
 		error: fmt.Errorf("error receiving function response"),
 	}
+	ErrFunctionFailed = err{
+		code:  http.StatusBadGateway,
+		error: fmt.Errorf("function failed"),
+	}
+	ErrFunctionInvalidResponse = err{
+		code:  http.StatusBadGateway,
+		error: fmt.Errorf("invalid function response"),
+	}
 	ErrRequestContentTooBig = err{
 		code:  http.StatusRequestEntityTooLarge,
 		error: fmt.Errorf("Request content too large"),


### PR DESCRIPTION
FDK must respond with 200/502/504 to http requests. Any other status is invalid and container
must be terminated if that occurs. HTTP timeouts are also considered a shutdown reason
for the container.

With this PR, we trust http client to use the context timeout and therefore avoid spawning
a go-routine. This simplifies the flow and also avoids case of call.stderr.Close() executing before swapBack.

