### PR TITLE
fn: introducing a new image pull layer

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -65,7 +65,8 @@ type DockerDriver struct {
 
 	instanceId string
 
-	imgCache ImageCacher
+	imgCache  ImageCacher
+	imgPuller ImagePuller
 }
 
 // NewDocker implements drivers.Driver
@@ -119,6 +120,8 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 	if err != nil {
 		logrus.WithError(err).Fatalf("cannot load docker images in %s", conf.DockerLoadFile)
 	}
+
+	driver.imgPuller = NewImagePuller(conf, driver.docker)
 
 	// finally spawn pool if enabled
 	if conf.PreForkPoolSize != 0 {

--- a/api/agent/drivers/docker/image_puller.go
+++ b/api/agent/drivers/docker/image_puller.go
@@ -1,0 +1,146 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/fnproject/fn/api/agent/drivers"
+	"github.com/fnproject/fn/api/common"
+	"github.com/fnproject/fn/api/models"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+// ImagePuller is an abstraction layer to handle concurrent docker-pulls. Docker internally
+// does not handle concurrency very well. Only layer-blob pulls have a listener/follow serialization
+// leaving manifest/config fetches out. For instance, a single layer image, when merely two docker-pulls
+// are initiated at the same time, this causes 9 HTTP-GET requests from docker to the repository where
+// 4 extra & unnecessary HTTP GETs are initiated. Below is a simple listener/follower serialization, where
+// any new requests are added as listeners to the ongoing docker-pull requests.
+
+type ImagePuller interface {
+	PullImage(ctx context.Context, cfg *docker.AuthConfiguration, img, repo, tag string) chan error
+}
+
+type transfer struct {
+	ctx context.Context // oldest context
+
+	key string
+
+	cfg  *docker.AuthConfiguration
+	img  string
+	repo string
+	tag  string
+
+	listeners []chan error
+}
+
+type imagePuller struct {
+	docker dockerClient
+
+	lock      sync.Mutex
+	transfers map[string]*transfer
+}
+
+func NewImagePuller(conf drivers.Config, docker dockerClient) ImagePuller {
+	c := imagePuller{
+		docker:    docker,
+		transfers: make(map[string]*transfer),
+	}
+
+	return &c
+}
+
+// newTransfer initiates a new docker-pull if there's no active docker-pull present for the same image.
+func (i *imagePuller) newTransfer(ctx context.Context, cfg *docker.AuthConfiguration, img, repo, tag string) chan error {
+
+	key := fmt.Sprintf("%s %s %+v", repo, tag, cfg)
+
+	i.lock.Lock()
+
+	trx, ok := i.transfers[key]
+	if !ok {
+		trx = &transfer{
+			ctx:       ctx,
+			key:       key,
+			cfg:       cfg,
+			img:       img,
+			repo:      repo,
+			tag:       tag,
+			listeners: make([]chan error, 0, 1),
+		}
+		i.transfers[key] = trx
+	}
+
+	errC := make(chan error, 1)
+	trx.listeners = append(trx.listeners, errC)
+
+	i.lock.Unlock()
+
+	// First time call for this image/key, start a docker-pull
+	if !ok {
+		go i.startTransfer(trx)
+	}
+
+	return errC
+}
+
+func (i *imagePuller) startTransfer(trx *transfer) {
+	ctx := trx.ctx
+	var ferr error
+	err := i.docker.PullImage(docker.PullImageOptions{Repository: trx.repo, Tag: trx.tag, Context: ctx}, *trx.cfg)
+	if err != nil {
+		common.Logger(ctx).WithError(err).Info("Failed to pull image")
+
+		// TODO need to inspect for hub or network errors and pick; for now, assume
+		// 500 if not a docker error
+		msg := err.Error()
+		code := http.StatusBadGateway
+		if dErr, ok := err.(*docker.Error); ok {
+			msg = dockerMsg(dErr)
+			if dErr.Status >= 400 && dErr.Status < 500 {
+				code = dErr.Status // decap 4xx errors
+			}
+		}
+
+		err := models.NewAPIError(code, fmt.Errorf("Failed to pull image '%s': %s", trx.img, msg))
+		ferr = models.NewFuncError(err)
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	// notify any listeners
+	for _, ch := range trx.listeners {
+		if ferr != nil {
+			ch <- ferr
+		}
+		close(ch)
+	}
+
+	// unregister the docker-pull
+	delete(i.transfers, trx.key)
+}
+
+func (i *imagePuller) PullImage(ctx context.Context, cfg *docker.AuthConfiguration, img, repo, tag string) chan error {
+	return i.newTransfer(ctx, cfg, img, repo, tag)
+}
+
+// removes docker err formatting: 'API Error (code) {"message":"..."}'
+func dockerMsg(derr *docker.Error) string {
+	// derr.Message is a JSON response from docker, which has a "message" field we want to extract if possible.
+	// this is pretty lame, but it is what it is
+	var v struct {
+		Msg string `json:"message"`
+	}
+
+	err := json.Unmarshal([]byte(derr.Message), &v)
+	if err != nil {
+		// If message was not valid JSON, the raw body is still better than nothing.
+		return derr.Message
+	}
+	return v.Msg
+}

--- a/api/agent/drivers/docker/image_puller_test.go
+++ b/api/agent/drivers/docker/image_puller_test.go
@@ -1,0 +1,67 @@
+package docker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fnproject/fn/api/agent/drivers"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+type mockClientPuller struct {
+	dockerWrap
+
+	numCalls uint64
+}
+
+func (c *mockClientPuller) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
+	time.Sleep(time.Second * 1)
+	atomic.AddUint64(&c.numCalls, uint64(1))
+	return nil
+}
+
+// Lets do concurrent docker-pulls for an image with two different tags. This should results in only
+// two calls to docker-pull.
+func TestImagePullConcurrent1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	var cli dockerClient
+	mock := mockClientPuller{}
+	cli = &mock
+
+	puller := NewImagePuller(drivers.Config{}, cli)
+
+	cfg := docker.AuthConfiguration{}
+	img := "foo"
+	repo := "zoo"
+	tag1 := "1.0.0"
+	tag2 := "1.0.1"
+
+	var wg sync.WaitGroup
+	wg.Add(20)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			<-puller.PullImage(ctx, &cfg, img, repo, tag1)
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			<-puller.PullImage(ctx, &cfg, img, repo, tag2)
+		}()
+	}
+
+	wg.Wait()
+
+	// Should be two docker-pulls
+	if mock.numCalls != 2 || ctx.Err() != nil {
+		t.Fatalf("fail numOfPulls=%d ctx=%s", mock.numCalls, ctx.Err())
+	}
+}

--- a/api/agent/drivers/docker/image_puller_test.go
+++ b/api/agent/drivers/docker/image_puller_test.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,12 +18,13 @@ type mockClientPuller struct {
 	dockerWrap
 
 	numCalls uint64
+	err      error
 }
 
 func (c *mockClientPuller) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	time.Sleep(time.Second * 1)
 	atomic.AddUint64(&c.numCalls, uint64(1))
-	return nil
+	return c.err
 }
 
 // Lets do concurrent docker-pulls for an image with two different tags. This should results in only
@@ -48,13 +51,19 @@ func TestImagePullConcurrent1(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer wg.Done()
-			<-puller.PullImage(ctx, &cfg, img, repo, tag1)
+			err := <-puller.PullImage(ctx, &cfg, img, repo, tag1)
+			if err != nil {
+				t.Fatalf("err received %v", err)
+			}
 		}()
 	}
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer wg.Done()
-			<-puller.PullImage(ctx, &cfg, img, repo, tag2)
+			err := <-puller.PullImage(ctx, &cfg, img, repo, tag2)
+			if err != nil {
+				t.Fatalf("err received %v", err)
+			}
 		}()
 	}
 
@@ -62,6 +71,43 @@ func TestImagePullConcurrent1(t *testing.T) {
 
 	// Should be two docker-pulls
 	if mock.numCalls != 2 || ctx.Err() != nil {
+		t.Fatalf("fail numOfPulls=%d ctx=%s", mock.numCalls, ctx.Err())
+	}
+}
+
+// Lets do concurrent docker-pulls for an image but with error.
+func TestImagePullConcurrent2(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+	defer cancel()
+
+	var cli dockerClient
+	mock := mockClientPuller{err: errors.New("yogurt")}
+	cli = &mock
+
+	puller := NewImagePuller(drivers.Config{}, cli)
+
+	cfg := docker.AuthConfiguration{}
+	img := "foo"
+	repo := "zoo"
+	tag := "1.0.0"
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			err := <-puller.PullImage(ctx, &cfg, img, repo, tag)
+			if err == nil || strings.Index(err.Error(), "yogurt") == -1 {
+				t.Fatalf("Unknown err received %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Should be one docker-pull
+	if mock.numCalls != 1 || ctx.Err() != nil {
 		t.Fatalf("fail numOfPulls=%d ctx=%s", mock.numCalls, ctx.Err())
 	}
 }


### PR DESCRIPTION
Due to unnecessary http traffic caused by docker internally, with
this PR a new image pull layer is introduced. This allows us to
serialize same image docker pulls using a simple active transfer
with list of listeners model.

The timeout behavior is slightly different when multiple listeners
are waiting. The timeout from first listener is emitted to all
listeners. However since the docker-pull timeout is globally
configured, overall timeout behavior is essentially the same.

