### PR TITLE
Extract name validation from model validators

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -68,19 +68,11 @@ type App struct {
 
 func (a *App) Validate() error {
 
-	if a.Name == "" {
-		return ErrMissingName
+	if err := a.ValidateName(); err != nil {
+		return err
 	}
-	if len(a.Name) > maxAppName {
-		return ErrAppsTooLongName
-	}
-	for _, c := range a.Name {
-		if !(unicode.IsLetter(c) || unicode.IsNumber(c) || c == '_' || c == '-') {
-			return ErrAppsInvalidName
-		}
-	}
-	err := a.Annotations.Validate()
-	if err != nil {
+
+	if err := a.Annotations.Validate(); err != nil {
 		return err
 	}
 
@@ -98,6 +90,24 @@ func (a *App) Validate() error {
 			return ErrInvalidSyslog(fmt.Sprintf(`invalid syslog url: "%v" %v`, *a.SyslogURL, err))
 		}
 	}
+	return nil
+}
+
+func (a *App) ValidateName() error {
+	if a.Name == "" {
+		return ErrMissingName
+	}
+
+	if len(a.Name) > maxAppName {
+		return ErrAppsTooLongName
+	}
+
+	for _, c := range a.Name {
+		if !(unicode.IsLetter(c) || unicode.IsNumber(c) || c == '_' || c == '-') {
+			return ErrAppsInvalidName
+		}
+	}
+
 	return nil
 }
 

--- a/api/models/app_test.go
+++ b/api/models/app_test.go
@@ -147,3 +147,48 @@ func TestAppEquality(t *testing.T) {
 
 	properties.TestingRun(t)
 }
+
+func TestValidateAppName(t *testing.T) {
+	testCases := []struct {
+		Name string
+		Want error
+	}{
+		{"valid_name-101", nil},
+		{"an_app_with_a_name_that_is_too_long", ErrAppsTooLongName},
+		{"", ErrMissingName},
+		{"invalid.character", ErrAppsInvalidName},
+	}
+
+	for _, testCase := range testCases {
+		app := App{Name: testCase.Name}
+		got := app.ValidateName()
+
+		if got != testCase.Want {
+			t.Errorf(
+				"App.ValidateName() failed for %q - wanted: %q but got: %q",
+				testCase.Name, testCase.Want, got)
+		}
+	}
+}
+
+func TestValidateApp(t *testing.T) {
+	valid_name := "valid_name"
+	valid_syslog := "tcp://localhost:13371"
+
+	testCases := []struct {
+		App  App
+		Want error
+	}{
+		{App{Name: valid_name, SyslogURL: &valid_syslog}, nil},
+		{App{Name: ""}, ErrMissingName},
+	}
+
+	for _, testCase := range testCases {
+		got := testCase.App.Validate()
+
+		if got != testCase.Want {
+			t.Errorf("App.Validate() failed for '%+v' - wanted: %q but got: %q",
+				testCase.App, testCase.Want, got)
+		}
+	}
+}

--- a/api/models/fn.go
+++ b/api/models/fn.go
@@ -146,15 +146,8 @@ func (f *Fn) SetDefaults() {
 // Validate validates all field values, returning the first error, if any.
 func (f *Fn) Validate() error {
 
-	if f.Name == "" {
-		return ErrFnsMissingName
-	}
-	if len(f.Name) > maxFnName {
-		return ErrFnsTooLongName
-	}
-
-	if url.PathEscape(f.Name) != f.Name {
-		return ErrFnsInvalidName
+	if err := f.ValidateName(); err != nil {
+		return err
 	}
 
 	if f.AppID == "" {
@@ -178,6 +171,22 @@ func (f *Fn) Validate() error {
 	}
 
 	return f.Annotations.Validate()
+}
+
+func (f *Fn) ValidateName() error {
+	if f.Name == "" {
+		return ErrFnsMissingName
+	}
+
+	if len(f.Name) > maxFnName {
+		return ErrFnsTooLongName
+	}
+
+	if url.PathEscape(f.Name) != f.Name {
+		return ErrFnsInvalidName
+	}
+
+	return nil
 }
 
 func (f *Fn) Clone() *Fn {

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -140,21 +140,12 @@ var (
 
 //Validate checks that trigger has valid data for inserting into a store
 func (t *Trigger) Validate() error {
-	if t.Name == "" {
-		return ErrTriggerMissingName
-	}
-
 	if t.AppID == "" {
 		return ErrTriggerMissingAppID
 	}
 
-	if len(t.Name) > MaxTriggerName {
-		return ErrTriggerTooLongName
-	}
-	for _, c := range t.Name {
-		if !(unicode.IsLetter(c) || unicode.IsNumber(c) || c == '_' || c == '-') {
-			return ErrTriggerInvalidName
-		}
+	if err := t.ValidateName(); err != nil {
+		return err
 	}
 
 	if t.FnID == "" {
@@ -176,6 +167,24 @@ func (t *Trigger) Validate() error {
 	err := t.Annotations.Validate()
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (t *Trigger) ValidateName() error {
+	if t.Name == "" {
+		return ErrTriggerMissingName
+	}
+
+	if len(t.Name) > MaxTriggerName {
+		return ErrTriggerTooLongName
+	}
+
+	for _, c := range t.Name {
+		if !(unicode.IsLetter(c) || unicode.IsNumber(c) || c == '_' || c == '-') {
+			return ErrTriggerInvalidName
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Extracting the name validation functionality from the models' validators means we can use them else where. In particular this means we can use them to validate user input in the CLI without duplicating the logic c.f. fnproject/cli#474

### Link to issue this resolves
This is a prerequisite for my changes in fnproject/cli#474

### What I did
The full explaination can be found [here](https://github.com/fnproject/cli/issues/474#issuecomment-478509980). In particular this commit seperates the name validation from `models.App`, `models.Fn`, and `models.Trigger` `Validate` functions so that they can be called independently. 

### How to verify it
```
cd $GOPATH/src/github.com/fnproject/fn/api/models/
go test
```

```
fn := models.Fn{Name: name}
fn.ValidateName()
fn.Validate()
```

```
app := models.App{Name: name}
app.ValidateName()
app.Validate()
```

```
trigger := models.Trigger{Name: name}
trigger.ValidateName()
trigger.Validate()
```

### One line description for the changelog

> Extract name validation from model validators

### One moving picture involving robots (not mandatory but encouraged)
```
<!DOCTYPE html>
<html>
<head>
<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
<script> 
$(document).ready(
    setInterval(
        function() {
            $("img").animate({
                    left: '100px'
                },
                500,
                function() {
                    $(this).animate({
                        left: 0
                    }, 500);
                }
            )
        },
        100
    )
);
</script> 
</head>
<body>

<img style="position:absolute" src="https://i.gifer.com/XmuP.gif" /></div>

</body>
</html>
```