### PR TITLE
fn: add stats for image cleaner and driver instance id

### DIFF
--- a/cmd/fnserver/main.go
+++ b/cmd/fnserver/main.go
@@ -18,9 +18,9 @@ import (
 
 func main() {
 	ctx := context.Background()
-	funcServer := server.NewFromEnv(ctx)
-
 	registerViews()
+
+	funcServer := server.NewFromEnv(ctx)
 	funcServer.Start(ctx)
 }
 


### PR DESCRIPTION
Add observability metrics to image cleaner: number of idle
images, idle image total size, busy image count, busy image total
size, max image cleaner size.

Record docker instance id (as fvn hash) at startup for detecting
docker driver (agent) restarts.
