### PR TITLE
fn: latency metrics for various call states

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -279,6 +279,9 @@ type call struct {
 	requestState RequestState
 	slotHashId   string
 
+	// amount of time attributed to user-code execution
+	userExecTime *time.Duration
+
 	// LB & Pure Runner Extra Config
 	extensions map[string]string
 }
@@ -309,6 +312,17 @@ func (c *call) ResponseWriter() http.ResponseWriter {
 
 func (c *call) StdErr() io.ReadWriteCloser {
 	return c.stderr
+}
+
+func (c *call) AddUserExecutionTime(dur time.Duration) {
+	if c.userExecTime == nil {
+		c.userExecTime = new(time.Duration)
+	}
+	*c.userExecTime += dur
+}
+
+func (c *call) GetUserExecutionTime() *time.Duration {
+	return c.userExecTime
 }
 
 func (c *call) Model() *models.Call { return c.Call }

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -353,14 +353,16 @@ func recordCallLatency(ctx context.Context, call *call, status string) {
 	// request processing latency as observed by runner agent.
 	execLatency := call.GetUserExecutionTime()
 
-	// some sanity check before
-	if execLatency != nil && *execLatency > callLatency {
-		common.Logger(ctx).Errorf("invalid latency callLatency=%v execLatency=%v", callLatency, execLatency)
-		return
-	}
+	// some sanity check before. If sanity checks flags something, then
+	// this is likely that runners are sending malicious/suspicious data.
 	if execLatency != nil {
+		if *execLatency >= callLatency {
+			common.Logger(ctx).Errorf("invalid latency callLatency=%v execLatency=%v", callLatency, execLatency)
+			return
+		}
 		callLatency -= *execLatency
 	}
+
 	statsCallLatency(ctx, callLatency, status)
 }
 

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -125,6 +125,9 @@ type mockRunnerCall struct {
 	stdErr     io.ReadWriteCloser
 	model      *models.Call
 	slotHashId string
+
+	// amount of time user execution inside container
+	userExecTime *time.Duration
 }
 
 func (c *mockRunnerCall) SlotHashId() string {
@@ -149,6 +152,17 @@ func (c *mockRunnerCall) StdErr() io.ReadWriteCloser {
 
 func (c *mockRunnerCall) Model() *models.Call {
 	return c.model
+}
+
+func (c *mockRunnerCall) AddUserExecutionTime(dur time.Duration) {
+	if c.userExecTime == nil {
+		c.userExecTime = new(time.Duration)
+	}
+	*c.userExecTime += dur
+}
+
+func (c *mockRunnerCall) GetUserExecutionTime() *time.Duration {
+	return c.userExecTime
 }
 
 func setupMockRunnerPool(expectedRunners []string, execSleep time.Duration, maxCalls int32) *mockRunnerPool {

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
@@ -61,4 +62,7 @@ type RunnerCall interface {
 	ResponseWriter() http.ResponseWriter
 	StdErr() io.ReadWriteCloser
 	Model() *models.Call
+	// For metrics/stats, add special accounting for time spent in customer code
+	AddUserExecutionTime(dur time.Duration)
+	GetUserExecutionTime() *time.Duration
 }

--- a/test/fn-system-tests/exec_runner_status_test.go
+++ b/test/fn-system-tests/exec_runner_status_test.go
@@ -94,12 +94,14 @@ func TestCannotExecuteStatusImage(t *testing.T) {
 type myCall struct{}
 
 // implements RunnerCall
-func (c *myCall) SlotHashId() string                  { return "" }
-func (c *myCall) Extensions() map[string]string       { return nil }
-func (c *myCall) RequestBody() io.ReadCloser          { return nil }
-func (c *myCall) ResponseWriter() http.ResponseWriter { return nil }
-func (c *myCall) StdErr() io.ReadWriteCloser          { return nil }
-func (c *myCall) Model() *models.Call                 { return nil }
+func (c *myCall) SlotHashId() string                   { return "" }
+func (c *myCall) Extensions() map[string]string        { return nil }
+func (c *myCall) RequestBody() io.ReadCloser           { return nil }
+func (c *myCall) ResponseWriter() http.ResponseWriter  { return nil }
+func (c *myCall) StdErr() io.ReadWriteCloser           { return nil }
+func (c *myCall) Model() *models.Call                  { return nil }
+func (c *myCall) GetUserExecutionTime() *time.Duration { return nil }
+func (c *myCall) AddUserExecutionTime(time.Duration)   {}
 
 func TestExecuteRunnerStatus(t *testing.T) {
 	buf := setLogBuffer()

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -110,6 +110,7 @@ func setUpSystem() (*state, error) {
 
 func downloadMetrics() {
 
+	time.Sleep(4 * time.Second)
 	fileName, ok := os.LookupEnv("SYSTEM_TEST_PROMETHEUS_FILE")
 	if !ok || fileName == "" {
 		return
@@ -225,7 +226,7 @@ func SetUpLBNode(ctx context.Context) (*server.Server, error) {
 	placerCfg := pool.NewPlacerConfig()
 	placer := pool.NewNaivePlacer(&placerCfg)
 
-	keys := []string{"fn_appname", "fn_path"}
+	keys := []string{}
 	dist := []float64{1, 10, 50, 100, 250, 500, 1000, 10000, 60000, 120000}
 	pool.RegisterPlacerViews(keys, dist)
 	agent.RegisterLBAgentViews(keys, dist)


### PR DESCRIPTION
This complements the API latency metrics available
on LB agent. In this case, we would like to measure
calls that have finished with the following status:
     "completed"
     "canceled"
     "timeouts"
     "errors"
     "server_busy"
and while measuring this latency, we subtract the
amount of time actual function execution took. This
is not precise, but an approximation mostly suitable
for trending.

Going forward, we could also subtract UDS wait time and/or
docker pull latency from this latency as an enhancement
to this PR.
