### PR TITLE
fn: container init timeout should be a 504

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -41,7 +41,7 @@ var (
 		error: errors.New("Docker pull timed out"),
 	}
 	ErrContainerInitTimeout = err{
-		code:  http.StatusServiceUnavailable,
+		code:  http.StatusGatewayTimeout,
 		error: errors.New("Container initialization timed out, please ensure you are using the latest fdk / format and check the logs"),
 	}
 	ErrUnsupportedMediaType = err{


### PR DESCRIPTION
Too-Busy 503 is a retriable error, this error
should be 504 instead. Fn LB will attempt to retry a 503.