### PR TITLE
remove unused images when total image size exceeds a limit

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -228,6 +228,8 @@ func NewDockerDriver(cfg *Config) (drivers.Driver, error) {
 		EnableReadOnlyRootFs: !cfg.DisableReadOnlyRootFs,
 		MaxRetries:           cfg.MaxDockerRetries,
 		ContainerLabelTag:    cfg.ContainerLabelTag,
+		ImageCleanMaxSize:    cfg.ImageCleanMaxSize,
+		ImageCleanExemptTags: cfg.ImageCleanExemptTags,
 	})
 }
 

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -80,9 +80,13 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		logrus.WithError(err).Fatal("couldn't resolve hostname")
 	}
 
-	instanceId, err := generateRandUUID()
-	if err != nil {
-		logrus.WithError(err).Fatal("couldn't initialize instanceId")
+	// This is for testing purposes. Tests override with custom id
+	instanceId := conf.InstanceId
+	if instanceId == "" {
+		instanceId, err = generateRandUUID()
+		if err != nil {
+			logrus.WithError(err).Fatal("couldn't initialize instanceId")
+		}
 	}
 
 	auths, err := registryFromEnv()
@@ -100,9 +104,14 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		instanceId: instanceId,
 	}
 
-	// This is for testing purposes. Tests override with custom id
-	if conf.InstanceId != "" {
-		driver.instanceId = conf.InstanceId
+	if driver.conf.ImageCleanMaxSize > 0 {
+		exemptImages := strings.Fields(conf.ImageCleanExemptTags)
+		// we never want to remove prefork image
+		if conf.PreForkPoolSize != 0 {
+			exemptImages = append(exemptImages, conf.PreForkImage)
+		}
+		// WARNING: assuming images in conf.DockerLoadFile are also added in conf.ImageCleanExemptTags
+		driver.imgCache = NewImageCache(exemptImages, conf.ImageCleanMaxSize)
 	}
 
 	nets := strings.Fields(conf.DockerNetworks)
@@ -118,8 +127,12 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		logrus.WithError(err).Fatal("docker version error")
 	}
 
-	// start the cleanup as early as possible
-	go containerCleaner(ctx, driver)
+	// start the cleanup jobs as early as possible
+	go func() {
+		killLeakedContainers(ctx, driver)
+		syncImageCleaner(ctx, driver)
+		runImageCleaner(ctx, driver)
+	}()
 
 	// before we do anything else, let's pre-load requested images
 	err = loadDockerImages(ctx, driver)
@@ -132,21 +145,13 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		driver.pool = NewDockerPool(conf, driver)
 	}
 
-	if driver.conf.ImageCleanMaxSize > 0 {
-		driver.imgCache = NewImageCache(conf.ImageCleanExemptTags, conf.ImageCleanMaxSize)
-		go func() {
-			syncImageCleaner(ctx, driver)
-			runImageCleaner(ctx, driver)
-		}()
-	}
-
 	return driver
 }
 
-// containerCleaner scans and destroys previously left over containers that were managed
+// killLeakedContainers scans and destroys previously left over containers that were managed
 // by this docker driver. This operation is executed once and if it fails, it will not
 // retry the procedure.
-func containerCleaner(ctx context.Context, driver *DockerDriver) {
+func killLeakedContainers(ctx context.Context, driver *DockerDriver) {
 
 	// Label Tag is used to isolate this cleanup. If docker has other containers
 	// that are not managed by fn-agent, then this tag can make sure those containers
@@ -197,7 +202,13 @@ func containerCleaner(ctx context.Context, driver *DockerDriver) {
 	}
 }
 
+// syncImageCleaner lists the current images on the system and adds them to the
+// image cache. The operation is performed once during startup to ensure a
+// restart of the fn-agent keeps track of previous state.
 func syncImageCleaner(ctx context.Context, driver *DockerDriver) {
+	if driver.imgCache == nil {
+		return
+	}
 
 	const imageListTimeout = time.Duration(60 * time.Second)
 
@@ -206,9 +217,7 @@ func syncImageCleaner(ctx context.Context, driver *DockerDriver) {
 
 	for limiter.Wait(ctx) != nil {
 		ctx, cancel := context.WithTimeout(ctx, imageListTimeout)
-		images, err := driver.docker.ListImages(docker.ListImagesOptions{
-			Context: ctx,
-		})
+		images, err := driver.docker.ListImages(docker.ListImagesOptions{Context: ctx})
 		cancel()
 
 		if err == nil {
@@ -227,7 +236,13 @@ func syncImageCleaner(ctx context.Context, driver *DockerDriver) {
 	}
 }
 
+// runImageCleaner runs continuously and monitors image cache state. If the
+// cache is over the high water mark limit, then it tries to least recently
+// used image.
 func runImageCleaner(ctx context.Context, driver *DockerDriver) {
+	if driver.imgCache == nil {
+		return
+	}
 
 	const removeImgTimeout = time.Duration(60 * time.Second)
 
@@ -249,13 +264,11 @@ func runImageCleaner(ctx context.Context, driver *DockerDriver) {
 			log.Infof("Removing %+v", img)
 
 			ctx, cancel := context.WithTimeout(ctx, removeImgTimeout)
-			err := driver.docker.RemoveImage(img.ID, docker.RemoveImageOptions{
-				Context: ctx,
-			})
+			err := driver.docker.RemoveImage(img.ID, docker.RemoveImageOptions{Context: ctx})
 			cancel()
 			if err != nil && err != docker.ErrNoSuchImage {
 				log.WithError(err).Infof("Removing image %+v failed", img)
-				// this must be in use or can't be removed or docker just timed out, add it back to the cache
+				// in-use or can't be removed or docker just timed out, try to add it back to the cache
 				driver.imgCache.Update(img)
 			}
 		}

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -213,7 +213,7 @@ func syncImageCleaner(ctx context.Context, driver *DockerDriver) {
 	const imageListTimeout = time.Duration(60 * time.Second)
 
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "syncImageCleaner"})
-	limiter := rate.NewLimiter(0.5, 1)
+	limiter := rate.NewLimiter(2.0, 1)
 
 	for limiter.Wait(ctx) == nil {
 		ctx, cancel := context.WithTimeout(ctx, imageListTimeout)
@@ -248,7 +248,7 @@ func runImageCleaner(ctx context.Context, driver *DockerDriver) {
 	const removeImgTimeout = time.Duration(60 * time.Second)
 
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "runImageCleaner"})
-	limiter := rate.NewLimiter(0.5, 1)
+	limiter := rate.NewLimiter(2.0, 1)
 	notifier := driver.imgCache.GetNotifier()
 
 	for limiter.Wait(ctx) == nil {

--- a/api/agent/drivers/docker/docker_client.go
+++ b/api/agent/drivers/docker/docker_client.go
@@ -426,7 +426,7 @@ func (d *dockerWrap) RemoveImage(image string, opts docker.RemoveImageOptions) (
 
 	ctx, _ = common.LoggerWithFields(ctx, logrus.Fields{"docker_cmd": "RemoveImage"})
 	err = d.retry(ctx, func() error {
-		err = d.RemoveImage(image, opts)
+		err = d.docker.RemoveImageExtended(image, opts)
 		return err
 	})
 	return err

--- a/api/agent/drivers/docker/image_cache.go
+++ b/api/agent/drivers/docker/image_cache.go
@@ -133,7 +133,7 @@ func (c *imageCacher) addBusyLocked(img *CachedImage) bool {
 }
 
 // rmBusyLocked updates an image in the in-use list and returns true if
-// the image is no longer in the in-use list.
+// the image is removed from the in-use list.
 func (c *imageCacher) rmBusyLocked(img *CachedImage) bool {
 	if ee, ok := c.busyRef[img.ID]; ok {
 		if ee > 1 {

--- a/api/agent/drivers/docker/image_cache.go
+++ b/api/agent/drivers/docker/image_cache.go
@@ -142,8 +142,9 @@ func (c *imageCacher) rmBusyLocked(img *CachedImage) bool {
 		}
 		delete(c.busyRef, img.ID)
 		c.busySize -= img.Size
+		return true
 	}
-	return true
+	return false
 }
 
 // sendNotify tries to wake up any pending listener on notify channel

--- a/api/agent/drivers/docker/image_cache.go
+++ b/api/agent/drivers/docker/image_cache.go
@@ -1,0 +1,196 @@
+package docker
+
+import (
+	"container/list"
+	"sync"
+)
+
+type CachedImage struct {
+	ID       string
+	ParentID string
+	RepoTags []string
+	Size     uint64
+}
+
+type ImageCacher interface {
+	IsMaxCapacity() bool
+	Update(img *CachedImage)
+	Pop() *CachedImage
+	GetNotifier() chan struct{}
+
+	MarkBusy(img *CachedImage)
+	MarkFree(img *CachedImage)
+}
+
+type imageCacher struct {
+	maxSize     uint64
+	blockedTags map[string]struct{}
+	notifier    chan struct{}
+
+	// big lock for both busy and lru elements below
+	lock sync.Mutex
+
+	lruSize uint64
+	lruList *list.List
+	lruMap  map[string]*list.Element
+
+	busySize uint64
+	busyRef  map[string]uint64
+}
+
+func NewImageCache(exemptTags []string, maxSize uint64) ImageCacher {
+	c := imageCacher{
+		maxSize:     maxSize,
+		blockedTags: make(map[string]struct{}),
+		notifier:    make(chan struct{}, 1),
+		lruList:     list.New(),
+		lruMap:      make(map[string]*list.Element),
+		busyRef:     make(map[string]uint64),
+	}
+
+	for _, tag := range exemptTags {
+		c.blockedTags[tag] = struct{}{}
+	}
+
+	return &c
+}
+
+func (c *imageCacher) isBlocked(img *CachedImage) bool {
+	for _, tag := range img.RepoTags {
+		if _, ok := c.blockedTags[tag]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *imageCacher) addLRULocked(img *CachedImage) {
+	ee, ok := c.lruMap[img.ID]
+	if ok {
+		c.lruList.MoveToFront(ee)
+	} else {
+		c.lruSize += img.Size
+		c.lruMap[img.ID] = c.lruList.PushFront(&img)
+	}
+}
+
+func (c *imageCacher) rmLRULocked(img *CachedImage) {
+	ee, ok := c.lruMap[img.ID]
+	if ok {
+		c.lruList.Remove(ee)
+		delete(c.lruMap, img.ID)
+		c.lruSize -= ee.Value.(*CachedImage).Size
+	}
+}
+
+func (c *imageCacher) sendNotify() {
+	select {
+	case c.notifier <- struct{}{}:
+	default:
+	}
+}
+
+func (c *imageCacher) GetNotifier() chan struct{} {
+	return c.notifier
+}
+
+// We compare both busy + lru size against max. However, we also check if lru is not empty.
+// This is because there's no point to show over capacity if Pop() is going to return nil.
+func (c *imageCacher) isMaxCapacityLocked() bool {
+	return (c.lruSize > 0) && ((c.lruSize + c.busySize) >= c.maxSize)
+}
+
+func (c *imageCacher) IsMaxCapacity() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.isMaxCapacityLocked()
+}
+
+func (c *imageCacher) Update(img *CachedImage) {
+	if c.isBlocked(img) {
+		return
+	}
+
+	c.lock.Lock()
+	c.addLRULocked(img)
+	doNotify := c.isMaxCapacityLocked()
+	c.lock.Unlock()
+
+	if doNotify {
+		c.sendNotify()
+	}
+}
+
+func (c *imageCacher) Pop() *CachedImage {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	item := c.lruList.Back()
+	if item == nil {
+		return nil
+	}
+	img := item.Value.(*CachedImage)
+	c.rmLRULocked(img)
+	return img
+}
+
+func (c *imageCacher) addBusyLocked(img *CachedImage) {
+	ee, ok := c.busyRef[img.ID]
+	if !ok {
+		c.busyRef[img.ID] = 1
+		c.busySize += img.Size
+	} else {
+		c.busyRef[img.ID] = 1 + ee
+	}
+}
+
+func (c *imageCacher) rmBusyLocked(img *CachedImage) bool {
+	ee, ok := c.busyRef[img.ID]
+	if !ok {
+		return true
+	}
+	if ee == 1 {
+		c.busySize -= img.Size
+		delete(c.busyRef, img.ID)
+		return true
+	}
+	c.busyRef[img.ID] = ee - 1
+	return false
+}
+
+func (c *imageCacher) MarkBusy(img *CachedImage) {
+	if c.isBlocked(img) {
+		return
+	}
+
+	c.lock.Lock()
+
+	c.addBusyLocked(img)
+	c.rmLRULocked(img)
+	doNotify := c.isMaxCapacityLocked()
+
+	c.lock.Unlock()
+
+	if doNotify {
+		c.sendNotify()
+	}
+}
+
+func (c *imageCacher) MarkFree(img *CachedImage) {
+	if c.isBlocked(img) {
+		return
+	}
+
+	c.lock.Lock()
+
+	if c.rmBusyLocked(img) {
+		c.addLRULocked(img)
+	}
+	doNotify := c.isMaxCapacityLocked()
+
+	c.lock.Unlock()
+
+	if doNotify {
+		c.sendNotify()
+	}
+}

--- a/api/agent/drivers/docker/image_cache.go
+++ b/api/agent/drivers/docker/image_cache.go
@@ -5,6 +5,17 @@ import (
 	"sync"
 )
 
+// ImageCacher is an image tracker for docker driver. It consists
+// of a LRU cache and a reference count map. It keeps of both in-use
+// and not in-use images and if the total size exceeds the configured
+// limit, then it notifies its consumer. The consumer is expected to
+// use IsMaxCapacity()/GetNotifier() functions to keep track of the
+// capacity state and is expected to use Pop() function to remove a
+// least recently used image from the cache. ImageCacher provides
+// Update() to add/update the LRU cache and MarkBusy()/MarkFree()
+// function pair to mark/unmark a specific image (reference count)
+// in use.
+
 type CachedImage struct {
 	ID       string
 	ParentID string
@@ -13,57 +24,81 @@ type CachedImage struct {
 }
 
 type ImageCacher interface {
+	// IsMaxCapacity returns true if total size of all images exceeds the limit
+	// and if there's an image in LRU cache that can be removed.
 	IsMaxCapacity() bool
-	Update(img *CachedImage)
-	Pop() *CachedImage
-	GetNotifier() chan struct{}
 
+	// GetNotifier returns a channel that can be monitored. The channel will return
+	// data every time IsMaxCapacity() flips from false to true state.
+	GetNotifier() <-chan struct{}
+
+	// Removes an image from the LRU cache if cache is not empty
+	Pop() *CachedImage
+
+	// Update adds an image to the LRU cache if the image is not marked in-use
+	Update(img *CachedImage)
+
+	// Mark/Unmark an image in-use. If an image is in-use, it will
+	// not be a candidate in LRU. When the reference count of the
+	// image drops to zero (via MarkFree() calls), the image will
+	// be added back to LRU.
 	MarkBusy(img *CachedImage)
 	MarkFree(img *CachedImage)
 }
 
 type imageCacher struct {
-	maxSize     uint64
-	blockedTags map[string]struct{}
-	notifier    chan struct{}
+	// max total size of images that are in-use or in LRU cache
+	maxSize uint64
+
+	// image names/tags that are not eligible for image cacher
+	blacklistTags map[string]struct{}
+
+	// notification channel for/when image cacher is over capacity
+	// and has an LRU candidate
+	notifier chan struct{}
 
 	// big lock for both busy and lru elements below
 	lock sync.Mutex
 
+	// LRU for images that are not in-use
 	lruSize uint64
 	lruList *list.List
 	lruMap  map[string]*list.Element
 
+	// reference count of images that are in-use
 	busySize uint64
 	busyRef  map[string]uint64
 }
 
 func NewImageCache(exemptTags []string, maxSize uint64) ImageCacher {
 	c := imageCacher{
-		maxSize:     maxSize,
-		blockedTags: make(map[string]struct{}),
-		notifier:    make(chan struct{}, 1),
-		lruList:     list.New(),
-		lruMap:      make(map[string]*list.Element),
-		busyRef:     make(map[string]uint64),
+		maxSize:       maxSize,
+		blacklistTags: make(map[string]struct{}),
+		notifier:      make(chan struct{}, 1),
+		lruList:       list.New(),
+		lruMap:        make(map[string]*list.Element),
+		busyRef:       make(map[string]uint64),
 	}
 
 	for _, tag := range exemptTags {
-		c.blockedTags[tag] = struct{}{}
+		c.blacklistTags[tag] = struct{}{}
 	}
 
 	return &c
 }
 
-func (c *imageCacher) isBlocked(img *CachedImage) bool {
+// isEligible returns true if the image is eligible to be managed
+// by image cacher.
+func (c *imageCacher) isEligible(img *CachedImage) bool {
 	for _, tag := range img.RepoTags {
-		if _, ok := c.blockedTags[tag]; ok {
-			return true
+		if _, ok := c.blacklistTags[tag]; ok {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
+// addLRULocked performs a classic LRU add operation
 func (c *imageCacher) addLRULocked(img *CachedImage) {
 	ee, ok := c.lruMap[img.ID]
 	if ok {
@@ -74,6 +109,7 @@ func (c *imageCacher) addLRULocked(img *CachedImage) {
 	}
 }
 
+// addLRULocked performs a classic LRU remove operation
 func (c *imageCacher) rmLRULocked(img *CachedImage) {
 	ee, ok := c.lruMap[img.ID]
 	if ok {
@@ -83,67 +119,21 @@ func (c *imageCacher) rmLRULocked(img *CachedImage) {
 	}
 }
 
-func (c *imageCacher) sendNotify() {
-	select {
-	case c.notifier <- struct{}{}:
-	default:
-	}
-}
-
-func (c *imageCacher) GetNotifier() chan struct{} {
-	return c.notifier
-}
-
-// We compare both busy + lru size against max. However, we also check if lru is not empty.
-// This is because there's no point to show over capacity if Pop() is going to return nil.
-func (c *imageCacher) isMaxCapacityLocked() bool {
-	return (c.lruSize > 0) && ((c.lruSize + c.busySize) >= c.maxSize)
-}
-
-func (c *imageCacher) IsMaxCapacity() bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	return c.isMaxCapacityLocked()
-}
-
-func (c *imageCacher) Update(img *CachedImage) {
-	if c.isBlocked(img) {
-		return
-	}
-
-	c.lock.Lock()
-	c.addLRULocked(img)
-	doNotify := c.isMaxCapacityLocked()
-	c.lock.Unlock()
-
-	if doNotify {
-		c.sendNotify()
-	}
-}
-
-func (c *imageCacher) Pop() *CachedImage {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	item := c.lruList.Back()
-	if item == nil {
-		return nil
-	}
-	img := item.Value.(*CachedImage)
-	c.rmLRULocked(img)
-	return img
-}
-
-func (c *imageCacher) addBusyLocked(img *CachedImage) {
+// addBusyLocked updates an image in the in-use list and returns true if
+// a new insertion to in-use list was performed.
+func (c *imageCacher) addBusyLocked(img *CachedImage) bool {
 	ee, ok := c.busyRef[img.ID]
 	if !ok {
 		c.busyRef[img.ID] = 1
 		c.busySize += img.Size
-	} else {
-		c.busyRef[img.ID] = 1 + ee
+		return true
 	}
+	c.busyRef[img.ID] = 1 + ee
+	return false
 }
 
+// rmBusyLocked updates an image in the in-use list and returns true if
+// the image is no longer in the in-use list.
 func (c *imageCacher) rmBusyLocked(img *CachedImage) bool {
 	ee, ok := c.busyRef[img.ID]
 	if !ok {
@@ -158,26 +148,84 @@ func (c *imageCacher) rmBusyLocked(img *CachedImage) bool {
 	return false
 }
 
-func (c *imageCacher) MarkBusy(img *CachedImage) {
-	if c.isBlocked(img) {
+// sendNotify tries to wake up any pending listener on notify channel
+func (c *imageCacher) sendNotify() {
+	select {
+	case c.notifier <- struct{}{}:
+	default:
+	}
+}
+
+// We compare both busy + lru size against max. However, we also check if lru is not empty.
+// This is because there's no point to show over capacity if Pop() is going to return nil.
+func (c *imageCacher) isMaxCapacityLocked() bool {
+	return (c.lruSize > 0) && ((c.lruSize + c.busySize) >= c.maxSize)
+}
+
+func (c *imageCacher) GetNotifier() <-chan struct{} {
+	return c.notifier
+}
+
+func (c *imageCacher) IsMaxCapacity() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.isMaxCapacityLocked()
+}
+
+// Update adds an image to LRU if the image is not in-use.
+func (c *imageCacher) Update(img *CachedImage) {
+	if !c.isEligible(img) {
 		return
 	}
 
 	c.lock.Lock()
 
-	c.addBusyLocked(img)
-	c.rmLRULocked(img)
-	doNotify := c.isMaxCapacityLocked()
+	if _, ok := c.busyRef[img.ID]; !ok {
+		c.addLRULocked(img)
+		if c.isMaxCapacityLocked() {
+			defer c.sendNotify()
+		}
+	}
 
 	c.lock.Unlock()
-
-	if doNotify {
-		c.sendNotify()
-	}
 }
 
+// Pop removes and returns an image from LRU if LRU is not empty
+func (c *imageCacher) Pop() *CachedImage {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	item := c.lruList.Back()
+	if item == nil {
+		return nil
+	}
+	img := item.Value.(*CachedImage)
+	c.rmLRULocked(img)
+	return img
+}
+
+// MarkBusy marks an image as in-use and removes it from LRU
+func (c *imageCacher) MarkBusy(img *CachedImage) {
+	if !c.isEligible(img) {
+		return
+	}
+
+	c.lock.Lock()
+
+	if c.addBusyLocked(img) {
+		c.rmLRULocked(img)
+		if c.isMaxCapacityLocked() {
+			defer c.sendNotify()
+		}
+	}
+
+	c.lock.Unlock()
+}
+
+// MarkFree marks an image as not in-use and if in-use reference count
+// for the image becomes zero, then MarkFree adds the image to the LRU
 func (c *imageCacher) MarkFree(img *CachedImage) {
-	if c.isBlocked(img) {
+	if !c.isEligible(img) {
 		return
 	}
 
@@ -185,12 +233,10 @@ func (c *imageCacher) MarkFree(img *CachedImage) {
 
 	if c.rmBusyLocked(img) {
 		c.addLRULocked(img)
+		if c.isMaxCapacityLocked() {
+			defer c.sendNotify()
+		}
 	}
-	doNotify := c.isMaxCapacityLocked()
 
 	c.lock.Unlock()
-
-	if doNotify {
-		c.sendNotify()
-	}
 }

--- a/api/agent/drivers/docker/image_cache_test.go
+++ b/api/agent/drivers/docker/image_cache_test.go
@@ -1,0 +1,252 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func isNotifySet(ctx context.Context, notify <-chan struct{}) bool {
+	select {
+	case <-notify:
+		return true
+	case <-ctx.Done():
+	case <-time.After(600 * time.Millisecond):
+	}
+	return false
+}
+
+func TestImageCacherBasic1(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	blTag := "zoo"
+	obj := NewImageCache([]string{blTag}, 20)
+	rec := obj.GetNotifier()
+	inner := obj.(*imageCacher)
+
+	salsa1 := &CachedImage{
+		ID:       "salsa1",
+		RepoTags: []string{blTag},
+		Size:     uint64(25),
+	}
+	salsa2 := &CachedImage{
+		ID:       "salsa2",
+		RepoTags: []string{blTag},
+		Size:     uint64(25),
+	}
+	salsa3 := &CachedImage{
+		ID:   "salsa3",
+		Size: uint64(5),
+	}
+	salsa4 := &CachedImage{
+		ID:   "salsa4",
+		Size: uint64(5),
+	}
+
+	if obj.IsMaxCapacity() {
+		t.Fatalf("empty cache %v over capacity?", inner)
+	}
+
+	item := obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	// Blacklisted images, these all should be no-op
+	obj.Update(salsa1)
+	obj.MarkBusy(salsa2)
+	obj.MarkFree(salsa2)
+
+	if obj.IsMaxCapacity() {
+		t.Fatalf("empty cache %v over capacity?", inner)
+	}
+
+	item = obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	if isNotifySet(ctx, rec) {
+		t.Fatalf("empty cache %v with notify!", inner)
+	}
+
+	// Capacity 0 -> 5
+	obj.Update(salsa3)
+	// No Capacity change
+	obj.MarkBusy(salsa4)
+
+	if obj.IsMaxCapacity() {
+		t.Fatalf("cache %v should have 5 < 20 capacity", inner)
+	}
+
+	if isNotifySet(ctx, rec) {
+		t.Fatalf("cache %v should have 5 < 20 capacity, no ticks", inner)
+	}
+
+	// Capacity 5 -> 0
+	item = obj.Pop()
+	if item == nil || item.ID != "salsa3" {
+		t.Fatalf("cache %v should Pop(%+v) salsa3", inner, item)
+	}
+
+	// Capacity 0 -> 5
+	obj.MarkFree(salsa4)
+
+	item = obj.Pop()
+	if item == nil || item.ID != "salsa4" {
+		t.Fatalf("cache %v should Pop(%+v) salsa4", inner, item)
+	}
+}
+
+func TestImageCacherBasic2(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	obj := NewImageCache([]string{}, 20)
+	inner := obj.(*imageCacher)
+	rec := obj.GetNotifier()
+
+	salsa1 := &CachedImage{
+		ID:   "salsa1",
+		Size: uint64(25),
+	}
+
+	// Capacity 0 -> 25
+	obj.Update(salsa1)
+
+	if !obj.IsMaxCapacity() {
+		t.Fatalf("cache %v should be over capacity", inner)
+	}
+
+	if !isNotifySet(ctx, rec) {
+		t.Fatalf("cache %v should have notify!", inner)
+	}
+
+	item := obj.Pop()
+	if item == nil {
+		t.Fatalf("cache %v should Pop", inner)
+	}
+
+	item = obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	if isNotifySet(ctx, rec) {
+		t.Fatalf("empty cache %v should have no ticks", inner)
+	}
+}
+
+func TestImageCacherBasic3(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	obj := NewImageCache([]string{}, 20)
+	inner := obj.(*imageCacher)
+	rec := obj.GetNotifier()
+
+	img1 := &CachedImage{
+		ID:   "salsa1",
+		Size: uint64(25),
+	}
+
+	obj.Update(img1)
+
+	if !obj.IsMaxCapacity() {
+		t.Fatalf("cache %+v should be over capacity", inner)
+	}
+
+	if !isNotifySet(ctx, rec) {
+		t.Fatalf("cache %+v should have notify!", inner)
+	}
+
+	// Busy with ref count 2
+	obj.MarkBusy(img1)
+	obj.MarkBusy(img1)
+
+	if obj.IsMaxCapacity() {
+		t.Fatalf("cache %+v should not be over capacity", inner)
+	}
+
+	item := obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	if isNotifySet(ctx, rec) {
+		t.Fatalf("empty cache %+v should have no ticks", inner)
+	}
+
+	// ref count 1
+	obj.MarkFree(img1)
+
+	if obj.IsMaxCapacity() {
+		t.Fatalf("cache %+v should not be over capacity", inner)
+	}
+
+	item = obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	if isNotifySet(ctx, rec) {
+		t.Fatalf("empty cache %+v should have no notify", inner)
+	}
+
+	// ref count 0 -> adds to LRU
+	obj.MarkFree(img1)
+
+	if !obj.IsMaxCapacity() {
+		t.Fatalf("cache %+v should be over capacity", inner)
+	}
+
+	item = obj.Pop()
+	if item == nil {
+		t.Fatalf("cache %+v should Pop()", inner)
+	}
+
+	if !isNotifySet(ctx, rec) {
+		t.Fatalf("cache %+v should have notify!", inner)
+	}
+
+	// Should be no-op
+	obj.MarkFree(img1)
+	obj.MarkFree(img1)
+
+}
+
+func TestImageCacherBasic4(t *testing.T) {
+	obj := NewImageCache([]string{}, 20)
+	inner := obj.(*imageCacher)
+
+	img1 := &CachedImage{
+		ID:   "salsa1",
+		Size: uint64(25),
+	}
+
+	obj.MarkBusy(img1)
+
+	item := obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	// This should be a no-op (it is busy)
+	obj.Update(img1)
+
+	item = obj.Pop()
+	if item != nil {
+		t.Fatalf("cache %+v should not Pop(%+v)?", inner, item)
+	}
+
+	obj.MarkFree(img1)
+
+	item = obj.Pop()
+	if item == nil {
+		t.Fatalf("cache %+v should Pop()?", inner)
+	}
+}

--- a/api/agent/drivers/docker/image_cleaner_test.go
+++ b/api/agent/drivers/docker/image_cleaner_test.go
@@ -1,0 +1,142 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+
+	"github.com/fnproject/fn/api/agent/drivers"
+)
+
+type mockClient struct {
+	dockerWrap
+	listImages    []docker.APIImages
+	removedImages []string
+
+	inspectImage    *docker.Image
+	inspectImageErr error
+}
+
+func (c *mockClient) ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error) {
+	return c.listImages, nil
+}
+func (c *mockClient) RemoveImage(id string, opts docker.RemoveImageOptions) error {
+	c.removedImages = append(c.removedImages, id)
+	return nil
+}
+func (c *mockClient) InspectImage(ctx context.Context, name string) (i *docker.Image, err error) {
+	return c.inspectImage, c.inspectImageErr
+}
+
+// Basic startup scenario. ListImages() with exempt as well as exceeding capacity images
+// should result in image removals.
+func TestImageCleaner1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	dkr := &DockerDriver{
+		cancel:   cancel,
+		conf:     drivers.Config{},
+		docker:   &mockClient{},
+		imgCache: NewImageCache([]string{"exempt"}, uint64(1024*1024)),
+	}
+
+	defer dkr.Close()
+
+	inner := dkr.imgCache.(*imageCacher)
+	mock := dkr.docker.(*mockClient)
+
+	mock.listImages = append(mock.listImages, docker.APIImages{
+		ID:       "zoo0",
+		RepoTags: []string{"exempt"},
+		Size:     512 * 1024,
+	})
+	mock.listImages = append(mock.listImages, docker.APIImages{
+		ID:   "zoo1",
+		Size: 512 * 1024,
+	})
+	mock.listImages = append(mock.listImages, docker.APIImages{
+		ID:   "zoo2",
+		Size: 512 * 1024,
+	})
+	mock.listImages = append(mock.listImages, docker.APIImages{
+		ID:   "zoo3",
+		Size: 512 * 1024,
+	})
+
+	go func() {
+		syncImageCleaner(ctx, dkr)
+		runImageCleaner(ctx, dkr)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		if len(mock.removedImages) != 2 {
+			t.Fatalf("fail cache=%+v removed=%+v", inner, mock.removedImages)
+		} else if mock.removedImages[0] != "zoo1" || mock.removedImages[1] != "zoo2" {
+			t.Fatalf("fail cache=%+v removed=%+v", inner, mock.removedImages)
+		}
+	case <-ctx.Done():
+		t.Fatalf("ctx timeout cache=%+v removed=%+v", inner, mock.removedImages)
+	}
+
+}
+
+// Basic cookie scenario, cookie marks a huge image as busy, then unmark it. Image
+// cache should not report IsMaxCapacity() first, but after unmark, it should...
+func TestImageCleaner2(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	dkr := &DockerDriver{
+		cancel:   cancel,
+		conf:     drivers.Config{},
+		docker:   &mockClient{},
+		imgCache: NewImageCache([]string{}, uint64(1024*1024)),
+	}
+
+	defer dkr.Close()
+
+	var output bytes.Buffer
+	var errors bytes.Buffer
+
+	inner := dkr.imgCache.(*imageCacher)
+	mock := dkr.docker.(*mockClient)
+
+	// huge  image
+	mock.inspectImage = &docker.Image{
+		ID:   "zoo0",
+		Size: 512 * 1024 * 1024,
+	}
+
+	task := &taskDockerTest{"test-docker", bytes.NewBufferString(`{"isDebug": true}`), &output, &errors}
+
+	cookie, err := dkr.CreateCookie(ctx, task)
+	if err != nil {
+		t.Fatal("Couldn't create task cookie")
+	}
+
+	shouldPull, err := cookie.ValidateImage(ctx)
+	if err != nil || shouldPull {
+		t.Fatalf("Couldn't validate image test cache=%+v", inner)
+	}
+
+	if inner.IsMaxCapacity() {
+		t.Fatalf("should not be max capacity cache=%+v", inner)
+	}
+	if item := inner.Pop(); item != nil {
+		t.Fatalf("should not pop item (busy) cache=%+v item=%+v", inner, item)
+	}
+
+	cookie.Close(ctx)
+
+	if !inner.IsMaxCapacity() {
+		t.Fatalf("should be max capacity cache=%+v", inner)
+	}
+	if item := inner.Pop(); item == nil {
+		t.Fatalf("should pop item cache=%+v", inner)
+	}
+}

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -243,22 +243,22 @@ const (
 type Config struct {
 	// TODO this should all be driver-specific config and not in the
 	// driver package itself. fix if we ever one day try something else
-	Docker               string   `json:"docker"`
-	DockerNetworks       string   `json:"docker_networks"`
-	DockerLoadFile       string   `json:"docker_load_file"`
-	ServerVersion        string   `json:"server_version"`
-	PreForkPoolSize      uint64   `json:"pre_fork_pool_size"`
-	PreForkImage         string   `json:"pre_fork_image"`
-	PreForkCmd           string   `json:"pre_fork_cmd"`
-	PreForkUseOnce       uint64   `json:"pre_fork_use_once"`
-	PreForkNetworks      string   `json:"pre_fork_networks"`
-	MaxTmpFsInodes       uint64   `json:"max_tmpfs_inodes"`
-	EnableReadOnlyRootFs bool     `json:"enable_readonly_rootfs"`
-	MaxRetries           uint64   `json:"max_retries"`
-	ContainerLabelTag    string   `json:"container_label_tag"`
-	InstanceId           string   `json:"instance_id"`
-	ImageCleanMaxSize    uint64   `json:"image_clean_max_size"`
-	ImageCleanExemptTags []string `json:"image_clean_exempt_tags"`
+	Docker               string `json:"docker"`
+	DockerNetworks       string `json:"docker_networks"`
+	DockerLoadFile       string `json:"docker_load_file"`
+	ServerVersion        string `json:"server_version"`
+	PreForkPoolSize      uint64 `json:"pre_fork_pool_size"`
+	PreForkImage         string `json:"pre_fork_image"`
+	PreForkCmd           string `json:"pre_fork_cmd"`
+	PreForkUseOnce       uint64 `json:"pre_fork_use_once"`
+	PreForkNetworks      string `json:"pre_fork_networks"`
+	MaxTmpFsInodes       uint64 `json:"max_tmpfs_inodes"`
+	EnableReadOnlyRootFs bool   `json:"enable_readonly_rootfs"`
+	MaxRetries           uint64 `json:"max_retries"`
+	ContainerLabelTag    string `json:"container_label_tag"`
+	InstanceId           string `json:"instance_id"`
+	ImageCleanMaxSize    uint64 `json:"image_clean_max_size"`
+	ImageCleanExemptTags string `json:"image_clean_exempt_tags"`
 }
 
 func average(samples []Stat) (Stat, bool) {

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -243,20 +243,22 @@ const (
 type Config struct {
 	// TODO this should all be driver-specific config and not in the
 	// driver package itself. fix if we ever one day try something else
-	Docker               string `json:"docker"`
-	DockerNetworks       string `json:"docker_networks"`
-	DockerLoadFile       string `json:"docker_load_file"`
-	ServerVersion        string `json:"server_version"`
-	PreForkPoolSize      uint64 `json:"pre_fork_pool_size"`
-	PreForkImage         string `json:"pre_fork_image"`
-	PreForkCmd           string `json:"pre_fork_cmd"`
-	PreForkUseOnce       uint64 `json:"pre_fork_use_once"`
-	PreForkNetworks      string `json:"pre_fork_networks"`
-	MaxTmpFsInodes       uint64 `json:"max_tmpfs_inodes"`
-	EnableReadOnlyRootFs bool   `json:"enable_readonly_rootfs"`
-	MaxRetries           uint64 `json:"max_retries"`
-	ContainerLabelTag    string `json:"container_label_tag"`
-	InstanceId           string `json:"instance_id"`
+	Docker               string   `json:"docker"`
+	DockerNetworks       string   `json:"docker_networks"`
+	DockerLoadFile       string   `json:"docker_load_file"`
+	ServerVersion        string   `json:"server_version"`
+	PreForkPoolSize      uint64   `json:"pre_fork_pool_size"`
+	PreForkImage         string   `json:"pre_fork_image"`
+	PreForkCmd           string   `json:"pre_fork_cmd"`
+	PreForkUseOnce       uint64   `json:"pre_fork_use_once"`
+	PreForkNetworks      string   `json:"pre_fork_networks"`
+	MaxTmpFsInodes       uint64   `json:"max_tmpfs_inodes"`
+	EnableReadOnlyRootFs bool     `json:"enable_readonly_rootfs"`
+	MaxRetries           uint64   `json:"max_retries"`
+	ContainerLabelTag    string   `json:"container_label_tag"`
+	InstanceId           string   `json:"instance_id"`
+	ImageCleanMaxSize    uint64   `json:"image_clean_max_size"`
+	ImageCleanExemptTags []string `json:"image_clean_exempt_tags"`
 }
 
 func average(samples []Stat) (Stat, bool) {


### PR DESCRIPTION
Introducing a new image cleaner background job in docker driver. If enabled (with FN_IMAGE_CLEAN_MAX_SIZE set > 0 bytes), the cleaner performs the following
at startup:

1) list images to populate the image cache, once this completes, then
2) in a loop, wait for notifications from image cache if/when total cache size exceeds max.
Periodically pick a LRU image and delete it in docker in order to meet the cache size constraint.

The cleaner is not tested and will likely fail if docker build environment is present since these
can leave intermediate and/or dangling images. Also the cleaner expects that no outside manual
action is performed on these images. For example, a force removal can leave an image untagged/dangling. Cleaner interaction with these environments/cases is not tested.

FN_IMAGE_CLEAN_EXEMPT_TAGS also allows to exempt various tags from the image cleaner.

When hot containers are running, they allocate a Cookie. These cookies set their images "in-use" if
Inspect/Pull succeeds. These "in-use" images are reference counted and moved to a busy-list internally in the image cleaner. "in-use" images are not stored in the LRU cache and therefore cleaner job will
not try to delete them. During termination of the Cookie objects, image reference count
is decremented and once it hits zero, only then that image becomes eligible for removal in the LRU cache.

Occasionally, the image cleaner may make the wrong call and remove an image that was just Pulled or Inspected by a new Cookie. Here the behavior is optimistic and assumes that this will be rare. If it occurs, then CreateContainer emits a 503 "server-too-busy" error which can be retried on the same or a different runner. Pathological cases in which requests trigger removal of the other can be monitored
by CreateContainer failure and RemoveImage call counters.
