### PR TITLE
Rework call placement/finish logs to take advantage of user blame tag

### DIFF
--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -73,7 +73,7 @@ func (tr *placerTracker) TryRunner(r Runner, call RunnerCall) (bool, error) {
 		// Only log unusual errors for isPlaced (customer impacting) calls
 		if err != nil && tr.requestCtx.Err() != err {
 			logger := common.Logger(ctx).WithField("runner_addr", r.Address())
-			logger.WithError(err).Errorf("Failed during call placement")
+			logger.WithError(err).Warn("Failed during call placement")
 		}
 		if err == nil {
 			stats.Record(tr.requestCtx, placedOKCountMeasure.M(0))

--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -69,12 +69,6 @@ func (tr *placerTracker) TryRunner(r Runner, call RunnerCall) (bool, error) {
 		}
 
 	} else {
-
-		// Only log unusual errors for isPlaced (customer impacting) calls
-		if err != nil && tr.requestCtx.Err() != err {
-			logger := common.Logger(ctx).WithField("runner_addr", r.Address())
-			logger.WithError(err).Warn("Failed during call placement")
-		}
 		if err == nil {
 			stats.Record(tr.requestCtx, placedOKCountMeasure.M(0))
 		} else if tr.requestCtx.Err() == err {


### PR DESCRIPTION
If a customer function fails due to an issue with the function itself (e.g. customer-side timeout or usage of an old FDK), the error is logged at the error level. We should log at warning since it is not a platform error and it only affects the function in question.