### PR TITLE
Add blame to APIErrorWrapper

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -279,20 +279,27 @@ func (m *ErrorWrapper) Validate() error {
 type APIErrorWrapper interface {
 	APIError
 	RootError() error
+	Blame() string
 }
 
 type apiErrorWrapper struct {
 	APIError
-	root error
+	root  error
+	blame string
 }
 
 func (w apiErrorWrapper) RootError() error {
 	return w.root
 }
 
-func NewAPIErrorWrapper(apiErr APIError, rootErr error) APIErrorWrapper {
+func (w apiErrorWrapper) Blame() string {
+	return w.blame
+}
+
+func NewAPIErrorWrapper(apiErr APIError, rootErr error, blame string) APIErrorWrapper {
 	return &apiErrorWrapper{
 		APIError: apiErr,
 		root:     rootErr,
+		blame:    blame,
 	}
 }

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -29,7 +29,7 @@ func handleErrorResponse(c *gin.Context, err error) {
 func HandleErrorResponse(ctx context.Context, w http.ResponseWriter, err error) {
 	log := common.Logger(ctx)
 	if w, ok := err.(models.APIErrorWrapper); ok {
-		log = log.WithField("root_error", w.RootError())
+		log = log.WithField("root_error", w.RootError()).WithField("blame", w.Blame())
 	}
 
 	if ctx.Err() == context.Canceled {


### PR DESCRIPTION
I'm not sure if I should be doing a tag.Insert(whodoneitKey, err.Blame()) somewhere...