### PR TITLE
Prevent in-built docker VOLUME commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ checkfmt:
 .PHONY: clear-images
 clear-images:
 	-docker images -q -f dangling=true | xargs docker rmi -f
-	for i in fnproject/fn-test-utils fnproject/fn-status-checker fnproject/dind fnproject/fnserver ; do \
+	for i in fnproject/fn-test-utils fnproject/fn-status-checker fnproject/dind fnproject/fnserver fnproject/fn-test-volume ; do \
 	    docker images "$$i" --format '{{ .ID }}\t{{ .Repository }}\t{{ .Tag}}' | while read id repo tag; do \
 	        if [ "$$tag" = "<none>" ]; then docker rmi "$$id"; else docker rmi "$$repo:$$tag"; fi; done; done
 
@@ -49,6 +49,10 @@ fn-status-checker: checkfmt
 fn-test-utils: checkfmt
 	cd images/fn-test-utils && ./build.sh
 
+.PHONY: fn-test-volume
+fn-test-volume:
+	cd images/fn-test-volume && ./build.sh
+
 .PHONY: test-middleware
 test-middleware: test-basic
 	cd examples/middleware && go build
@@ -58,7 +62,7 @@ test-extensions: test-basic
 	cd examples/extensions && go build
 
 .PHONY: test-basic
-test-basic: checkfmt pull-images fn-test-utils fn-status-checker
+test-basic: checkfmt pull-images fn-test-utils fn-status-checker fn-test-volume
 	./test.sh
 
 .PHONY: test

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -230,6 +230,7 @@ func NewDockerDriver(cfg *Config) (drivers.Driver, error) {
 		ContainerLabelTag:    cfg.ContainerLabelTag,
 		ImageCleanMaxSize:    cfg.ImageCleanMaxSize,
 		ImageCleanExemptTags: cfg.ImageCleanExemptTags,
+		ImageEnableVolume:    cfg.ImageEnableVolume,
 	})
 }
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	MaxDockerRetries        uint64        `json:"max_docker_retries"`
 	ImageCleanMaxSize       uint64        `json:"image_clean_max_size"`
 	ImageCleanExemptTags    string        `json:"image_clean_exempt_tags"`
+	ImageEnableVolume       bool          `json:"image_enable_volume"`
 }
 
 const (
@@ -52,6 +53,8 @@ const (
 	EnvImageCleanMaxSize = "FN_IMAGE_CLEAN_MAX_SIZE"
 	// EnvImageCleanExemptTags list of image names separated by whitespace that are exempt from removal in image cleaner
 	EnvImageCleanExemptTags = "FN_IMAGE_CLEAN_EXEMPT_TAGS"
+	// EnvImageEnableVolume allows image to contain VOLUME definitions
+	EnvImageEnableVolume = "FN_IMAGE_ENABLE_VOLUME"
 	// EnvDockerNetworks is a comma separated list of networks to attach to each container started
 	EnvDockerNetworks = "FN_DOCKER_NETWORKS"
 	// EnvDockerLoadFile is a file location for a file that contains a tarball of a docker image to load on startup
@@ -170,6 +173,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvBool(err, EnvDisableDebugUserLogs, &cfg.DisableDebugUserLogs)
 	err = setEnvUint(err, EnvImageCleanMaxSize, &cfg.ImageCleanMaxSize)
 	err = setEnvStr(err, EnvImageCleanExemptTags, &cfg.ImageCleanExemptTags)
+	err = setEnvBool(err, EnvImageEnableVolume, &cfg.ImageEnableVolume)
 	if err != nil {
 		return cfg, err
 	}

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -263,6 +263,7 @@ type Config struct {
 	InstanceId           string `json:"instance_id"`
 	ImageCleanMaxSize    uint64 `json:"image_clean_max_size"`
 	ImageCleanExemptTags string `json:"image_clean_exempt_tags"`
+	ImageEnableVolume    bool   `json:"image_enable_volume"`
 }
 
 func average(samples []Stat) (Stat, bool) {

--- a/images/fn-test-volume/Dockerfile
+++ b/images/fn-test-volume/Dockerfile
@@ -1,0 +1,4 @@
+# This image is used by runner tests only
+FROM scratch
+
+VOLUME /data

--- a/images/fn-test-volume/build.sh
+++ b/images/fn-test-volume/build.sh
@@ -1,0 +1,2 @@
+set -e
+docker build --build-arg HTTPS_PROXY --build-arg HTTP_PROXY -t fnproject/fn-test-volume:latest .


### PR DESCRIPTION
- What I did
Added validation to check function image for VOLUME definitions, reject to run if VOLUME is present.

- How to verify it
Try to run an image with VOLUME defined.

- One line description for the changelog
Function image can't contain VOLUME definition

