### PR TITLE
adds tests for Fn-Call-Id, and adds for timeouts

### DIFF
--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -97,18 +97,16 @@ func (s *Server) fnInvoke(resp http.ResponseWriter, req *http.Request, app *mode
 		return err
 	}
 
+	// add this before submit, always tie a call id to the response at this point
+	writer.Header().Add("Fn-Call-Id", call.Model().ID)
+
 	err = s.agent.Submit(call)
 	if err != nil {
-		if err == models.ErrCallTimeout {
-			// TODO(reed): we could add this header for any error if we want to, or we can just treat it as only for calls that attempted to run, up to us
-			writer.Header().Add("Fn-Call-Id", call.Model().ID) // XXX(reed): move to before Submit when adding streaming
-		}
 		return err
 	}
 
 	// because we can...
 	writer.Header().Set("Content-Length", strconv.Itoa(int(buf.Len())))
-	writer.Header().Add("Fn-Call-Id", call.Model().ID) // XXX(reed): move to before Submit when adding streaming
 
 	// buffered response writer traps status (so we can add headers), we need to write it still
 	if writer.Status() > 0 {

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -99,6 +99,10 @@ func (s *Server) fnInvoke(resp http.ResponseWriter, req *http.Request, app *mode
 
 	err = s.agent.Submit(call)
 	if err != nil {
+		if err == models.ErrCallTimeout {
+			// TODO(reed): we could add this header for any error if we want to, or we can just treat it as only for calls that attempted to run, up to us
+			writer.Header().Add("Fn-Call-Id", call.Model().ID) // XXX(reed): move to before Submit when adding streaming
+		}
 		return err
 	}
 


### PR DESCRIPTION
back when we streamed responses out from the container, we set this header
regardless of whether the task ran or not. now, we're setting this header at
the end since we're doing buffering, only if the task runs successfully atm.
we can change to the old policy pretty readily if we want to, up for
discussion. as this patch presents it, it's just adding a test that it exists
in the normal case and the timeout case, and adding the timeout case. however,
other relevant cases exist, like fdk protocol errors, and we can whitelist
those each or just cover all errors, even if the call was never executed, up
to us. when we add streaming, the plumbing goes back to the way it was where
we just add this at some point before the container writes any headers out of
it, and we can pick what level to do that if we want special behavior around
this header for whether the call executed or not.