### PR TITLE
fn: allow server and client dial keepalive settings

### DIFF
--- a/api/agent/static_pool_test.go
+++ b/api/agent/static_pool_test.go
@@ -2,47 +2,18 @@ package agent
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
 	"testing"
 
 	pool "github.com/fnproject/fn/api/runnerpool"
 )
 
 func setupStaticPool(runners []string) pool.RunnerPool {
-	return NewStaticRunnerPool(runners, nil, mockRunnerFactory)
-}
-
-var (
-	ErrorGarbanzoBeans = errors.New("yes, that's right. Garbanzo beans...")
-)
-
-type mockStaticRunner struct {
-	address string
-}
-
-func (r *mockStaticRunner) TryExec(ctx context.Context, call pool.RunnerCall) (bool, error) {
-	return true, nil
-}
-
-func (r *mockStaticRunner) Status(ctx context.Context) (*pool.RunnerStatus, error) {
-	return nil, nil
-}
-
-func (r *mockStaticRunner) Close(context.Context) error {
-	return ErrorGarbanzoBeans
-}
-
-func (r *mockStaticRunner) Address() string {
-	return r.address
-}
-
-func mockRunnerFactory(addr string, tlsConf *tls.Config) (pool.Runner, error) {
-	return &mockStaticRunner{address: addr}, nil
+	return NewStaticRunnerPool(runners, nil)
 }
 
 func TestNewStaticPool(t *testing.T) {
-	addrs := []string{"127.0.0.1:8080", "127.0.0.1:8081"}
+	// TEST-NET-1 unreachable
+	addrs := []string{"192.0.2.255:8080", "192.0.2.255:8081"}
 	np := setupStaticPool(addrs)
 
 	runners, err := np.Runners(context.Background(), nil)
@@ -54,8 +25,8 @@ func TestNewStaticPool(t *testing.T) {
 	}
 
 	err = np.Shutdown(context.Background())
-	if err != ErrorGarbanzoBeans {
-		t.Fatalf("Expected garbanzo beans error from shutdown %v", err)
+	if err != nil {
+		t.Fatalf("Expected no error from shutdown %v", err)
 	}
 }
 

--- a/api/runnerpool/runner_pool.go
+++ b/api/runnerpool/runner_pool.go
@@ -2,7 +2,6 @@ package runnerpool
 
 import (
 	"context"
-	"crypto/tls"
 	"io"
 	"net/http"
 	"time"
@@ -24,9 +23,6 @@ type RunnerPool interface {
 	Runners(ctx context.Context, call RunnerCall) ([]Runner, error)
 	Shutdown(ctx context.Context) error
 }
-
-// MTLSRunnerFactory represents a factory method for constructing runners using mTLS
-type MTLSRunnerFactory func(addr string, tlsConf *tls.Config) (Runner, error)
 
 // RunnerStatus is general information on Runner health as returned by Runner::Status() call
 type RunnerStatus struct {


### PR DESCRIPTION
Clients/Servers should be allowed to pass options to
grpc server or grpc dial. As an example, client and
server keepalive settings are used in system tests
to demonstrate.

MTLSRunnerFactory type is also removed as this
hinders extensibility.