### PR TITLE
To Enable configuring http server settings through env

### DIFF
--- a/api/server/init.go
+++ b/api/server/init.go
@@ -62,7 +62,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	var err error
 	res := fallback
 	if tmp := os.Getenv(key); tmp != "" {
-		res, err = time.ParseDuration(tmp)
+		res, err = time.ParseDuration(tmp + "s")
 		if err != nil {
 			res = fallback
 			err = fmt.Errorf("%s invalid %s=%s", err.Error(), key, tmp)

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -41,7 +40,7 @@ func getEnvInt(key string, fallback int) int {
 		var err error
 		var i int
 		if i, err = strconv.Atoi(value); err != nil {
-			panic(err) // not sure how to handle this
+			logrus.WithError(err).WithFields(logrus.Fields{"string": value, "environment_key": key}).Fatal("Failed to convert string to int")
 		}
 		return i
 	} else if value, ok := os.LookupEnv(key + "_FILE"); ok {
@@ -50,7 +49,7 @@ func getEnvInt(key string, fallback int) int {
 			var err error
 			var i int
 			if i, err = strconv.Atoi(strings.TrimSpace(string(dat))); err != nil {
-				panic(err) // not sure how to handle this
+				logrus.WithError(err).WithFields(logrus.Fields{"string": dat, "environment_key": key}).Fatal("Failed to convert string to int")
 			}
 			return i
 		}
@@ -64,8 +63,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	if tmp := os.Getenv(key); tmp != "" {
 		res, err = time.ParseDuration(tmp + "s")
 		if err != nil {
-			err = fmt.Errorf("%s invalid %s=%s", err.Error(), key, tmp)
-			panic(err)
+			logrus.WithError(err).WithFields(logrus.Fields{"duration_string": tmp, "environment_key": key}).Fatal("Failed to parse duration from environment")
 		}
 	}
 	return res

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/fnproject/fn/api/common"
 	"github.com/gin-gonic/gin"
@@ -54,6 +56,20 @@ func getEnvInt(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	var err error
+	res := fallback
+	if tmp := os.Getenv(key); tmp != "" {
+		res, err = time.ParseDuration(tmp)
+		if err != nil {
+			res = fallback
+			err = fmt.Errorf("%s invalid %s=%s", err.Error(), key, tmp)
+			panic(err)
+		}
+	}
+	return res
 }
 
 func contextWithSignal(ctx context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -61,7 +61,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	var err error
 	res := fallback
 	if tmp := os.Getenv(key); tmp != "" {
-		// if the retuned value is not null it needs to be either an integral value in seconds or a parsable duration-format string
+		// if the returned value is not null it needs to be either an integral value in seconds or a parsable duration-format string
 		res, err = time.ParseDuration(tmp)
 		if err != nil {
 			// try to parse an int

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -64,7 +64,6 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	if tmp := os.Getenv(key); tmp != "" {
 		res, err = time.ParseDuration(tmp + "s")
 		if err != nil {
-			res = fallback
 			err = fmt.Errorf("%s invalid %s=%s", err.Error(), key, tmp)
 			panic(err)
 		}

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -61,9 +61,16 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	var err error
 	res := fallback
 	if tmp := os.Getenv(key); tmp != "" {
-		res, err = time.ParseDuration(tmp + "s")
+		// if the retuned value is not null it needs to be either an integral value in seconds or a parsable duration-format string
+		res, err = time.ParseDuration(tmp)
 		if err != nil {
-			logrus.WithError(err).WithFields(logrus.Fields{"duration_string": tmp, "environment_key": key}).Fatal("Failed to parse duration from environment")
+			// try to parse an int
+			s, perr := strconv.Atoi(tmp)
+			if perr != nil {
+				logrus.WithError(err).WithFields(logrus.Fields{"duration_string": tmp, "environment_key": key}).Fatal("Failed to parse duration from env")
+			} else {
+				res = time.Duration(s) * time.Second
+			}
 		}
 	}
 	return res

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -116,8 +116,23 @@ const (
 	// EnvLBPlacementAlg is the algorithm to place fn calls to fn runners in lb.[0w
 	EnvLBPlacementAlg = "FN_PLACER"
 
-	// EnvMaxRequestSize sets the limit in bytes for any API request's length.
-	EnvMaxRequestSize = "FN_MAX_REQUEST_SIZE"
+	// EnvMaxRequestSize sets the limit in bytes for any API request body's length.
+	EnvMaxRequestSize = "FN_MAX_REQUEST_BODY_SIZE"
+
+	// EnvMaxHeaderSize sets the limit in bytes for any API request body's length.
+	EnvMaxHeaderSize = "FN_MAX_REQUEST_HEADER_SIZE"
+
+	// EnvReadTimeout sets the timeout limit for reading a http request body.
+	EnvReadTimeout = "FN_REQUEST_BODY_READ_TIMEOUT"
+
+	// EnvReadHeaderTimeout sets the timeout limit for reading a http request header.
+	EnvReadHeaderTimeout = "FN_REQUEST_HEADER_READ_TIMEOUT"
+
+	// EnvWriteTimeout sets the timeout limit for writing a http response.
+	EnvWriteTimeout = "FN_RESPONSE_WRITE_TIMEOUT"
+
+	// EnvHTTPIdleTimeout maximum amount of time to wait for the next request.
+	EnvHTTPIdleTimeout = "FN_HTTP_IDLE_TIMEOUT"
 
 	// DefaultLogFormat is text
 	DefaultLogFormat = "text"
@@ -639,7 +654,14 @@ func New(ctx context.Context, opts ...Option) *Server {
 		AdminRouter: engine,
 		lbEnqueue:   agent.NewUnsupportedAsyncEnqueueAccess(),
 		svcConfigs: map[string]*http.Server{
-			WebServer:   &http.Server{},
+			WebServer: &http.Server{
+				MaxHeaderBytes:    getEnvInt(EnvMaxHeaderSize, http.DefaultMaxHeaderBytes),
+				ReadHeaderTimeout: getEnvDuration(EnvReadHeaderTimeout, 0),
+				ReadTimeout:       getEnvDuration(EnvReadTimeout, 0),
+				WriteTimeout:      getEnvDuration(EnvWriteTimeout, 0),
+				IdleTimeout:       getEnvDuration(EnvHTTPIdleTimeout, 0),
+				// TODO is it okay to leave the defaults to 0? check if go http library takes care of this
+			},
 			AdminServer: &http.Server{},
 			GRPCServer:  &http.Server{},
 		},

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -122,6 +122,11 @@ const (
 	// EnvMaxHeaderSize sets the limit in bytes for any API request body's length.
 	EnvMaxHeaderSize = "FN_MAX_REQUEST_HEADER_SIZE"
 
+	// The following 4 env-vars (FN_REQUEST_BODY_READ_TIMEOUT, FN_REQUEST_HEADER_READ_TIMEOUT, FN_RESPONSE_WRITE_TIMEOUT, FN_HTTP_IDLE_TIMEOUT)
+	// need to be set as strings that are either :
+	// 1. Valid integral values of duration in seconds ("120", "125")
+	// 2. Valid duration-format strings ("120s", "2m5s")
+
 	// EnvReadTimeout sets the timeout limit for reading a http request body.
 	EnvReadTimeout = "FN_REQUEST_BODY_READ_TIMEOUT"
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -117,7 +117,7 @@ const (
 	EnvLBPlacementAlg = "FN_PLACER"
 
 	// EnvMaxRequestSize sets the limit in bytes for any API request body's length.
-	EnvMaxRequestSize = "FN_MAX_REQUEST_BODY_SIZE"
+	EnvMaxRequestSize = "FN_MAX_REQUEST_SIZE"
 
 	// EnvMaxHeaderSize sets the limit in bytes for any API request body's length.
 	EnvMaxHeaderSize = "FN_MAX_REQUEST_HEADER_SIZE"

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -660,7 +660,6 @@ func New(ctx context.Context, opts ...Option) *Server {
 				ReadTimeout:       getEnvDuration(EnvReadTimeout, 0),
 				WriteTimeout:      getEnvDuration(EnvWriteTimeout, 0),
 				IdleTimeout:       getEnvDuration(EnvHTTPIdleTimeout, 0),
-				// TODO is it okay to leave the defaults to 0? check if go http library takes care of this
 			},
 			AdminServer: &http.Server{},
 			GRPCServer:  &http.Server{},


### PR DESCRIPTION
currently the fn server uses default http server settings such as timeouts and limits on header sizes.

This change enables setting them using environment variables, but if not set, default values will be used.
