### PR TITLE
Fix response message on invoke handler

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -14,6 +14,11 @@ const (
 )
 
 var (
+	ErrInvokePostOnly = err{
+		code:  http.StatusMethodNotAllowed,
+		error: errors.New("Method not allowed, only HTTP POST supported"),
+	}
+
 	ErrInvalidJSON = err{
 		code:  http.StatusBadRequest,
 		error: errors.New("Invalid JSON"),

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -14,9 +14,9 @@ const (
 )
 
 var (
-	ErrInvokePostOnly = err{
+	ErrMethodNotAllowed = err{
 		code:  http.StatusMethodNotAllowed,
-		error: errors.New("Method not allowed, only HTTP POST supported"),
+		error: errors.New("Method not allowed"),
 	}
 
 	ErrInvalidJSON = err{

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -44,10 +44,6 @@ func (s *syncResponseWriter) Status() int          { return s.status }
 
 // handleFnInvokeCall executes the function, for router handlers
 func (s *Server) handleFnInvokeCall(c *gin.Context) {
-	if c.Request.Method != http.MethodPost {
-		handleErrorResponse(c, models.ErrInvokePostOnly)
-		return
-	}
 	fnID := c.Param(api.ParamFnID)
 	ctx, _ := common.LoggerWithFields(c.Request.Context(), logrus.Fields{"fnID": fnID})
 	c.Request = c.Request.WithContext(ctx)

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -46,9 +45,7 @@ func (s *syncResponseWriter) Status() int          { return s.status }
 // handleFnInvokeCall executes the function, for router handlers
 func (s *Server) handleFnInvokeCall(c *gin.Context) {
 	if c.Request.Method != http.MethodPost {
-		handleErrorResponse(c, models.NewAPIError(http.StatusMethodNotAllowed,
-			errors.New("Method not allowed, only HTTP POST supported.")),
-		)
+		handleErrorResponse(c, models.ErrInvokePostOnly)
 		return
 	}
 	fnID := c.Param(api.ParamFnID)

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -44,6 +45,12 @@ func (s *syncResponseWriter) Status() int          { return s.status }
 
 // handleFnInvokeCall executes the function, for router handlers
 func (s *Server) handleFnInvokeCall(c *gin.Context) {
+	if c.Request.Method != http.MethodPost {
+		handleErrorResponse(c, models.NewAPIError(http.StatusMethodNotAllowed,
+			errors.New("Method not allowed, only HTTP POST supported.")),
+		)
+		return
+	}
 	fnID := c.Param(api.ParamFnID)
 	ctx, _ := common.LoggerWithFields(c.Request.Context(), logrus.Fields{"fnID": fnID})
 	c.Request = c.Request.WithContext(ctx)

--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -211,6 +211,7 @@ func TestFnInvokeRunnerExecution(t *testing.T) {
 
 		// TODO consider removing this, see comment above the image
 		{"/invoke/fail_fn", ok, http.MethodPost, http.StatusBadGateway, nil, "container failed to initialize", nil},
+		{"/invoke/fn_id", ok, http.MethodPut, http.StatusMethodNotAllowed, nil, "only HTTP POST", nil},
 	}
 
 	callIds := make([]string, len(testCases))
@@ -375,7 +376,6 @@ func TestInvokeRunnerMinimalConcurrentHotSync(t *testing.T) {
 		expectedHeaders map[string][]string
 	}{
 		{"/invoke/fn_id", `{"sleepTime": 100, "isDebug": true}`, http.MethodPost, http.StatusOK, nil},
-		{"/invoke/fn_id", `{"sleepTime": 100, "isDebug": true}`, http.MethodPut, http.StatusMethodNotAllowed, nil},
 	} {
 		errs := make(chan error)
 		numCalls := 4

--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -211,7 +211,7 @@ func TestFnInvokeRunnerExecution(t *testing.T) {
 
 		// TODO consider removing this, see comment above the image
 		{"/invoke/fail_fn", ok, http.MethodPost, http.StatusBadGateway, nil, "container failed to initialize", nil},
-		{"/invoke/fn_id", ok, http.MethodPut, http.StatusMethodNotAllowed, nil, "only HTTP POST", nil},
+		{"/invoke/fn_id", ok, http.MethodPut, http.StatusMethodNotAllowed, nil, "Method not allowed", nil},
 	}
 
 	callIds := make([]string, len(testCases))

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1166,7 +1166,7 @@ func (s *Server) bindHandlers(ctx context.Context) {
 
 		if !s.noFnInvokeEndpoint {
 			lbFnInvokeGroup := engine.Group("/invoke")
-			lbFnInvokeGroup.POST("/:fnID", s.handleFnInvokeCall)
+			lbFnInvokeGroup.Any("/:fnID", s.handleFnInvokeCall)
 		}
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1171,23 +1171,15 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	}
 
 	engine.NoRoute(func(c *gin.Context) {
-		var err models.APIError
-		parts := strings.Split(c.Request.URL.Path, "/")
-		if len(parts) > 1 {
-			domain := parts[1]
-			engine.Routes()
-			for _, route := range engine.Routes() {
-				if strings.HasPrefix(route.Path, "/"+domain) {
-					err = models.ErrMethodNotAllowed
-				}
-			}
-		}
+		var e models.APIError = models.ErrPathNotFound
+		err := models.NewAPIError(e.Code(), fmt.Errorf("%v: %s %s", e.Error(), c.Request.Method, c.Request.URL.Path))
+		handleErrorResponse(c, err)
+	})
 
-		// default to 404
-		if err == nil {
-			err = models.ErrPathNotFound
-		}
-		err = models.NewAPIError(err.Code(), fmt.Errorf("%v: %s %s", err.Error(), c.Request.Method, c.Request.URL.Path))
+	engine.HandleMethodNotAllowed = true
+	engine.NoMethod(func(c *gin.Context) {
+		var e models.APIError = models.ErrMethodNotAllowed
+		err := models.NewAPIError(e.Code(), fmt.Errorf("%v: %s %s", e.Error(), c.Request.Method, c.Request.URL.Path))
 		handleErrorResponse(c, err)
 	})
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1171,15 +1171,15 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	}
 
 	engine.NoRoute(func(c *gin.Context) {
-		url := c.Request.URL.String()
-		for _, p := range c.Params {
-			url = strings.Replace(url, p.Value, ":"+p.Key, 1)
-		}
-
 		var err models.APIError
-		for _, route := range engine.Routes() {
-			if route.Path == url {
-				err = models.ErrMethodNotAllowed
+		parts := strings.Split(c.Request.URL.Path, "/")
+		if len(parts) > 1 {
+			domain := parts[1]
+			engine.Routes()
+			for _, route := range engine.Routes() {
+				if strings.HasPrefix(route.Path, "/"+domain) {
+					err = models.ErrMethodNotAllowed
+				}
 			}
 		}
 

--- a/docs/swagger_invoke.yml
+++ b/docs/swagger_invoke.yml
@@ -25,7 +25,7 @@ paths:
        200:
          description: "Function successfully invoked."
        405:
-         description: "Method not allowed, only HTTP POST supported."
+         description: "Method not allowed"
          schema:
            $ref: '#/definitions/Error'
        default:

--- a/docs/swagger_invoke.yml
+++ b/docs/swagger_invoke.yml
@@ -24,6 +24,10 @@ paths:
      responses:
        200:
          description: "Function successfully invoked."
+       405:
+         description: "Method not allowed, only HTTP POST supported."
+         schema:
+           $ref: '#/definitions/Error'
        default:
           description: "An unexpected error occurred."
           schema:


### PR DESCRIPTION
Closes: #1310

- Link to issue this resolves: #1310 

- What I did: changed Gin handler definition with some HTTP method validation for the sake of valid error message.


- How I did it: with no problem ;)

- How to verify it: call invoke handler with any http method except POST.

- One line description for the changelog: The following commit improves error status code and message for the cases when invoke path called with any HTTP method except HTTP POST

- One moving picture involving robots (not mandatory but encouraged)
![robot](https://media.giphy.com/media/1Mng0gXC5Tpcs/giphy.gif)