### PR TITLE
run function container as unprivileged user

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -199,20 +199,21 @@ func WithCallOptions(opts ...CallOpt) Option {
 // NewDockerDriver creates a default docker driver from agent config
 func NewDockerDriver(cfg *Config) (drivers.Driver, error) {
 	return drivers.New("docker", drivers.Config{
-		DockerNetworks:       cfg.DockerNetworks,
-		DockerLoadFile:       cfg.DockerLoadFile,
-		ServerVersion:        cfg.MinDockerVersion,
-		PreForkPoolSize:      cfg.PreForkPoolSize,
-		PreForkImage:         cfg.PreForkImage,
-		PreForkCmd:           cfg.PreForkCmd,
-		PreForkUseOnce:       cfg.PreForkUseOnce,
-		PreForkNetworks:      cfg.PreForkNetworks,
-		MaxTmpFsInodes:       cfg.MaxTmpFsInodes,
-		EnableReadOnlyRootFs: !cfg.DisableReadOnlyRootFs,
-		ContainerLabelTag:    cfg.ContainerLabelTag,
-		ImageCleanMaxSize:    cfg.ImageCleanMaxSize,
-		ImageCleanExemptTags: cfg.ImageCleanExemptTags,
-		ImageEnableVolume:    cfg.ImageEnableVolume,
+		DockerNetworks:                cfg.DockerNetworks,
+		DockerLoadFile:                cfg.DockerLoadFile,
+		ServerVersion:                 cfg.MinDockerVersion,
+		PreForkPoolSize:               cfg.PreForkPoolSize,
+		PreForkImage:                  cfg.PreForkImage,
+		PreForkCmd:                    cfg.PreForkCmd,
+		PreForkUseOnce:                cfg.PreForkUseOnce,
+		PreForkNetworks:               cfg.PreForkNetworks,
+		MaxTmpFsInodes:                cfg.MaxTmpFsInodes,
+		EnableReadOnlyRootFs:          !cfg.DisableReadOnlyRootFs,
+		ContainerLabelTag:             cfg.ContainerLabelTag,
+		ImageCleanMaxSize:             cfg.ImageCleanMaxSize,
+		ImageCleanExemptTags:          cfg.ImageCleanExemptTags,
+		ImageEnableVolume:             cfg.ImageEnableVolume,
+		DisableUnprivilegedContainers: cfg.DisableUnprivilegedContainers,
 	})
 }
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -11,39 +11,40 @@ import (
 
 // Config specifies various settings for an agent
 type Config struct {
-	MinDockerVersion        string        `json:"min_docker_version"`
-	ContainerLabelTag       string        `json:"container_label_tag"`
-	DockerNetworks          string        `json:"docker_networks"`
-	DockerLoadFile          string        `json:"docker_load_file"`
-	FreezeIdle              time.Duration `json:"freeze_idle_msecs"`
-	HotPoll                 time.Duration `json:"hot_poll_msecs"`
-	HotLauncherTimeout      time.Duration `json:"hot_launcher_timeout_msecs"`
-	HotPullTimeout          time.Duration `json:"hot_pull_timeout_msecs"`
-	HotStartTimeout         time.Duration `json:"hot_start_timeout_msecs"`
-	DetachedHeadRoom        time.Duration `json:"detached_head_room_msecs"`
-	MaxResponseSize         uint64        `json:"max_response_size_bytes"`
-	MaxHdrResponseSize      uint64        `json:"max_hdr_response_size_bytes"`
-	MaxLogSize              uint64        `json:"max_log_size_bytes"`
-	MaxTotalCPU             uint64        `json:"max_total_cpu_mcpus"`
-	MaxTotalMemory          uint64        `json:"max_total_memory_bytes"`
-	MaxFsSize               uint64        `json:"max_fs_size_mb"`
-	MaxPIDs                 uint64        `json:"max_pids"`
-	PreForkPoolSize         uint64        `json:"pre_fork_pool_size"`
-	PreForkImage            string        `json:"pre_fork_image"`
-	PreForkCmd              string        `json:"pre_fork_pool_cmd"`
-	PreForkUseOnce          uint64        `json:"pre_fork_use_once"`
-	PreForkNetworks         string        `json:"pre_fork_networks"`
-	EnableNBResourceTracker bool          `json:"enable_nb_resource_tracker"`
-	MaxTmpFsInodes          uint64        `json:"max_tmpfs_inodes"`
-	DisableReadOnlyRootFs   bool          `json:"disable_readonly_rootfs"`
-	DisableDebugUserLogs    bool          `json:"disable_debug_user_logs"`
-	IOFSEnableTmpfs         bool          `json:"iofs_enable_tmpfs"`
-	IOFSAgentPath           string        `json:"iofs_path"`
-	IOFSMountRoot           string        `json:"iofs_mount_root"`
-	IOFSOpts                string        `json:"iofs_opts"`
-	ImageCleanMaxSize       uint64        `json:"image_clean_max_size"`
-	ImageCleanExemptTags    string        `json:"image_clean_exempt_tags"`
-	ImageEnableVolume       bool          `json:"image_enable_volume"`
+	MinDockerVersion              string        `json:"min_docker_version"`
+	ContainerLabelTag             string        `json:"container_label_tag"`
+	DockerNetworks                string        `json:"docker_networks"`
+	DockerLoadFile                string        `json:"docker_load_file"`
+	DisableUnprivilegedContainers bool          `json:"disable_unprivileged_containers"`
+	FreezeIdle                    time.Duration `json:"freeze_idle_msecs"`
+	HotPoll                       time.Duration `json:"hot_poll_msecs"`
+	HotLauncherTimeout            time.Duration `json:"hot_launcher_timeout_msecs"`
+	HotPullTimeout                time.Duration `json:"hot_pull_timeout_msecs"`
+	HotStartTimeout               time.Duration `json:"hot_start_timeout_msecs"`
+	DetachedHeadRoom              time.Duration `json:"detached_head_room_msecs"`
+	MaxResponseSize               uint64        `json:"max_response_size_bytes"`
+	MaxHdrResponseSize            uint64        `json:"max_hdr_response_size_bytes"`
+	MaxLogSize                    uint64        `json:"max_log_size_bytes"`
+	MaxTotalCPU                   uint64        `json:"max_total_cpu_mcpus"`
+	MaxTotalMemory                uint64        `json:"max_total_memory_bytes"`
+	MaxFsSize                     uint64        `json:"max_fs_size_mb"`
+	MaxPIDs                       uint64        `json:"max_pids"`
+	PreForkPoolSize               uint64        `json:"pre_fork_pool_size"`
+	PreForkImage                  string        `json:"pre_fork_image"`
+	PreForkCmd                    string        `json:"pre_fork_pool_cmd"`
+	PreForkUseOnce                uint64        `json:"pre_fork_use_once"`
+	PreForkNetworks               string        `json:"pre_fork_networks"`
+	EnableNBResourceTracker       bool          `json:"enable_nb_resource_tracker"`
+	MaxTmpFsInodes                uint64        `json:"max_tmpfs_inodes"`
+	DisableReadOnlyRootFs         bool          `json:"disable_readonly_rootfs"`
+	DisableDebugUserLogs          bool          `json:"disable_debug_user_logs"`
+	IOFSEnableTmpfs               bool          `json:"iofs_enable_tmpfs"`
+	IOFSAgentPath                 string        `json:"iofs_path"`
+	IOFSMountRoot                 string        `json:"iofs_mount_root"`
+	IOFSOpts                      string        `json:"iofs_opts"`
+	ImageCleanMaxSize             uint64        `json:"image_clean_max_size"`
+	ImageCleanExemptTags          string        `json:"image_clean_exempt_tags"`
+	ImageEnableVolume             bool          `json:"image_enable_volume"`
 }
 
 const (
@@ -59,6 +60,8 @@ const (
 	EnvDockerNetworks = "FN_DOCKER_NETWORKS"
 	// EnvDockerLoadFile is a file location for a file that contains a tarball of a docker image to load on startup
 	EnvDockerLoadFile = "FN_DOCKER_LOAD_FILE"
+	// EnvDisableUnprivilegedContainers disables docker security features like user name, cap drop etc.
+	EnvDisableUnprivilegedContainers = "FN_DISABLE_UNPRIVILEGED_CONTAINERS"
 	// EnvFreezeIdle is the delay between a container being last used and being frozen
 	EnvFreezeIdle = "FN_FREEZE_IDLE_MSECS"
 	// EnvHotPoll is the interval to ping for a slot manager thread to check if a container should be
@@ -164,6 +167,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvStr(err, EnvContainerLabelTag, &cfg.ContainerLabelTag)
 	err = setEnvStr(err, EnvDockerNetworks, &cfg.DockerNetworks)
 	err = setEnvStr(err, EnvDockerLoadFile, &cfg.DockerLoadFile)
+	err = setEnvBool(err, EnvDisableUnprivilegedContainers, &cfg.DisableUnprivilegedContainers)
 	err = setEnvUint(err, EnvMaxTmpFsInodes, &cfg.MaxTmpFsInodes)
 	err = setEnvStr(err, EnvIOFSPath, &cfg.IOFSAgentPath)
 	err = setEnvStr(err, EnvIOFSDockerPath, &cfg.IOFSMountRoot)

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -412,6 +412,7 @@ func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.Containe
 	cookie.configureNetwork(log)
 	cookie.configureHostname(log)
 	cookie.configureImage(log)
+	cookie.configureSecurity(log)
 
 	return cookie, nil
 }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -228,22 +228,23 @@ const (
 type Config struct {
 	// TODO this should all be driver-specific config and not in the
 	// driver package itself. fix if we ever one day try something else
-	Docker               string `json:"docker"`
-	DockerNetworks       string `json:"docker_networks"`
-	DockerLoadFile       string `json:"docker_load_file"`
-	ServerVersion        string `json:"server_version"`
-	PreForkPoolSize      uint64 `json:"pre_fork_pool_size"`
-	PreForkImage         string `json:"pre_fork_image"`
-	PreForkCmd           string `json:"pre_fork_cmd"`
-	PreForkUseOnce       uint64 `json:"pre_fork_use_once"`
-	PreForkNetworks      string `json:"pre_fork_networks"`
-	MaxTmpFsInodes       uint64 `json:"max_tmpfs_inodes"`
-	EnableReadOnlyRootFs bool   `json:"enable_readonly_rootfs"`
-	ContainerLabelTag    string `json:"container_label_tag"`
-	InstanceId           string `json:"instance_id"`
-	ImageCleanMaxSize    uint64 `json:"image_clean_max_size"`
-	ImageCleanExemptTags string `json:"image_clean_exempt_tags"`
-	ImageEnableVolume    bool   `json:"image_enable_volume"`
+	Docker                        string `json:"docker"`
+	DockerNetworks                string `json:"docker_networks"`
+	DockerLoadFile                string `json:"docker_load_file"`
+	ServerVersion                 string `json:"server_version"`
+	PreForkPoolSize               uint64 `json:"pre_fork_pool_size"`
+	PreForkImage                  string `json:"pre_fork_image"`
+	PreForkCmd                    string `json:"pre_fork_cmd"`
+	PreForkUseOnce                uint64 `json:"pre_fork_use_once"`
+	PreForkNetworks               string `json:"pre_fork_networks"`
+	MaxTmpFsInodes                uint64 `json:"max_tmpfs_inodes"`
+	EnableReadOnlyRootFs          bool   `json:"enable_readonly_rootfs"`
+	ContainerLabelTag             string `json:"container_label_tag"`
+	InstanceId                    string `json:"instance_id"`
+	ImageCleanMaxSize             uint64 `json:"image_clean_max_size"`
+	ImageCleanExemptTags          string `json:"image_clean_exempt_tags"`
+	ImageEnableVolume             bool   `json:"image_enable_volume"`
+	DisableUnprivilegedContainers bool   `json:"disable_unprivileged_containers"`
 }
 
 // https://github.com/fsouza/go-dockerclient/blob/master/misc.go#L166

--- a/api/agent/iofs.go
+++ b/api/agent/iofs.go
@@ -64,6 +64,13 @@ func newDirectoryIOFS(ctx context.Context, cfg *Config) (*directoryIOFS, error) 
 		}
 		return nil, fmt.Errorf("cannot create tmpdir for iofs: %v", err)
 	}
+	if !cfg.DisableUnprivilegedContainers && !cfg.IOFSEnableTmpfs {
+		err = os.Chmod(iofsAgentDir, 0777) // #nosec G302
+		if err != nil {
+			common.Logger(ctx).WithError(err).Error("failed to change mode")
+			return nil, fmt.Errorf("cannot change iofs mod: %v", err)
+		}
+	}
 
 	if cfg.IOFSMountRoot != "" {
 		iofsRelPath, err := filepath.Rel(dir, iofsAgentDir)

--- a/images/fn-test-utils/Dockerfile
+++ b/images/fn-test-utils/Dockerfile
@@ -10,6 +10,7 @@ RUN cd $D && go build -o fn-test-utils && cp fn-test-utils /tmp/
 
 # final stage
 FROM alpine
+RUN addgroup -g 1000 -S fn && adduser -S -u 1000 -G fn fn
 WORKDIR /function
 COPY --from=build-env /tmp/fn-test-utils /function
 ENTRYPOINT ["./fn-test-utils"]


### PR DESCRIPTION
Runs the function container as user (id:1000, gid:1000) in docker. This requires corresponding changes in base runtime images (add user/group) that are used by the fdks.

It also drops all the security capabilities (by using `CapDrop=all`).

Note that there is an opt-out environment variable `FN_DISABLE_DOCKER_SECURITY` which can be set to true to disable this features.