### PR TITLE
fn: remove old test related images

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1280,7 +1280,6 @@ func (c *container) Volumes() [][2]string               { return nil }
 func (c *container) WorkDir() string                    { return "" }
 func (c *container) Close()                             { c.close() }
 func (c *container) Image() string                      { return c.image }
-func (c *container) Timeout() time.Duration             { return 0 } // context handles this
 func (c *container) EnvVars() map[string]string         { return c.env }
 func (c *container) Memory() uint64                     { return c.memory * 1024 * 1024 } // convert MB
 func (c *container) CPUs() uint64                       { return c.cpus }

--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/fnproject/fn/api/agent/drivers"
 	"github.com/fnproject/fn/api/common"
@@ -63,7 +62,6 @@ func (c *poolTask) Volumes() [][2]string                             { return ni
 func (c *poolTask) WorkDir() string                                  { return "" }
 func (c *poolTask) Close()                                           {}
 func (c *poolTask) Image() string                                    { return c.image }
-func (c *poolTask) Timeout() time.Duration                           { return 0 }
 func (c *poolTask) EnvVars() map[string]string                       { return nil }
 func (c *poolTask) Memory() uint64                                   { return 0 }
 func (c *poolTask) CPUs() uint64                                     { return 0 }

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -21,12 +21,11 @@ type taskDockerTest struct {
 	errors io.Writer
 }
 
-func (f *taskDockerTest) Command() string                         { return "" }
+func (f *taskDockerTest) Command() string                         { return "echo hello" }
 func (f *taskDockerTest) EnvVars() map[string]string              { return map[string]string{} }
 func (f *taskDockerTest) Id() string                              { return f.id }
 func (f *taskDockerTest) Group() string                           { return "" }
-func (f *taskDockerTest) Image() string                           { return "hello-world" }
-func (f *taskDockerTest) Timeout() time.Duration                  { return 30 * time.Second }
+func (f *taskDockerTest) Image() string                           { return "busybox" }
 func (f *taskDockerTest) Logger() (stdout, stderr io.Writer)      { return f.output, f.errors }
 func (f *taskDockerTest) WriteStat(context.Context, drivers.Stat) { /* TODO */ }
 func (f *taskDockerTest) Volumes() [][2]string                    { return [][2]string{} }
@@ -224,8 +223,7 @@ func TestRunnerDockerStdout(t *testing.T) {
 			result.Error(), output.String(), errors.String())
 	}
 
-	// if hello world image changes, change dis
-	expect := "Hello from Docker!"
+	expect := "hello"
 	got := output.String()
 	if !strings.Contains(got, expect) {
 		t.Errorf("Test expected output to contain '%s', got '%s'", expect, got)

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -126,9 +126,6 @@ type ContainerTask interface {
 	// Image returns the runtime specific image to run.
 	Image() string
 
-	// Timeout specifies the maximum time a task is allowed to run. Return 0 to let it run forever.
-	Timeout() time.Duration
-
 	// Driver will write output log from task execution to these writers. Must be
 	// non-nil. Use io.Discard if log is irrelevant.
 	Logger() (stdout, stderr io.Writer)


### PR DESCRIPTION
Removing hello-world, fnproject/hello images from tests.

In drivers.ContainerTask Timeout is obsoleted code from cold
containers, which we no longer have.
