### PR TITLE
allow private registries to specify raw host

### DIFF
--- a/api/agent/drivers/docker/registry.go
+++ b/api/agent/drivers/docker/registry.go
@@ -40,6 +40,13 @@ func preprocessAuths(auths *docker.AuthConfigurations) (map[string]driverAuthCon
 			return drvAuths, err
 		}
 
+		if u.Scheme == "" {
+			// url.Parse won't return an error for urls who do not provide a scheme, and
+			// host field will be unset. docker defaults to bare hosts without scheme
+			// in its configs, so support this here as well.
+			u.Host = v.ServerAddress
+		}
+
 		drvAuths[key] = driverAuthConfig{
 			auth:       v,
 			subdomains: getSubdomains(u.Host),

--- a/api/agent/drivers/docker/registry_test.go
+++ b/api/agent/drivers/docker/registry_test.go
@@ -67,7 +67,8 @@ func TestRegistryEnv(t *testing.T) {
 	"auths":{
 		"https://my.registry.com":{"auth":"Y29jbzpjaGVlc2UK"},
 		"https://my.registry.com:5000":{"auth":"Y29jbzpjaGVlc2UK"},
-		"https://index.docker.io/v2/":{"auth":"Y29jbzpjaGVlc2UK"}
+		"https://index.docker.io/v2/":{"auth":"Y29jbzpjaGVlc2UK"},
+		"rawregistry.com":{"auth":"Y29jbzpjaGVlc2UK"}
 	}}`
 
 	auths, err := docker.NewAuthConfigurations(strings.NewReader(testCfg))
@@ -109,5 +110,8 @@ func TestRegistryEnv(t *testing.T) {
 	if res == nil || res.ServerAddress != "https://my.registry.com:5000" {
 		t.Fatalf("registry.com:5000 registry should pickup my.registry.com:5000 cfg %v", res)
 	}
-
+	res = findRegistryConfig("rawregistry.com", drvAuths)
+	if res == nil || res.ServerAddress != "rawregistry.com" {
+		t.Fatalf("rawregistry.com registry should pickup rawregistry.com cfg %v", res)
+	}
 }


### PR DESCRIPTION
see the linked issue for a good example, it's kind of confusing. docker
defaults to not using a scheme, but the way we were preprocessing registry
urls meant that we were doing this incorrectly (it would parse out `u.Host = ''`
which is incorrect), even though we should allow this since it's dockers own
format and the registry parser itself allows this.

it seems like the reason we're pre-processing is for the subdomain logic,
which kind of makes sense, though it exhibits odd behaviors when specifying a
registry like `registry.com` when only 2 subdomains `raw.registry.com` and
`my.registry.com` have been registered, it's not deterministic between reboots
which credentials will be used, not sure how to reconcile this, I was unable
to find an issue pointing to why this came into existence with some cursory
searching, perhaps someone knows.

closes #1354
