### PR TITLE
Make syslog-url nullable in the swagger so it can be explicitly unset

### DIFF
--- a/docs/swagger_v2.yml
+++ b/docs/swagger_v2.yml
@@ -504,6 +504,7 @@ definitions:
           type: object
       syslog_url:
         type: string
+        x-nullable: true
         description: "A comma separated list of syslog urls to send all function logs to. supports tls, udp or tcp. e.g. tls://logs.papertrailapp.com:1"
       created_at:
         type: string


### PR DESCRIPTION
- What I did
Fixed the swagger spec to allow syslog-url in apps to be nullable, therefore enabling the possibility to distinguish between it being not set and it being explicitly set to an empty string.
The Fn server already handles that distinction, but the swagger did not allow clients to take advantage of that.

- How I did it
The swagger spec is changed to include the `x-nullable` notation for `syslog-url` in the `App` definition.

- How to verify it
Regenerate clients, see that the generated code changes according to the language of choice.

- One line description for the changelog
Fixed the swagger spec to allow syslog-url in apps to be nullable, therefore enabling the possibility to distinguish between it being not set and it being explicitly set to an empty string.