### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: fn
+version: '1.0'
+summary: The container native, cloud agnostic serverless platform  
+description: |
+  The container native, cloud agnostic serverless platform.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  fn:
+    plugin: go
+    source: https://github.com/fnproject/cli.git
+    go-importpath: github.com/fnproject/cli
+    build-packages:
+      - build-essential
+apps:
+  fn:
+    command: bin/cli
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
I've created this PR to request support for building a snap package of fn.

Snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntu, as well as many others distributions. I think you might find this rather interesting as snap support is also enabled on Ubuntu server, so this could be quite useful for cloud deployments, which I believe is the main target for fn.

Snaps also come with automatic updates via the Snap Store (snapcraft.io/store), which again should be useful for installs in the cloud. There's also the security element of confinement in snaps, allowing fine-tuned, selective control of resources (and devices).

I built and tested fn with strict confinement, taking security into consideration. This is the sequence of steps I ran (on Ubuntu 18.04) to get fn built and running.

- Install snapcraft & clone the project

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/fn.git
cd fn
git checkout add-snapcraft
snapcraft

The last command creates a <fn-version>.snap file, something like fn_1.0_amd64.snap.

This snap can be installed and tested with:

snap install fn_1.0_amd64.snap --dangerous

You need the --dangerous flag because the snap hasn’t gone through the snap store review process and is not signed. Later on, after you upload the snap to the store, you will not need this flag, and you can install from the store with: snap install fn.

Once installed, the fn command can be executed, e.g.: snap run fn <options>.

Next, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the fn name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels” with the 'edge' channel typically used to host the latest (and most likely least stable) build. Stable is as the name implies where stable releases are pushed. Optionally, beta and candidate channels also exist, for different levels of stability and testing.

snapcraft push fn_1.0_amd64.snap --release edge

- Test installing on a clean machine

snap install fn --edge

After you have completed your tests, you can push a stable release to the stable channel, update the store page, and promote the application online. We can definitely help there, and we'd be happy to feature your application in our store.

Thanks!