### PR TITLE
fn: added a simple validation function for encoded IDs

### DIFF
--- a/api/id/id.go
+++ b/api/id/id.go
@@ -213,6 +213,25 @@ var dec = [...]byte{
 // EncodedSize is the length of a text encoded Id.
 const EncodedSize = 26
 
+// ValidateText returns true if the data is a valid
+// encoding.
+func ValidateText(v []byte) bool {
+	return len(v) == EncodedSize &&
+		dec[v[0]] != 0xFF && dec[v[1]] != 0xFF &&
+		dec[v[2]] != 0xFF && dec[v[3]] != 0xFF &&
+		dec[v[4]] != 0xFF && dec[v[5]] != 0xFF &&
+		dec[v[6]] != 0xFF && dec[v[7]] != 0xFF &&
+		dec[v[8]] != 0xFF && dec[v[9]] != 0xFF &&
+		dec[v[10]] != 0xFF && dec[v[11]] != 0xFF &&
+		dec[v[12]] != 0xFF && dec[v[13]] != 0xFF &&
+		dec[v[14]] != 0xFF && dec[v[15]] != 0xFF &&
+		dec[v[16]] != 0xFF && dec[v[17]] != 0xFF &&
+		dec[v[18]] != 0xFF && dec[v[19]] != 0xFF &&
+		dec[v[20]] != 0xFF && dec[v[21]] != 0xFF &&
+		dec[v[22]] != 0xFF && dec[v[23]] != 0xFF &&
+		dec[v[24]] != 0xFF && dec[v[25]] != 0xFF
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface by
 // parsing the data as string encoded Id.
 //

--- a/api/id/id_test.go
+++ b/api/id/id_test.go
@@ -33,6 +33,26 @@ func BenchmarkUnmarshalText(b *testing.B) {
 	}
 }
 
+func BenchmarkValidateText(b *testing.B) {
+	id := New()
+	byts, _ := id.MarshalText()
+	for i := 0; i < b.N; i++ {
+		ValidateText(byts)
+	}
+}
+
+func TestValidInValid(t *testing.T) {
+	id := New()
+	byts, _ := id.MarshalText()
+	if !ValidateText(byts) {
+		t.Fatal("valid id should pass")
+	}
+	byts[5] = ' '
+	if ValidateText(byts) {
+		t.Fatal("invalid id should not pass")
+	}
+}
+
 func TestIdRaw(t *testing.T) {
 	SetMachineIdHost(net.IP{127, 0, 0, 1}, 8080)
 


### PR DESCRIPTION
Useful for Fn implementers to validate encoded call ids.