### PR TITLE
Log latency error if the difference is >= 2ms

### DIFF
--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -364,7 +364,7 @@ func recordCallLatency(ctx context.Context, call *call, status string) {
 	// some sanity check before. If sanity checks flags something, then
 	// this is likely that runners are sending malicious/suspicious data.
 	if execLatency != nil {
-		if *execLatency >= callLatency {
+		if *execLatency-callLatency >= 2*time.Millisecond {
 			common.Logger(ctx).Errorf("invalid latency callLatency=%v execLatency=%v", callLatency, execLatency)
 			return
 		}


### PR DESCRIPTION
The lb_agent logs an error if the difference between exec and call
latency is >=0, this change increase the value to reduce some potential
false positive.

resolve #1371
