### PR TITLE
fn: docker pull retry / backoff options

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -121,7 +121,7 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		logrus.WithError(err).Fatalf("cannot load docker images in %s", conf.DockerLoadFile)
 	}
 
-	driver.imgPuller = NewImagePuller(conf, driver.docker)
+	driver.imgPuller = NewImagePuller(driver.docker)
 
 	// finally spawn pool if enabled
 	if conf.PreForkPoolSize != 0 {
@@ -359,9 +359,8 @@ func (drv *DockerDriver) Close() error {
 	return err
 }
 
-// Obsoleted.
-func (drv *DockerDriver) PrepareCookie(ctx context.Context, cookie drivers.Cookie) error {
-	return nil
+func (drv *DockerDriver) SetPullImageRetryPolicy(policy common.BackOffConfig, checker drivers.RetryErrorChecker) error {
+	return drv.imgPuller.SetRetryPolicy(policy, checker)
 }
 
 func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.ContainerTask) (drivers.Cookie, error) {

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -67,13 +67,16 @@ type WaitResult interface {
 	Wait(context.Context) RunResult
 }
 
+// Check if the provided error is retriable. Returns true and a tag reason if the error is retriable.
+type RetryErrorChecker func(error) (bool, string)
+
 type Driver interface {
 	// Create a new cookie with defaults and/or settings from container task.
 	// Callers should Close the cookie regardless of whether they prepare or run it.
 	CreateCookie(ctx context.Context, task ContainerTask) (Cookie, error)
 
-	// Obsoleted. No-Op
-	PrepareCookie(ctx context.Context, cookie Cookie) error
+	// Set image pull retry policy and retriable error checker
+	SetPullImageRetryPolicy(policy common.BackOffConfig, checker RetryErrorChecker) error
 
 	// close & shutdown the driver
 	Close() error

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fnproject/fn/api/agent/drivers"
+	"github.com/fnproject/fn/api/common"
 )
 
 func New() drivers.Driver {
@@ -21,7 +22,7 @@ func (m *Mocker) CreateCookie(context.Context, drivers.ContainerTask) (drivers.C
 	return &cookie{m}, nil
 }
 
-func (m *Mocker) PrepareCookie(context.Context, drivers.Cookie) error {
+func (m *Mocker) SetPullImageRetryPolicy(policy common.BackOffConfig, checker drivers.RetryErrorChecker) error {
 	return nil
 }
 

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -173,19 +173,17 @@ type httpErr struct {
 }
 
 func (cl *client) do(ctx context.Context, request, result interface{}, method string, query map[string]string, url ...string) error {
-	// TODO determine policy (should we count to infinity?)
 
-	var b common.Backoff
-	var err error
-	for i := 0; i < 5; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	backoff := common.NewBackOff(common.BackOffConfig{
+		MaxRetries: 5,
+		Interval:   25,
+		MaxDelay:   1000,
+		MinDelay:   25,
+	})
 
+	for {
 		// TODO this isn't re-using buffers very efficiently, but retries should be rare...
-		err = cl.once(ctx, request, result, method, query, url...)
+		err := cl.once(ctx, request, result, method, query, url...)
 		switch err := err.(type) {
 		case nil:
 			return nil
@@ -199,12 +197,17 @@ func (cl *client) do(ctx context.Context, request, result interface{}, method st
 		}
 
 		common.Logger(ctx).WithError(err).Error("error from API server, retrying")
+		delay, ok := backoff.NextBackOff()
+		if !ok {
+			return err
+		}
 
-		b.Sleep(ctx)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
 	}
-
-	// return last error
-	return err
 }
 
 func (cl *client) once(ctx context.Context, request, result interface{}, method string, query map[string]string, path ...string) error {

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -174,10 +174,10 @@ type httpErr struct {
 
 func (cl *client) do(ctx context.Context, request, result interface{}, method string, query map[string]string, url ...string) error {
 
+	// Sequence of 25..75  25..175  25..200  25..725  25..1575
 	backoff := common.NewBackOff(common.BackOffConfig{
 		MaxRetries: 5,
-		Interval:   25,
-		MaxDelay:   1000,
+		Interval:   50,
 		MinDelay:   25,
 	})
 

--- a/api/common/backoff.go
+++ b/api/common/backoff.go
@@ -1,55 +1,100 @@
 package common
 
 import (
-	"context"
 	"math"
 	"math/rand"
 	"sync"
 	"time"
 )
 
-type BoxTime struct{}
-
-func (BoxTime) Now() time.Time                         { return time.Now() }
-func (BoxTime) Sleep(d time.Duration)                  { time.Sleep(d) }
-func (BoxTime) After(d time.Duration) <-chan time.Time { return time.After(d) }
-
-type Backoff int
-
-func (b *Backoff) Sleep(ctx context.Context) {
-	const (
-		maxexp   = 7
-		interval = 25 * time.Millisecond
-	)
-
-	rng := defaultRNG
-	clock := defaultClock
-
-	// 25-50ms, 50-100ms, 100-200ms, 200-400ms, 400-800ms, 800-1600ms, 1600-3200ms, 3200-6400ms
-	d := time.Duration(math.Pow(2, float64(*b))) * interval
-	d += (d * time.Duration(rng.Float64()))
-
-	select {
-	case <-ctx.Done():
-	case <-clock.After(d):
-	}
-
-	if *b < maxexp {
-		(*b)++
-	}
+type BackOffConfig struct {
+	MaxRetries uint64 `json:"max_retries"`
+	Interval   uint64 `json:"interval_msec"`
+	MaxDelay   uint64 `json:"max_delay_msec"`
+	MinDelay   uint64 `json:"min_delay_msec"`
 }
 
-var (
-	defaultRNG   = NewRNG(time.Now().UnixNano())
-	defaultClock = BoxTime{}
-)
-
-func NewRNG(seed int64) *rand.Rand {
-	return rand.New(&lockedSource{src: rand.NewSource(seed)})
+type BackOff interface {
+	NextBackOff() (time.Duration, bool)
 }
 
-// taken from go1.5.1 math/rand/rand.go +233-250
-// bla bla if it puts a hole in the earth don't sue them
+const RetryForever uint64 = math.MaxUint64
+
+type backoff struct {
+	cfg      BackOffConfig
+	rand     *rand.Rand
+	attempts uint64
+	pow      uint64
+}
+
+func NewBackOff(cfg BackOffConfig) BackOff {
+	// if retries are enabled, then check the config
+	if cfg.MaxRetries != 0 {
+		if cfg.MaxDelay != 0 && cfg.MinDelay > cfg.MaxDelay {
+			panic("invalid max min delay")
+		}
+	}
+
+	b := &backoff{
+		cfg:  cfg,
+		rand: rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())}),
+		pow:  1,
+	}
+
+	return b
+}
+
+func (b *backoff) NextBackOff() (time.Duration, bool) {
+	// check if retries disabled
+	if b.cfg.MaxRetries == 0 {
+		return 0, false
+	}
+
+	// check max retries if enabled
+	if b.cfg.MaxRetries != RetryForever {
+		if b.attempts >= b.cfg.MaxRetries {
+			return 0, false
+		}
+		b.attempts += 1
+	}
+
+	// https://en.wikipedia.org/wiki/Exponential_backoff
+
+	// 2^c
+	if b.pow < math.MaxUint64>>1 {
+		b.pow = b.pow * 2
+	}
+
+	// (2^c - 1) * slot time
+	delay := math.MaxUint64 / b.cfg.Interval
+	if delay >= b.pow-1 {
+		delay = (b.pow - 1) * b.cfg.Interval
+	}
+
+	// check for max
+	if b.cfg.MaxDelay != 0 && delay > b.cfg.MaxDelay-b.cfg.MinDelay {
+		delay = b.cfg.MaxDelay - b.cfg.MinDelay
+	}
+
+	// get rand for max-min
+	if delay != 0 {
+		delay = b.rand.Uint64() % delay
+	} else {
+		delay = 0
+	}
+
+	// add min
+	if math.MaxUint64-b.cfg.MinDelay >= delay {
+		delay += b.cfg.MinDelay
+	}
+
+	// See if our result overflows time.Duration
+	if delay > uint64(math.MaxInt64/time.Millisecond) {
+		return time.Duration(math.MaxInt64), true
+	}
+	return time.Duration(delay) * time.Millisecond, true
+}
+
 type lockedSource struct {
 	lk  sync.Mutex
 	src rand.Source

--- a/api/common/backoff_test.go
+++ b/api/common/backoff_test.go
@@ -1,43 +1,37 @@
 package common
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
 )
 
-func checkRange(bck BackOff, expOk bool, min, max uint64) error {
+func checkRange(t *testing.T, bck BackOff, expOk bool, min, max uint64) {
 	delay, ok := bck.NextBackOff()
 	if ok != expOk {
-		return fmt.Errorf("%v != %v delay=%v", ok, expOk, delay)
+		t.Fatalf("%v != %v delay=%v", ok, expOk, delay)
 	}
 	dMax := time.Duration(max) * time.Millisecond
 	dMin := time.Duration(min) * time.Millisecond
 	if delay > dMax || delay < dMin {
-		return fmt.Errorf("%v == %v but %v < %v < %v", ok, expOk, dMin, delay, dMax)
+		t.Fatalf("%v == %v but %v < %v < %v", ok, expOk, dMin, delay, dMax)
 	}
 	logrus.Infof("checkRange ok=%v %v < %v < %v", ok, dMin, delay, dMax)
-	return nil
 }
 
 func TestBackoff1(t *testing.T) {
 
 	cfg := BackOffConfig{
-		MaxRetries: 0,
-		Interval:   100,
-		MaxDelay:   1000,
-		MinDelay:   100,
+		Interval: 100,
+		MaxDelay: 1000,
+		MinDelay: 100,
 	}
 
 	bck := NewBackOff(cfg)
 
 	for i := 0; i < 32; i++ {
-		err := checkRange(bck, false, 0, 0)
-		if err != nil {
-			t.Fatalf("fail %v", err)
-		}
+		checkRange(t, bck, false, 0, 0)
 	}
 }
 
@@ -53,10 +47,7 @@ func TestBackoff2(t *testing.T) {
 	bck := NewBackOff(cfg)
 
 	for i := 0; i < 32; i++ {
-		err := checkRange(bck, true, 100, 100)
-		if err != nil {
-			t.Fatalf("fail %v", err)
-		}
+		checkRange(t, bck, true, 100, 100)
 	}
 }
 
@@ -70,32 +61,13 @@ func TestBackoff3(t *testing.T) {
 	}
 
 	bck := NewBackOff(cfg)
-	var err error
 
-	err = checkRange(bck, true, 1000, 1100)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 1300)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 1700)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 2500)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 4100)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, false, 0, 0)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
+	checkRange(t, bck, true, 1000, 1100)
+	checkRange(t, bck, true, 1000, 1300)
+	checkRange(t, bck, true, 1000, 1700)
+	checkRange(t, bck, true, 1000, 2500)
+	checkRange(t, bck, true, 1000, 4100)
+	checkRange(t, bck, false, 0, 0)
 }
 
 func TestBackoff4(t *testing.T) {
@@ -108,32 +80,13 @@ func TestBackoff4(t *testing.T) {
 	}
 
 	bck := NewBackOff(cfg)
-	var err error
 
-	err = checkRange(bck, true, 1000, 1100)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 1300)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 1700)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 2000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 1000, 2000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, false, 0, 0)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
+	checkRange(t, bck, true, 1000, 1100)
+	checkRange(t, bck, true, 1000, 1300)
+	checkRange(t, bck, true, 1000, 1700)
+	checkRange(t, bck, true, 1000, 2000)
+	checkRange(t, bck, true, 1000, 2000)
+	checkRange(t, bck, false, 0, 0)
 }
 
 func TestBackoff5(t *testing.T) {
@@ -141,35 +94,14 @@ func TestBackoff5(t *testing.T) {
 	cfg := BackOffConfig{
 		MaxRetries: 5,
 		Interval:   1000,
-		MaxDelay:   0,
-		MinDelay:   0,
 	}
 
 	bck := NewBackOff(cfg)
-	var err error
 
-	err = checkRange(bck, true, 0, 1000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 0, 3000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 0, 7000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 0, 15000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, true, 0, 31000)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
-	err = checkRange(bck, false, 0, 0)
-	if err != nil {
-		t.Fatalf("fail %v", err)
-	}
+	checkRange(t, bck, true, 0, 1000)
+	checkRange(t, bck, true, 0, 3000)
+	checkRange(t, bck, true, 0, 7000)
+	checkRange(t, bck, true, 0, 15000)
+	checkRange(t, bck, true, 0, 31000)
+	checkRange(t, bck, false, 0, 0)
 }

--- a/api/common/backoff_test.go
+++ b/api/common/backoff_test.go
@@ -1,0 +1,175 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func checkRange(bck BackOff, expOk bool, min, max uint64) error {
+	delay, ok := bck.NextBackOff()
+	if ok != expOk {
+		return fmt.Errorf("%v != %v delay=%v", ok, expOk, delay)
+	}
+	dMax := time.Duration(max) * time.Millisecond
+	dMin := time.Duration(min) * time.Millisecond
+	if delay > dMax || delay < dMin {
+		return fmt.Errorf("%v == %v but %v < %v < %v", ok, expOk, dMin, delay, dMax)
+	}
+	logrus.Infof("checkRange ok=%v %v < %v < %v", ok, dMin, delay, dMax)
+	return nil
+}
+
+func TestBackoff1(t *testing.T) {
+
+	cfg := BackOffConfig{
+		MaxRetries: 0,
+		Interval:   100,
+		MaxDelay:   1000,
+		MinDelay:   100,
+	}
+
+	bck := NewBackOff(cfg)
+
+	for i := 0; i < 32; i++ {
+		err := checkRange(bck, false, 0, 0)
+		if err != nil {
+			t.Fatalf("fail %v", err)
+		}
+	}
+}
+
+func TestBackoff2(t *testing.T) {
+
+	cfg := BackOffConfig{
+		MaxRetries: RetryForever,
+		Interval:   100,
+		MaxDelay:   100,
+		MinDelay:   100,
+	}
+
+	bck := NewBackOff(cfg)
+
+	for i := 0; i < 32; i++ {
+		err := checkRange(bck, true, 100, 100)
+		if err != nil {
+			t.Fatalf("fail %v", err)
+		}
+	}
+}
+
+func TestBackoff3(t *testing.T) {
+
+	cfg := BackOffConfig{
+		MaxRetries: 5,
+		Interval:   100,
+		MaxDelay:   10000,
+		MinDelay:   1000,
+	}
+
+	bck := NewBackOff(cfg)
+	var err error
+
+	err = checkRange(bck, true, 1000, 1100)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 1300)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 1700)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 2500)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 4100)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, false, 0, 0)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+}
+
+func TestBackoff4(t *testing.T) {
+
+	cfg := BackOffConfig{
+		MaxRetries: 5,
+		Interval:   100,
+		MaxDelay:   2000,
+		MinDelay:   1000,
+	}
+
+	bck := NewBackOff(cfg)
+	var err error
+
+	err = checkRange(bck, true, 1000, 1100)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 1300)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 1700)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 2000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 1000, 2000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, false, 0, 0)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+}
+
+func TestBackoff5(t *testing.T) {
+
+	cfg := BackOffConfig{
+		MaxRetries: 5,
+		Interval:   1000,
+		MaxDelay:   0,
+		MinDelay:   0,
+	}
+
+	bck := NewBackOff(cfg)
+	var err error
+
+	err = checkRange(bck, true, 0, 1000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 0, 3000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 0, 7000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 0, 15000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, true, 0, 31000)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+	err = checkRange(bck, false, 0, 0)
+	if err != nil {
+		t.Fatalf("fail %v", err)
+	}
+}

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -68,8 +68,14 @@ func (s *Server) handleRunnerDequeue(c *gin.Context) {
 	var m [1]*models.Call // avoid alloc
 	resp.M = m[:0]
 
+	backoff := common.NewBackOff(common.BackOffConfig{
+		MaxRetries: common.RetryForever,
+		Interval:   25,
+		MaxDelay:   6400,
+		MinDelay:   25,
+	})
+
 	// long poll until ctx expires / we find a message
-	var b common.Backoff
 	for {
 		call, err := s.mq.Reserve(ctx)
 		if err != nil {
@@ -82,13 +88,13 @@ func (s *Server) handleRunnerDequeue(c *gin.Context) {
 			return
 		}
 
-		b.Sleep(ctx)
+		delay, _ := backoff.NextBackOff()
 
 		select {
 		case <-ctx.Done():
 			c.JSON(200, resp) // TODO assert this return `[]` & not 'nil'
 			return
-		default: // poll until we find a cookie
+		case <-time.After(delay):
 		}
 	}
 }

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -68,10 +68,10 @@ func (s *Server) handleRunnerDequeue(c *gin.Context) {
 	var m [1]*models.Call // avoid alloc
 	resp.M = m[:0]
 
+	// Sequence of 25..75  25..175  25..200  25..725  25..1575, etc.
 	backoff := common.NewBackOff(common.BackOffConfig{
 		MaxRetries: common.RetryForever,
-		Interval:   25,
-		MaxDelay:   6400,
+		Interval:   50,
 		MinDelay:   25,
 	})
 

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -475,8 +475,8 @@ func (d *customDriver) CreateCookie(ctx context.Context, task drivers.ContainerT
 }
 
 // implements Driver
-func (d *customDriver) PrepareCookie(ctx context.Context, cookie drivers.Cookie) error {
-	return d.drv.PrepareCookie(ctx, cookie)
+func (d *customDriver) SetPullImageRetryPolicy(policy common.BackOffConfig, checker drivers.RetryErrorChecker) error {
+	return d.drv.SetPullImageRetryPolicy(policy, checker)
 }
 
 // implements Driver


### PR DESCRIPTION
Introducing SetPullImageRetryPolicy() for docker driver to allow
customizations of docker pull behavior.

Replacing old backoff code with a more formal exponential backoff
with policy options.