### PR TITLE
Format error string and return do not log error reduce log spamming

### DIFF
--- a/grpcutil/dial.go
+++ b/grpcutil/dial.go
@@ -28,7 +28,7 @@ func dial(ctx context.Context, address string, creds credentials.TransportCreden
 		defer cancel()
 		conn, err := (&net.Dialer{Cancel: ctx.Done(), Timeout: timeoutDialer}).Dial("tcp", address)
 		if err != nil {
-			log.WithError(err).Warn("Failed to dial grpc connection")
+			log.WithError(err).Debug("Failed to dial grpc connection")
 			return nil, err
 		}
 		if creds == nil {
@@ -38,7 +38,7 @@ func dial(ctx context.Context, address string, creds credentials.TransportCreden
 
 		conn, _, err = creds.ClientHandshake(ctx, address, conn)
 		if err != nil {
-			log.Warn("Failed grpc TLS handshake")
+			log.Debug("Failed grpc TLS handshake")
 			return nil, err
 		}
 		return conn, nil


### PR DESCRIPTION
- What I did
Format error string in grpc dial function to reduce log spam.
- How I did it
Changed the error that is returned.
- How to verify it
Read the logs.
- One line description for the changelog
Reduce log spam from grpc dials