### PR TITLE
Pass Request to CallOverrider

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -42,7 +42,7 @@ type Call interface {
 }
 
 // CallOverrider should die. Interceptor in GetCall
-type CallOverrider func(*models.Call, map[string]string) (map[string]string, error)
+type CallOverrider func(*http.Request, *models.Call, map[string]string) (map[string]string, error)
 
 // CallOpt allows configuring a call before execution
 // TODO(reed): consider the interface here, all options must be defined in agent and flexible
@@ -241,7 +241,7 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 	// If overrider is present, let's allow it to modify models.Call
 	// and call extensions
 	if a.callOverrider != nil {
-		ext, err := a.callOverrider(c.Call, c.extensions)
+		ext, err := a.callOverrider(c.req, c.Call, c.extensions)
 		if err != nil {
 			return nil, err
 		}

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -160,7 +160,7 @@ func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
 	// If overrider is present, let's allow it to modify models.Call
 	// and call extensions
 	if a.callOverrider != nil {
-		ext, err := a.callOverrider(c.Call, c.extensions)
+		ext, err := a.callOverrider(c.req, c.Call, c.extensions)
 		if err != nil {
 			return nil, err
 		}

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -405,7 +405,7 @@ func TestMain(m *testing.M) {
 }
 
 // Memory Only LB Agent Call Option
-func LBCallOverrider(c *models.Call, exts map[string]string) (map[string]string, error) {
+func LBCallOverrider(req *http.Request, c *models.Call, exts map[string]string) (map[string]string, error) {
 
 	// Set TmpFsSize and CPU to unlimited. This means LB operates on Memory
 	// only. Operators/Service providers are expected to override this
@@ -425,7 +425,7 @@ func LBCallOverrider(c *models.Call, exts map[string]string) (map[string]string,
 }
 
 // Pure Runner Agent Call Option
-func PureRunnerCallOverrider(c *models.Call, exts map[string]string) (map[string]string, error) {
+func PureRunnerCallOverrider(req *http.Request, c *models.Call, exts map[string]string) (map[string]string, error) {
 
 	if exts == nil {
 		exts = make(map[string]string)


### PR DESCRIPTION
With this change CallOverrider get the request as its first parameter.
We know that we want to get rid of it but there are some cases where the
CallOverrider at the moment is the only place where we can customize a
call before it gets executed until we find a solution for the problem
reported in issue #1426.

Having access to the original request it could be handy during in
CallOverrider.