### PR TITLE
Add a way to disable admin profiler

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -119,6 +119,9 @@ const (
 	// EnvMaxRequestSize sets the limit in bytes for any API request's length.
 	EnvMaxRequestSize = "FN_MAX_REQUEST_SIZE"
 
+	// EnvEnableAdminProfiler is used to enable the profiler for the admin API
+	EnvEnableAdminProfiler = "FN_ENABLE_ADMIN_PROFILER"
+
 	// DefaultLogFormat is text
 	DefaultLogFormat = "text"
 
@@ -1099,7 +1102,14 @@ func (s *Server) bindHandlers(ctx context.Context) {
 		admin.GET("/metrics", gin.WrapH(s.promExporter))
 	}
 
-	profilerSetup(admin, "/debug")
+	profilerEnabled, err := strconv.ParseBool(getEnv(EnvEnableAdminProfiler, "true"))
+	if err != nil {
+		profilerEnabled = true
+	}
+
+	if profilerEnabled {
+		profilerSetup(admin, "/debug")
+	}
 
 	// Pure runners don't have any route, they have grpc
 	switch s.nodeType {


### PR DESCRIPTION
This change adds a way to disable the admin profiler when the admin
server is enabled.

I added a new env variable that can be used to disable the admin profiler
To verify it you can:
- Enable the admin api
- set the "FN_ENABLE_ADMIN_PROFILER" to "false"
-  GET the admin_api:admin_port/debug/vars, you should get an error


