### PR TITLE
add app/fn id and image to container metrics

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -455,7 +455,7 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 		return
 	}
 
-	state := NewContainerState(a.cfg.EnableContainerMetrics)
+	state := NewContainerState()
 	state.UpdateState(ctx, ContainerStateWait, call)
 
 	mem := call.Memory + uint64(call.TmpFsSize)

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -455,8 +455,8 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 		return
 	}
 
-	state := NewContainerState()
-	state.UpdateState(ctx, ContainerStateWait, call.slots)
+	state := NewContainerState(a.cfg.EnableContainerMetrics)
+	state.UpdateState(ctx, ContainerStateWait, call)
 
 	mem := call.Memory + uint64(call.TmpFsSize)
 
@@ -521,7 +521,7 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 		tok.Close()
 	}
 
-	defer state.UpdateState(ctx, ContainerStateDone, call.slots)
+	defer state.UpdateState(ctx, ContainerStateDone, call)
 
 	// IMPORTANT: we wait here for any possible evictions to finalize. Otherwise
 	// hotLauncher could call checkLaunch again and cause a capacity full (http 503)
@@ -797,7 +797,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	errQueue := make(chan error, 1)    // errors to be reflected back to the slot queue
 
 	statsUtilization(ctx, a.resources.GetUtilization())
-	state.UpdateState(ctx, ContainerStateStart, call.slots)
+	state.UpdateState(ctx, ContainerStateStart, call)
 
 	// stack unwind spelled out with strict ordering below.
 	defer func() {
@@ -828,9 +828,10 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 			}
 			container.Close()
 		}
+
 		tok.Close() // release cpu/mem
 
-		state.UpdateState(ctx, ContainerStateDone, call.slots)
+		state.UpdateState(ctx, ContainerStateDone, call)
 		statsUtilization(ctx, a.resources.GetUtilization())
 	}()
 
@@ -1065,7 +1066,7 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 		}
 	}()
 
-	state.UpdateState(ctx, ContainerStateIdle, call.slots)
+	state.UpdateState(ctx, ContainerStateIdle, call)
 	c.EnableEviction(call)
 
 	s := call.slots.queueSlot(slot)
@@ -1088,7 +1089,7 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 					return false
 				}
 				isFrozen = true
-				state.UpdateState(ctx, ContainerStatePaused, call.slots)
+				state.UpdateState(ctx, ContainerStatePaused, call)
 			}
 			continue
 		case <-evicted:
@@ -1126,7 +1127,7 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 		isFrozen = false
 	}
 
-	state.UpdateState(ctx, ContainerStateBusy, call.slots)
+	state.UpdateState(ctx, ContainerStateBusy, call)
 	return true
 }
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -43,10 +43,7 @@ type Config struct {
 	ImageCleanMaxSize       uint64        `json:"image_clean_max_size"`
 	ImageCleanExemptTags    string        `json:"image_clean_exempt_tags"`
 	ImageEnableVolume       bool          `json:"image_enable_volume"`
-	EnableContainerMetrics  bool          `json:"enable_container_state_metrics"`
 }
-
-//containerStateMetrics
 
 const (
 	// EnvContainerLabelTag is a classifier label tag that is used to distinguish fn managed containers
@@ -113,9 +110,6 @@ const (
 	// EnvIOFSOpts are the options to set when mounting the iofs directory for unix socket files
 	EnvIOFSOpts = "FN_IOFS_OPTS"
 
-	// EnvContainerStateMetrics enables metrics for which functions are currently in what container state
-	EnvContainerStateMetrics = "FN_CONTAINER_STATE_METRICS"
-
 	// EnvDetachedHeadroom is the extra room we want to give to a detached function to run.
 	EnvDetachedHeadroom = "FN_EXECUTION_HEADROOM"
 
@@ -178,7 +172,6 @@ func NewConfig() (*Config, error) {
 	err = setEnvUint(err, EnvImageCleanMaxSize, &cfg.ImageCleanMaxSize)
 	err = setEnvStr(err, EnvImageCleanExemptTags, &cfg.ImageCleanExemptTags)
 	err = setEnvBool(err, EnvImageEnableVolume, &cfg.ImageEnableVolume)
-	err = setEnvBool(err, EnvContainerStateMetrics, &cfg.EnableContainerMetrics)
 
 	if err != nil {
 		return cfg, err

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -43,7 +43,10 @@ type Config struct {
 	ImageCleanMaxSize       uint64        `json:"image_clean_max_size"`
 	ImageCleanExemptTags    string        `json:"image_clean_exempt_tags"`
 	ImageEnableVolume       bool          `json:"image_enable_volume"`
+	EnableContainerMetrics  bool          `json:"enable_container_state_metrics"`
 }
+
+//containerStateMetrics
 
 const (
 	// EnvContainerLabelTag is a classifier label tag that is used to distinguish fn managed containers
@@ -110,6 +113,9 @@ const (
 	// EnvIOFSOpts are the options to set when mounting the iofs directory for unix socket files
 	EnvIOFSOpts = "FN_IOFS_OPTS"
 
+	// EnvContainerStateMetrics enables metrics for which functions are currently in what container state
+	EnvContainerStateMetrics = "FN_CONTAINER_STATE_METRICS"
+
 	// EnvDetachedHeadroom is the extra room we want to give to a detached function to run.
 	EnvDetachedHeadroom = "FN_EXECUTION_HEADROOM"
 
@@ -132,7 +138,6 @@ const (
 
 // NewConfig returns a config set from env vars, plus defaults
 func NewConfig() (*Config, error) {
-
 	cfg := &Config{
 		MinDockerVersion: "17.10.0-ce",
 		MaxLogSize:       1 * 1024 * 1024,
@@ -173,6 +178,8 @@ func NewConfig() (*Config, error) {
 	err = setEnvUint(err, EnvImageCleanMaxSize, &cfg.ImageCleanMaxSize)
 	err = setEnvStr(err, EnvImageCleanExemptTags, &cfg.ImageCleanExemptTags)
 	err = setEnvBool(err, EnvImageEnableVolume, &cfg.ImageEnableVolume)
+	err = setEnvBool(err, EnvContainerStateMetrics, &cfg.EnableContainerMetrics)
+
 	if err != nil {
 		return cfg, err
 	}

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -22,6 +22,11 @@ var (
 	statusCallCacheKey    = common.MakeKey("cached")
 	statusCallSuccessKey  = common.MakeKey("success")
 	statusCallNetReadyKey = common.MakeKey("network")
+
+	appIdKey      = common.MakeKey("app_id")
+	functionIdKey = common.MakeKey("function_id")
+	imageNameKey  = common.MakeKey("image_name")
+	containerKeys = []tag.Key{appIdKey, functionIdKey, imageNameKey}
 )
 
 func statsCalls(ctx context.Context) {
@@ -181,23 +186,21 @@ const (
 )
 
 var (
-	queuedMeasure          = common.MakeMeasure(queuedMetricName, "calls currently queued against agent", "")
-	callsMeasure           = common.MakeMeasure(callsMetricName, "calls created in agent", "")
-	runningMeasure         = common.MakeMeasure(runningMetricName, "calls currently running in agent", "")
-	completedMeasure       = common.MakeMeasure(completedMetricName, "calls completed in agent", "")
-	canceledMeasure        = common.MakeMeasure(canceledMetricName, "calls canceled in agent", "")
-	timedoutMeasure        = common.MakeMeasure(timedoutMetricName, "calls timed out in agent", "")
-	errorsMeasure          = common.MakeMeasure(errorsMetricName, "calls errored in agent", "")
-	serverBusyMeasure      = common.MakeMeasure(serverBusyMetricName, "calls where server was too busy in agent", "")
-	dockerMeasures         = initDockerMeasures()
-	containerGaugeMeasures = initContainerGaugeMeasures()
-	containerTimeMeasures  = initContainerTimeMeasures()
-
-	utilCpuUsedMeasure  = common.MakeMeasure(utilCpuUsedMetricName, "agent cpu in use", "")
-	utilCpuAvailMeasure = common.MakeMeasure(utilCpuAvailMetricName, "agent cpu available", "")
-	utilMemUsedMeasure  = common.MakeMeasure(utilMemUsedMetricName, "agent memory in use", "By")
-	utilMemAvailMeasure = common.MakeMeasure(utilMemAvailMetricName, "agent memory available", "By")
-
+	queuedMeasure                  = common.MakeMeasure(queuedMetricName, "calls currently queued against agent", "")
+	callsMeasure                   = common.MakeMeasure(callsMetricName, "calls created in agent", "")
+	runningMeasure                 = common.MakeMeasure(runningMetricName, "calls currently running in agent", "")
+	completedMeasure               = common.MakeMeasure(completedMetricName, "calls completed in agent", "")
+	canceledMeasure                = common.MakeMeasure(canceledMetricName, "calls canceled in agent", "")
+	timedoutMeasure                = common.MakeMeasure(timedoutMetricName, "calls timed out in agent", "")
+	errorsMeasure                  = common.MakeMeasure(errorsMetricName, "calls errored in agent", "")
+	serverBusyMeasure              = common.MakeMeasure(serverBusyMetricName, "calls where server was too busy in agent", "")
+	dockerMeasures                 = initDockerMeasures()
+	containerGaugeMeasures         = initContainerGaugeMeasures()
+	containerTimeMeasures          = initContainerTimeMeasures()
+	utilCpuUsedMeasure             = common.MakeMeasure(utilCpuUsedMetricName, "agent cpu in use", "")
+	utilCpuAvailMeasure            = common.MakeMeasure(utilCpuAvailMetricName, "agent cpu available", "")
+	utilMemUsedMeasure             = common.MakeMeasure(utilMemUsedMetricName, "agent memory in use", "By")
+	utilMemAvailMeasure            = common.MakeMeasure(utilMemAvailMetricName, "agent memory available", "By")
 	containerEvictedMeasure        = common.MakeMeasure(containerEvictedMetricName, "containers evicted", "")
 	containerUDSInitLatencyMeasure = common.MakeMeasure(containerUDSInitLatencyMetricName, "container UDS Init-Wait Latency", "msecs")
 
@@ -247,6 +250,7 @@ func RegisterAgentViews(tagKeys []string, latencyDist []float64) {
 		common.CreateView(utilMemUsedMeasure, view.LastValue(), tagKeys),
 		common.CreateView(utilMemAvailMeasure, view.LastValue(), tagKeys),
 	)
+
 	if err != nil {
 		logrus.WithError(err).Fatal("cannot register view")
 	}
@@ -311,7 +315,8 @@ func RegisterContainerViews(tagKeys []string, latencyDist []float64) {
 		if key == "" {
 			continue
 		}
-		v := common.CreateView(containerGaugeMeasures[i], view.Sum(), tagKeys)
+		v := common.CreateViewWithTags(containerGaugeMeasures[i], view.Sum(), containerKeys)
+
 		if err := view.Register(v); err != nil {
 			logrus.WithError(err).Fatal("cannot register view")
 		}

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -23,10 +23,12 @@ var (
 	statusCallSuccessKey  = common.MakeKey("success")
 	statusCallNetReadyKey = common.MakeKey("network")
 
-	appIdKey      = common.MakeKey("app_id")
-	functionIdKey = common.MakeKey("function_id")
-	imageNameKey  = common.MakeKey("image_name")
-	containerKeys = []tag.Key{appIdKey, functionIdKey, imageNameKey}
+	// AppIDMetricKey is a tag for metrics
+	AppIDMetricKey = common.MakeKey("app_id")
+	// FnIDMetricKey is a tag for metrics
+	FnIDMetricKey = common.MakeKey("fn_id")
+	// ImageNameMetricKey is a tag for metrics
+	ImageNameMetricKey = common.MakeKey("image_name")
 )
 
 func statsCalls(ctx context.Context) {
@@ -315,7 +317,7 @@ func RegisterContainerViews(tagKeys []string, latencyDist []float64) {
 		if key == "" {
 			continue
 		}
-		v := common.CreateViewWithTags(containerGaugeMeasures[i], view.Sum(), containerKeys)
+		v := common.CreateView(containerGaugeMeasures[i], view.Sum(), tagKeys)
 
 		if err := view.Register(v); err != nil {
 			logrus.WithError(err).Fatal("cannot register view")

--- a/cmd/fnserver/main.go
+++ b/cmd/fnserver/main.go
@@ -43,7 +43,11 @@ func registerViews() {
 	agent.RegisterRunnerViews(keys, latencyDist)
 	agent.RegisterAgentViews(keys, latencyDist)
 	agent.RegisterDockerViews(keys, latencyDist, ioDist, ioDist, memoryDist, cpuDist)
-	agent.RegisterContainerViews(keys, latencyDist)
+
+	// container views have additional metrics, optional to turn on
+	// TODO more cohesive plan for wiring these in
+	cKeys := append(keys, agent.AppIDMetricKey.Name(), agent.FnIDMetricKey.Name(), agent.ImageNameMetricKey.Name())
+	agent.RegisterContainerViews(cKeys, latencyDist)
 
 	// Register docker client views
 	docker.RegisterViews(keys, latencyDist)


### PR DESCRIPTION
in main we wire in view tags, so for OSS we can wire these tags in by default
and anybody that builds their own version of fn that doesn't want them can
easily turn them off (I did this, and it works as expected, the tags don't
appear in prometheus). I think we probably want to add these tags in more
places, but for purpose of discussion and closing out for the metrics we want,
I'm okay with starting out with a limited set of metrics.

I'll say that the symmetry of wiring them into the agent to optionally turn
them on in main seems somewhat appealing though slightly odd specifically for
cases where certain sets of metrics may have different sets of tags. it seems
like we should bundle metrics by what tags they offer, and allow configuring
views that way. I have not gotten into the weeds on strictly defining this
across each set of metrics, as noted earlier, this handles the metrics of
interest to add these tags of interest, but I think the general intent
expressed here seems appealing, we just need to define all the bundles well.

works as intended:

```
✗: curl -sSL localhost:8080/metrics | grep "paused"
fn_container_paused_total{app_id="01D2RHGQ15180043RZJ0000001",fn_id="01D2SN4A7Z180043RZJ000000C",image_name="hello:0.0.41"} 1.0
```

again, anyone that registers the views without these tags won't see these.