### PR TITLE
fn: placer stats and client context

### DIFF
--- a/api/runnerpool/placer_stats.go
+++ b/api/runnerpool/placer_stats.go
@@ -17,8 +17,10 @@ var (
 	errorPoolCountMeasure    = common.MakeMeasure("lb_placer_rp_error_count", "LB Placer RunnerPool RunnerList Error Count", "")
 	emptyPoolCountMeasure    = common.MakeMeasure("lb_placer_rp_empty_count", "LB Placer RunnerPool RunnerList Empty Count", "")
 	cancelCountMeasure       = common.MakeMeasure("lb_placer_client_cancelled_count", "LB Placer Client Cancel Count", "")
+	timeoutCountMeasure      = common.MakeMeasure("lb_placer_client_timeout_count", "LB Placer Client Timeout Count", "")
 	placerTimeoutMeasure     = common.MakeMeasure("lb_placer_timeout_count", "LB Placer Timeout Count", "")
 	placedErrorCountMeasure  = common.MakeMeasure("lb_placer_placed_error_count", "LB Placer Placed Call Count With Errors", "")
+	placedAbortCountMeasure  = common.MakeMeasure("lb_placer_placed_abort_count", "LB Placer Placed Call Count With Client Timeout/Cancel", "")
 	placedOKCountMeasure     = common.MakeMeasure("lb_placer_placed_ok_count", "LB Placer Placed Call Count Without Errors", "")
 	retryTooBusyCountMeasure = common.MakeMeasure("lb_placer_retry_busy_count", "LB Placer Retry Count - Too Busy", "")
 	retryErrorCountMeasure   = common.MakeMeasure("lb_placer_retry_error_count", "LB Placer Retry Count - Errors", "")
@@ -70,9 +72,11 @@ func RegisterPlacerViews(tagKeys []string, latencyDist []float64) {
 		common.CreateView(attemptCountMeasure, view.Distribution(0, 2, 3, 4, 8, 16, 32, 64, 128, 256), tagKeys),
 		common.CreateView(errorPoolCountMeasure, view.Count(), tagKeys),
 		common.CreateView(emptyPoolCountMeasure, view.Count(), tagKeys),
+		common.CreateView(timeoutCountMeasure, view.Count(), tagKeys),
 		common.CreateView(cancelCountMeasure, view.Count(), tagKeys),
 		common.CreateView(placerTimeoutMeasure, view.Count(), tagKeys),
 		common.CreateView(placedErrorCountMeasure, view.Count(), tagKeys),
+		common.CreateView(placedAbortCountMeasure, view.Count(), tagKeys),
 		common.CreateView(placedOKCountMeasure, view.Count(), tagKeys),
 		common.CreateView(retryTooBusyCountMeasure, view.Count(), tagKeys),
 		common.CreateView(retryErrorCountMeasure, view.Count(), tagKeys),


### PR DESCRIPTION
For the sake of completeness and also as defensive coding,
let's record client context cancel/timeout cases. In retry
reason, if error is same as client context (timeout/cancel),
we should not report as retry due to error. Similarly in
placed calls, do not flag the placed call as error if client
canceled or timedout. We track client context timeout/cancel
separately in addition to this.