### PR TITLE
Added change that exposes what functions are currently hot to metrics

### DIFF
--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -43,7 +43,10 @@ type Config struct {
 	ImageCleanMaxSize       uint64        `json:"image_clean_max_size"`
 	ImageCleanExemptTags    string        `json:"image_clean_exempt_tags"`
 	ImageEnableVolume       bool          `json:"image_enable_volume"`
+	EnableContainerMetrics  bool          `json:"enable_container_state_metrics"`
 }
+
+//containerStateMetrics
 
 const (
 	// EnvContainerLabelTag is a classifier label tag that is used to distinguish fn managed containers
@@ -110,6 +113,9 @@ const (
 	// EnvIOFSOpts are the options to set when mounting the iofs directory for unix socket files
 	EnvIOFSOpts = "FN_IOFS_OPTS"
 
+	// EnvContainerStateMetrics enables metrics for which functions are currently in what container state
+	EnvContainerStateMetrics = "FN_CONTAINER_STATE_METRICS"
+
 	// EnvDetachedHeadroom is the extra room we want to give to a detached function to run.
 	EnvDetachedHeadroom = "FN_EXECUTION_HEADROOM"
 
@@ -132,7 +138,6 @@ const (
 
 // NewConfig returns a config set from env vars, plus defaults
 func NewConfig() (*Config, error) {
-
 	cfg := &Config{
 		MinDockerVersion: "17.10.0-ce",
 		MaxLogSize:       1 * 1024 * 1024,
@@ -173,6 +178,8 @@ func NewConfig() (*Config, error) {
 	err = setEnvUint(err, EnvImageCleanMaxSize, &cfg.ImageCleanMaxSize)
 	err = setEnvStr(err, EnvImageCleanExemptTags, &cfg.ImageCleanExemptTags)
 	err = setEnvBool(err, EnvImageEnableVolume, &cfg.ImageEnableVolume)
+	err = setEnvBool(err, EnvContainerStateMetrics, &cfg.EnableContainerMetrics)
+
 	if err != nil {
 		return cfg, err
 	}

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -22,6 +22,11 @@ var (
 	statusCallCacheKey    = common.MakeKey("cached")
 	statusCallSuccessKey  = common.MakeKey("success")
 	statusCallNetReadyKey = common.MakeKey("network")
+
+	appIdKey      = common.MakeKey("app_id")
+	functionIdKey = common.MakeKey("function_id")
+	imageNameKey  = common.MakeKey("image_name")
+	containerKeys = []tag.Key{appIdKey, functionIdKey, imageNameKey}
 )
 
 func statsCalls(ctx context.Context) {
@@ -181,23 +186,21 @@ const (
 )
 
 var (
-	queuedMeasure          = common.MakeMeasure(queuedMetricName, "calls currently queued against agent", "")
-	callsMeasure           = common.MakeMeasure(callsMetricName, "calls created in agent", "")
-	runningMeasure         = common.MakeMeasure(runningMetricName, "calls currently running in agent", "")
-	completedMeasure       = common.MakeMeasure(completedMetricName, "calls completed in agent", "")
-	canceledMeasure        = common.MakeMeasure(canceledMetricName, "calls canceled in agent", "")
-	timedoutMeasure        = common.MakeMeasure(timedoutMetricName, "calls timed out in agent", "")
-	errorsMeasure          = common.MakeMeasure(errorsMetricName, "calls errored in agent", "")
-	serverBusyMeasure      = common.MakeMeasure(serverBusyMetricName, "calls where server was too busy in agent", "")
-	dockerMeasures         = initDockerMeasures()
-	containerGaugeMeasures = initContainerGaugeMeasures()
-	containerTimeMeasures  = initContainerTimeMeasures()
-
-	utilCpuUsedMeasure  = common.MakeMeasure(utilCpuUsedMetricName, "agent cpu in use", "")
-	utilCpuAvailMeasure = common.MakeMeasure(utilCpuAvailMetricName, "agent cpu available", "")
-	utilMemUsedMeasure  = common.MakeMeasure(utilMemUsedMetricName, "agent memory in use", "By")
-	utilMemAvailMeasure = common.MakeMeasure(utilMemAvailMetricName, "agent memory available", "By")
-
+	queuedMeasure                  = common.MakeMeasure(queuedMetricName, "calls currently queued against agent", "")
+	callsMeasure                   = common.MakeMeasure(callsMetricName, "calls created in agent", "")
+	runningMeasure                 = common.MakeMeasure(runningMetricName, "calls currently running in agent", "")
+	completedMeasure               = common.MakeMeasure(completedMetricName, "calls completed in agent", "")
+	canceledMeasure                = common.MakeMeasure(canceledMetricName, "calls canceled in agent", "")
+	timedoutMeasure                = common.MakeMeasure(timedoutMetricName, "calls timed out in agent", "")
+	errorsMeasure                  = common.MakeMeasure(errorsMetricName, "calls errored in agent", "")
+	serverBusyMeasure              = common.MakeMeasure(serverBusyMetricName, "calls where server was too busy in agent", "")
+	dockerMeasures                 = initDockerMeasures()
+	containerGaugeMeasures         = initContainerGaugeMeasures()
+	containerTimeMeasures          = initContainerTimeMeasures()
+	utilCpuUsedMeasure             = common.MakeMeasure(utilCpuUsedMetricName, "agent cpu in use", "")
+	utilCpuAvailMeasure            = common.MakeMeasure(utilCpuAvailMetricName, "agent cpu available", "")
+	utilMemUsedMeasure             = common.MakeMeasure(utilMemUsedMetricName, "agent memory in use", "By")
+	utilMemAvailMeasure            = common.MakeMeasure(utilMemAvailMetricName, "agent memory available", "By")
 	containerEvictedMeasure        = common.MakeMeasure(containerEvictedMetricName, "containers evicted", "")
 	containerUDSInitLatencyMeasure = common.MakeMeasure(containerUDSInitLatencyMetricName, "container UDS Init-Wait Latency", "msecs")
 
@@ -247,6 +250,7 @@ func RegisterAgentViews(tagKeys []string, latencyDist []float64) {
 		common.CreateView(utilMemUsedMeasure, view.LastValue(), tagKeys),
 		common.CreateView(utilMemAvailMeasure, view.LastValue(), tagKeys),
 	)
+
 	if err != nil {
 		logrus.WithError(err).Fatal("cannot register view")
 	}
@@ -311,7 +315,8 @@ func RegisterContainerViews(tagKeys []string, latencyDist []float64) {
 		if key == "" {
 			continue
 		}
-		v := common.CreateView(containerGaugeMeasures[i], view.Sum(), tagKeys)
+		v := common.CreateViewWithTags(containerGaugeMeasures[i], view.Sum(), containerKeys)
+
 		if err := view.Register(v); err != nil {
 			logrus.WithError(err).Fatal("cannot register view")
 		}


### PR DESCRIPTION
* Added to UpdateState  so as a container changes status to starts and done it notes that a given app/function/image tuple is hot or not in open census
* Changed UpdateState to take in the entire call for increased flexibility

- Link to issue this resolves
[1365](https://github.com/fnproject/fn/issues/1365)

- What I did
* Added to UpdateState  so as a container changes status to starts and done it notes that a given app/function/image tuple is hot or not in open census
* Changed UpdateState to take in the entire call for increased flexibility

- How I did it
In `agent.go`  I switched UpdatedState to take in `call` instead of `call.slots` so it can be more powerful.
In `stats.go` I added a `hotFunctionMeasure` and tags for it
in `state_trackers.go` I added the functionality such that when a container starts it increases the hot function measure by one for a given appId/FunctionId/Image and when that container closes it decreases the hot function measure by one

- How to verify it
Call a function on FN, then, while during it's timeout period, call 
`curl localhost:8080/metrics  | grep -a5 -b10 Function` and you should see a line that looks like 
`fn_Hot_Functions{app_id="01CVRYP3EWNG8G00GZJ0000001",function_id="01D0JFCNH8NG8G00GZJ000000Z",image_name="imagename:0.0.1} 1` After the function times out (which is 30 seconds by defualt) and is not longer hot make that call again and you should see something like `fn_Hot_Functions{app_id="01CVRYP3EWNG8G00GZJ0000001",function_id="01D0JFCNH8NG8G00GZJ000000Z",image_name="imagename:0.0.1} 1`` 

- One line description for the changelog
Added change that exposes what functions are currently hot to metrics

- One moving picture involving robots (not mandatory but encouraged)
