### PR TITLE
Enable extensible middleware for admin API

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1090,6 +1090,8 @@ func (s *Server) bindHandlers(ctx context.Context) {
 	admin := s.AdminRouter
 	// now for extensible middleware
 	engine.Use(s.rootMiddlewareWrapper())
+	// extensible middleware for the admin API
+	admin.Use(s.apiMiddlewareWrapper())
 
 	engine.GET("/", handlePing)
 	admin.GET("/version", handleVersion)


### PR DESCRIPTION
We need to inject in the gin middleware the function which allows to
load and extend the middleware with custom ones.

Fixes: #1326

