### PR TITLE
fn: add getter/setter for last/current call id in a container

### DIFF
--- a/api/agent/drivers/docker/docker_pool.go
+++ b/api/agent/drivers/docker/docker_pool.go
@@ -73,6 +73,8 @@ func (c *poolTask) WriteStat(ctx context.Context, stat drivers.Stat) {}
 func (c *poolTask) UDSAgentPath() string                             { return "" }
 func (c *poolTask) UDSDockerPath() string                            { return "" }
 func (c *poolTask) UDSDockerDest() string                            { return "" }
+func (c *poolTask) GetCallId() string                                { return "" }
+func (c *poolTask) SetCallId(string)                                 {}
 
 type dockerPoolItem struct {
 	id     string

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -47,6 +47,8 @@ func (f *taskDockerTest) UDSAgentPath() string  { return "" }
 func (f *taskDockerTest) UDSDockerPath() string { return "" }
 func (f *taskDockerTest) UDSDockerDest() string { return "" }
 func (f *taskDockerTest) DisableNet() bool      { return f.disableNet }
+func (f *taskDockerTest) GetCallId() string     { return "" }
+func (f *taskDockerTest) SetCallId(string)      {}
 
 func createTask(id string) *taskDockerTest {
 	return &taskDockerTest{

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -181,6 +181,12 @@ type ContainerTask interface {
 
 	// Returns true if network is disabled.
 	DisableNet() bool
+
+	// Set Currently Executing Call Id
+	SetCallId(id string)
+
+	// Get Current or Last Executed Call Id
+	GetCallId() string
 }
 
 // Stat is a bucket of stats from a driver at a point in time for a certain task.


### PR DESCRIPTION
This is useful to determine which call is about to run or
last call that was run on that container.
