### PR TITLE
fn: add status call prometheus metrics

### DIFF
--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -939,6 +939,10 @@ func (pr *pureRunner) Status(ctx context.Context, _ *empty.Empty) (*runner.Runne
 	if err != nil {
 		common.Logger(ctx).WithError(err).Errorf("Status call failed result=%+v", status)
 	}
+
+	isCached := err == nil && (status != nil && status.Cached)
+	isSuccess := err == nil && (status != nil && !status.Failed)
+	statsStatusCall(ctx, isCached, isSuccess)
 	return status, err
 }
 

--- a/cmd/fnserver/main.go
+++ b/cmd/fnserver/main.go
@@ -40,6 +40,7 @@ func registerViews() {
 	// 10% granularity buckets
 	cpuDist := []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
 
+	agent.RegisterRunnerViews(keys, latencyDist)
 	agent.RegisterAgentViews(keys, latencyDist)
 	agent.RegisterDockerViews(keys, latencyDist, ioDist, ioDist, memoryDist, cpuDist)
 	agent.RegisterContainerViews(keys, latencyDist)

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -39,6 +39,11 @@ const (
 	StatusImage = "fnproject/fn-status-checker:latest"
 )
 
+var (
+	viewKeys = []string{}
+	viewDist = []float64{1, 10, 50, 100, 250, 500, 1000, 10000, 60000, 120000}
+)
+
 func LB() (string, error) {
 	u, err := url.Parse(LBAddress)
 	if err != nil {
@@ -240,10 +245,9 @@ func SetUpLBNode(ctx context.Context) (*server.Server, error) {
 	placerCfg := pool.NewPlacerConfig()
 	placer := pool.NewNaivePlacer(&placerCfg)
 
-	keys := []string{}
-	dist := []float64{1, 10, 50, 100, 250, 500, 1000, 10000, 60000, 120000}
-	pool.RegisterPlacerViews(keys, dist)
-	agent.RegisterLBAgentViews(keys, dist)
+	pool.RegisterPlacerViews(viewKeys, viewDist)
+	agent.RegisterLBAgentViews(viewKeys, viewDist)
+	agent.RegisterRunnerViews(viewKeys, viewDist) // yes, runner views via LB, we are a single process/exporter
 
 	// Create an LB Agent with a Call Overrider to intercept calls in GetCall(). Overrider in this example
 	// scrubs CPU/TmpFsSize and adds FN_CHEESE key/value into extensions.


### PR DESCRIPTION
Simple metric to show number of status call executions with
cache/success prometheus tags.
