### PR TITLE
Use consistent log field for call and container ID

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -758,7 +758,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	var err error
 
 	id := id.New().String()
-	logger := logrus.WithFields(logrus.Fields{"id": id, "app_id": call.AppID, "fn_id": call.FnID, "image": call.Image, "memory": call.Memory, "cpus": call.CPUs, "idle_timeout": call.IdleTimeout})
+	logger := logrus.WithFields(logrus.Fields{"container_id": id, "app_id": call.AppID, "fn_id": call.FnID, "image": call.Image, "memory": call.Memory, "cpus": call.CPUs, "idle_timeout": call.IdleTimeout})
 	ctx, cancel := context.WithCancel(common.WithLogger(ctx, logger))
 
 	initialized := make(chan struct{}) // when closed, container is ready to handle requests

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -274,7 +274,7 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 
 func setupCtx(c *call) {
 	ctx, _ := common.LoggerWithFields(c.req.Context(),
-		logrus.Fields{"id": c.ID, "app_id": c.AppID, "fn_id": c.FnID})
+		logrus.Fields{"call_id": c.ID, "app_id": c.AppID, "fn_id": c.FnID})
 	c.req = c.req.WithContext(ctx)
 }
 


### PR DESCRIPTION
Container ID is logged inconsistently as `container_id` and `id` in
"call started" and "hot function terminating" messages. `id` is also
used elsewhere for Call ID. Change them all to `container_id` and
`call_id` for consistency.