### PR TITLE
fn: driver cookie interface changes for finer control

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -883,9 +883,9 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 				err = models.ErrDockerPullTimeout
 			}
 		}
-		if err == nil {
+		if tryQueueErr(err, errQueue) == nil {
 			needsPull, err = cookie.ValidateImage(ctx)
-			if needsPull && err == nil {
+			if needsPull {
 				// Image must have removed by image cleaner, manual intervention, etc.
 				err = models.ErrCallTimeoutServerBusy
 			}

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -60,6 +60,11 @@ func TestRunnerDocker(t *testing.T) {
 
 	defer cookie.Close(ctx)
 
+	err = cookie.AuthImage(ctx)
+	if err != nil {
+		t.Fatal("Couldn't auth image test")
+	}
+
 	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil {
 		t.Fatal("Couldn't validate image test")
@@ -68,6 +73,10 @@ func TestRunnerDocker(t *testing.T) {
 		err = cookie.PullImage(ctx)
 		if err != nil {
 			t.Fatal("Couldn't pull image test")
+		}
+		shouldPull, err = cookie.ValidateImage(ctx)
+		if err != nil || shouldPull {
+			t.Fatal("Couldn't validate image test")
 		}
 	}
 
@@ -176,6 +185,11 @@ func TestRunnerDockerStdout(t *testing.T) {
 	}
 	defer cookie.Close(ctx)
 
+	err = cookie.AuthImage(ctx)
+	if err != nil {
+		t.Fatal("Couldn't auth image test")
+	}
+
 	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil {
 		t.Fatal("Couldn't validate image test")
@@ -184,6 +198,10 @@ func TestRunnerDockerStdout(t *testing.T) {
 		err = cookie.PullImage(ctx)
 		if err != nil {
 			t.Fatal("Couldn't pull image test")
+		}
+		shouldPull, err = cookie.ValidateImage(ctx)
+		if err != nil || shouldPull {
+			t.Fatal("Couldn't validate image test")
 		}
 	}
 	err = cookie.CreateContainer(ctx)

--- a/api/agent/drivers/docker/image_cleaner_test.go
+++ b/api/agent/drivers/docker/image_cleaner_test.go
@@ -119,6 +119,11 @@ func TestImageCleaner2(t *testing.T) {
 		t.Fatal("Couldn't create task cookie")
 	}
 
+	err = cookie.AuthImage(ctx)
+	if err != nil {
+		t.Fatal("Couldn't auth image test")
+	}
+
 	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil || shouldPull {
 		t.Fatalf("Couldn't validate image test cache=%+v", inner)

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -41,11 +41,15 @@ type Cookie interface {
 	// Unfreeze a frozen container to unpause frozen processes
 	Unfreeze(ctx context.Context) error
 
-	// Validate/Inspect and Authenticate image. Returns true if the image needs
-	// to be pulled and non-nil error if validation/auth/inspection fails.
+	// Authenticate image. Returns non-nil error if auth fails.
+	AuthImage(ctx context.Context) error
+
+	// Validate/Inspect image. Returns true if the image needs
+	// to be pulled and non-nil error if validation/inspection fails.
 	ValidateImage(ctx context.Context) (bool, error)
 
-	// Pull the image.
+	// Pull the image. An image pull requires validation/inspection
+	// again.
 	PullImage(ctx context.Context) error
 
 	// Create container which can be Run() later

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -43,6 +43,10 @@ func (c *cookie) Unfreeze(context.Context) error {
 	return nil
 }
 
+func (c *cookie) AuthImage(context.Context) error {
+	return nil
+}
+
 func (c *cookie) ValidateImage(context.Context) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
Users of driver cookie, as seen in agent.go require specific
timeouts in contexts passed to the different operations. For
example, cookie.PullImage() context shows intent to apply
timeout/duration for the pull operation. To clarify this
and avoid tricky timeout related issues, removing implicit
docker-inspect in cookie.PullImage(). In addition, separating
the Authentication step as Auther interface calls unknown
code.

Additional changes to cookie implementation to clarify
inspected image, created container and authentication
configuration, where each AuthImage(), ValidateImage()
and CreateContainer() steps initialize the corresponding
pointer object in the cookie.

Changes now require ValidateImage() call if a PullImage()
is attempted. In all cases, AuthImage() call is required
before ValidateImage().

An example usage is as follows:

        cookie, err := driver.CreateCookie(ctx, task)
        err = cookie.AuthImage(ctx)
        pull, err := cookie.ValidateImage()
        if pull {
                err = cookie.PullImage(ctx)
                pull, err = cookie.ValidateImage()
        }

        err = cookie.CreateContainer(ctx)
        waiter := cookie.Run(ctx)
        waiter.Wait(ctx)

error handling is omitted for clarity in the above example.
