### PR TITLE
plumb docker auther to the depths

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1321,10 +1321,13 @@ func (c *container) WriteStat(ctx context.Context, stat drivers.Stat) {
 	c.swapMu.Unlock()
 }
 
+// assert we implement this at compile time
+var _ dockerdriver.Auther = new(container)
+
 // DockerAuth implements the docker.AuthConfiguration interface.
-func (c *container) DockerAuth(ctx context.Context) (*docker.AuthConfiguration, error) {
+func (c *container) DockerAuth(ctx context.Context, image string) (*docker.AuthConfiguration, error) {
 	if c.dockerAuth != nil {
-		return c.dockerAuth.DockerAuth(ctx)
+		return c.dockerAuth.DockerAuth(ctx, image)
 	}
 
 	// TODO(reed): kill this after using that

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 
 	"github.com/fnproject/fn/api/agent/drivers"
+	dockerdriver "github.com/fnproject/fn/api/agent/drivers/docker"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/id"
 	"github.com/fnproject/fn/api/models"
@@ -109,7 +110,12 @@ type agent struct {
 	shutWg   *common.WaitGroup
 	shutonce sync.Once
 
+	// TODO(reed): shoot this fucking thing
 	callOverrider CallOverrider
+
+	// additional options to configure each call
+	callOpts []CallOpt
+
 	// deferred actions to call at end of initialisation
 	onStartup []func()
 }
@@ -209,6 +215,15 @@ func WithCallOverrider(fn CallOverrider) Option {
 			return errors.New("lb-agent call overriders already exists")
 		}
 		a.callOverrider = fn
+		return nil
+	}
+}
+
+// WithCallOptions adds additional call options to each call created from GetCall, these
+// options will be executed after any other options supplied to GetCall
+func WithCallOptions(opts ...CallOpt) Option {
+	return func(a *agent) error {
+		a.callOpts = append(a.callOpts, opts...)
 		return nil
 	}
 }
@@ -867,11 +882,6 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		return
 	}
 
-	err = cookie.AuthImage(ctx)
-	if tryQueueErr(err, errQueue) != nil {
-		return
-	}
-
 	needsPull, err := cookie.ValidateImage(ctx)
 	if needsPull {
 		pullCtx, pullCancel := context.WithTimeout(ctx, a.cfg.HotPullTimeout)
@@ -1153,6 +1163,7 @@ type container struct {
 	iofs       iofs
 	logCfg     drivers.LoggerConfig
 	close      func()
+	dockerAuth dockerdriver.Auther
 
 	stderr io.Writer
 
@@ -1220,6 +1231,7 @@ func newHotContainer(ctx context.Context, call *call, cfg *Config, id string, ud
 		tmpFsSize:  uint64(call.TmpFsSize),
 		disableNet: call.disableNet,
 		iofs:       iofs,
+		dockerAuth: call.dockerAuth,
 		logCfg: drivers.LoggerConfig{
 			URL: strings.TrimSpace(call.SyslogURL),
 			Tags: []drivers.LoggerTag{
@@ -1310,7 +1322,12 @@ func (c *container) WriteStat(ctx context.Context, stat drivers.Stat) {
 }
 
 // DockerAuth implements the docker.AuthConfiguration interface.
-func (c *container) DockerAuth() (*docker.AuthConfiguration, error) {
+func (c *container) DockerAuth(ctx context.Context) (*docker.AuthConfiguration, error) {
+	if c.dockerAuth != nil {
+		return c.dockerAuth.DockerAuth(ctx)
+	}
+
+	// TODO(reed): kill this after using that
 	registryToken := c.extensions[RegistryToken]
 	if registryToken != "" {
 		return &docker.AuthConfiguration{

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -1323,7 +1323,7 @@ func TestDockerAuthExtn(t *testing.T) {
 		err := <-errC
 		t.Fatal("got unexpected err: ", err)
 	}
-	da, err := c.DockerAuth(ctx)
+	da, err := c.DockerAuth(ctx, modelCall.Image)
 	if da != nil {
 		t.Fatal("invalid docker auth configuration")
 	}
@@ -1341,7 +1341,7 @@ func TestDockerAuthExtn(t *testing.T) {
 		err := <-errC
 		t.Fatal("got unexpected err: ", err)
 	}
-	da, err = c.DockerAuth(ctx)
+	da, err = c.DockerAuth(ctx, modelCall.Image)
 	if da == nil {
 		t.Fatal("invalid docker auth configuration")
 	}

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -1323,7 +1323,7 @@ func TestDockerAuthExtn(t *testing.T) {
 		err := <-errC
 		t.Fatal("got unexpected err: ", err)
 	}
-	da, err := c.DockerAuth()
+	da, err := c.DockerAuth(ctx)
 	if da != nil {
 		t.Fatal("invalid docker auth configuration")
 	}

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -1341,7 +1341,7 @@ func TestDockerAuthExtn(t *testing.T) {
 		err := <-errC
 		t.Fatal("got unexpected err: ", err)
 	}
-	da, err = c.DockerAuth()
+	da, err = c.DockerAuth(ctx)
 	if da == nil {
 		t.Fatal("invalid docker auth configuration")
 	}

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -328,7 +328,7 @@ func (c *cookie) authImage(ctx context.Context) (*docker.AuthConfiguration, erro
 
 	if task, ok := c.task.(Auther); ok {
 		_, span := trace.StartSpan(ctx, "docker_auth")
-		authConfig, err := task.DockerAuth(ctx)
+		authConfig, err := task.DockerAuth(ctx, c.task.Image())
 		span.End()
 		if err != nil {
 			return nil, err

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fnproject/fn/api/agent/drivers"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
-
 	"github.com/fsouza/go-dockerclient"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -34,9 +33,6 @@ type cookie struct {
 	imgReg  string
 	imgRepo string
 	imgTag  string
-
-	// contains auth config if AuthImage() is called
-	imgAuthConf *docker.AuthConfiguration
 
 	// contains inspected image if ValidateImage() is called
 	image *CachedImage
@@ -322,8 +318,7 @@ func (c *cookie) Unfreeze(ctx context.Context) error {
 	return err
 }
 
-// implements Cookie
-func (c *cookie) AuthImage(ctx context.Context) error {
+func (c *cookie) authImage(ctx context.Context) (*docker.AuthConfiguration, error) {
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "AuthImage"})
 	log.WithFields(logrus.Fields{"call_id": c.task.Id()}).Debug("docker auth image")
 
@@ -333,18 +328,17 @@ func (c *cookie) AuthImage(ctx context.Context) error {
 
 	if task, ok := c.task.(Auther); ok {
 		_, span := trace.StartSpan(ctx, "docker_auth")
-		authConfig, err := task.DockerAuth()
+		authConfig, err := task.DockerAuth(ctx)
 		span.End()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if authConfig != nil {
 			config = authConfig
 		}
 	}
 
-	c.imgAuthConf = config
-	return nil
+	return config, nil
 }
 
 // implements Cookie
@@ -352,14 +346,12 @@ func (c *cookie) ValidateImage(ctx context.Context) (bool, error) {
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "ValidateImage"})
 	log.WithFields(logrus.Fields{"call_id": c.task.Id(), "image": c.task.Image()}).Debug("docker inspect image")
 
-	if c.imgAuthConf == nil {
-		log.Fatal("invalid usage: image not authenticated")
-	}
 	if c.image != nil {
 		return false, nil
 	}
 
 	// see if we already have it
+	// TODO this should use the image cache instead of making a docker call
 	img, err := c.drv.docker.InspectImage(ctx, c.task.Image())
 	if err == docker.ErrNoSuchImage {
 		return true, nil
@@ -384,21 +376,21 @@ func (c *cookie) ValidateImage(ctx context.Context) (bool, error) {
 // implements Cookie
 func (c *cookie) PullImage(ctx context.Context) error {
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"stack": "PullImage"})
-
-	if c.imgAuthConf == nil {
-		log.Fatal("invalid usage: image not authenticated")
-	}
 	if c.image != nil {
 		return nil
 	}
 
-	cfg := c.imgAuthConf
+	cfg, err := c.authImage(ctx)
+	if err != nil {
+		return err
+	}
+
 	repo := path.Join(c.imgReg, c.imgRepo)
 
 	log = common.Logger(ctx).WithFields(logrus.Fields{"registry": cfg.ServerAddress, "username": cfg.Username})
 	log.WithFields(logrus.Fields{"call_id": c.task.Id(), "image": c.task.Image()}).Debug("docker pull")
 
-	err := c.drv.docker.PullImage(docker.PullImageOptions{Repository: repo, Tag: c.imgTag, Context: ctx}, *cfg)
+	err = c.drv.docker.PullImage(docker.PullImageOptions{Repository: repo, Tag: c.imgTag, Context: ctx}, *cfg)
 	if err != nil {
 		log.WithError(err).Info("Failed to pull image")
 

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -38,7 +38,7 @@ type Auther interface {
 	// certain restrictions on images or if credentials must be acquired right
 	// before runtime and there's an error doing so. If these credentials don't
 	// work, the docker pull will fail and the task will be set to error status.
-	DockerAuth(ctx context.Context) (*docker.AuthConfiguration, error)
+	DockerAuth(ctx context.Context, image string) (*docker.AuthConfiguration, error)
 }
 
 type runResult struct {

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -52,11 +52,6 @@ func createTask(id string) *taskDockerTest {
 }
 
 func commonCookiePull(ctx context.Context, cookie drivers.Cookie) error {
-	err := cookie.AuthImage(ctx)
-	if err != nil {
-		return err
-	}
-
 	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil {
 		return err

--- a/api/agent/drivers/docker/image_cleaner_test.go
+++ b/api/agent/drivers/docker/image_cleaner_test.go
@@ -123,11 +123,6 @@ func TestImageCleaner2(t *testing.T) {
 		t.Fatal("Couldn't create task cookie")
 	}
 
-	err = cookie.AuthImage(ctx)
-	if err != nil {
-		t.Fatal("Couldn't auth image test")
-	}
-
 	shouldPull, err := cookie.ValidateImage(ctx)
 	if err != nil || shouldPull {
 		t.Fatalf("Couldn't validate image test cache=%+v", inner)

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -41,9 +41,6 @@ type Cookie interface {
 	// Unfreeze a frozen container to unpause frozen processes
 	Unfreeze(ctx context.Context) error
 
-	// Authenticate image. Returns non-nil error if auth fails.
-	AuthImage(ctx context.Context) error
-
 	// Validate/Inspect image. Returns true if the image needs
 	// to be pulled and non-nil error if validation/inspection fails.
 	ValidateImage(ctx context.Context) (bool, error)

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -43,10 +43,6 @@ func (c *cookie) Unfreeze(context.Context) error {
 	return nil
 }
 
-func (c *cookie) AuthImage(context.Context) error {
-	return nil
-}
-
 func (c *cookie) ValidateImage(context.Context) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
this patch accomplishes a few things wrt the docker auth interface used for
configuring credentials to be used for pull:

* adds context for timing out the docker auth call
* no longer call docker auth before validating an image, we were using this to
validate that a user still has access to an image that we have locally. this
policy itself could be TBD but we're being flagged for hitting registries too
hard, and runners have bounded lifetimes on the order of hours, so we decided
this is ok. now we only call docker auth function when pulling an image, and
it's time used is included in the pull timeout we've so delicately plumbed
* adds ability for agents to add call configurations to every call created via
getcall, this ought to help allow fn extenders configure calls and puts us on
the path of getting rid of the call overrider (and is enough to be able to
replace our current one that is causing issues)
* adds an option to configure calls to have a docker auth function they
provide, so that fn extenders can plumb this thing into here without having to
fork the driver (which would be absurd!)
* some lints...
