### PR TITLE
initialize ids in init

### DIFF
--- a/api/server/init.go
+++ b/api/server/init.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fnproject/fn/api/common"
+	"github.com/fnproject/fn/api/id"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -20,6 +23,43 @@ import (
 func init() {
 	// gin is not nice by default, this can get set in logging initialization
 	gin.SetMode(gin.ReleaseMode)
+
+	// set machine id in init() before any packages are initialized that may use it
+	// (you may change this to seed the id another way but be wary of package initialization)
+	setMachineID()
+}
+
+func setMachineID() {
+	port := uint16(getEnvInt(EnvPort, DefaultPort))
+	addr := whoAmI().To4()
+	if addr == nil {
+		addr = net.ParseIP("127.0.0.1").To4()
+		logrus.Warn("could not find non-local ipv4 address to use, using '127.0.0.1' for ids, if this is a cluster beware of duplicate ids!")
+	}
+	id.SetMachineIdHost(addr, port)
+}
+
+// whoAmI searches for a non-local address on any network interface, returning
+// the first one it finds. it could be expanded to search eth0 or en0 only but
+// to date this has been unnecessary.
+func whoAmI() net.IP {
+	ints, _ := net.Interfaces()
+	for _, i := range ints {
+		if i.Name == "docker0" || i.Name == "lo" {
+			// not perfect
+			continue
+		}
+		addrs, _ := i.Addrs()
+		for _, a := range addrs {
+			ip, _, err := net.ParseCIDR(a.String())
+			if a.Network() == "ip+net" && err == nil && ip.To4() != nil {
+				if !bytes.Equal(ip, net.ParseIP("127.0.0.1")) {
+					return ip
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func getEnv(key, fallback string) string {


### PR DESCRIPTION
this moves initialization up to the init() level as some packages were using
this to create ids before server.New() was called/finished (concurrency!), and
there was a race condition between setting this and creating ids.  this ought
to be sufficient while we're using the host ip address to seed these things,
that day may not last forever but at least this closes the hole for now.