### PR TITLE
Change individual placement failure to warning

### DIFF
--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -434,22 +434,21 @@ DataLoop:
 }
 
 func logCallFinish(log logrus.FieldLogger, msg *pb.RunnerMsg_Finished, headers http.Header, httpStatus int32) {
+	errorCode := msg.Finished.GetErrorCode()
 	errorUser := msg.Finished.GetErrorUser()
 	runnerSuccess := msg.Finished.GetSuccess()
 	logger := log.WithFields(logrus.Fields{
 		"function_error":     msg.Finished.GetErrorStr(),
 		"runner_success":     runnerSuccess,
-		"runner_error_code":  msg.Finished.GetErrorCode(),
+		"runner_error_code":  errorCode,
 		"runner_error_user":  errorUser,
 		"runner_http_status": httpStatus,
 		"fn_http_status":     headers.Get("Fn-Http-Status"),
 	})
-	if runnerSuccess {
-		logger.Info("Call finished successfully")
-	} else if errorUser {
-		logger.Info("Call finished with user error")
+	if !runnerSuccess && !errorUser && errorCode != http.StatusServiceUnavailable {
+		logger.Warn("Call finished")
 	} else {
-		logger.Error("Call finished with platform error")
+		logger.Info("Call finished")
 	}
 }
 


### PR DESCRIPTION
We are currently logging at error level for individual placement
failures which could be retried and could still succeed. This makes the
maximum log level for a per-placement-attempt failure a warning, and
reduces runner 503s to info level (since they are expected if the system
is under any kind of load)