### PR TITLE
lb read cache everything under it

### DIFF
--- a/api/agent/data_access.go
+++ b/api/agent/data_access.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fnproject/fn/api/models"
 	"github.com/golang/groupcache/singleflight"
 	"github.com/patrickmn/go-cache"
+	"go.opencensus.io/trace"
 )
 
 // XXX(reed): this is only used by the front end now, this should be in the server/ package
@@ -23,6 +24,39 @@ type ReadDataAccess interface {
 // XXX(reed): replace all uses of ReadDataAccess with DataAccess or vice versa, whatever is easier
 type DataAccess interface {
 	ReadDataAccess
+}
+
+// NewMetricReadDataAccess adds metrics to a ReadDataAccess
+func NewMetricReadDataAccess(rda ReadDataAccess) ReadDataAccess {
+	return &metricda{rda}
+}
+
+type metricda struct {
+	rda ReadDataAccess
+}
+
+func (m *metricda) GetTriggerBySource(ctx context.Context, appID string, triggerType, source string) (*models.Trigger, error) {
+	ctx, span := trace.StartSpan(ctx, "rda_get_trigger_by_source")
+	defer span.End()
+	return m.rda.GetTriggerBySource(ctx, appID, triggerType, source)
+}
+
+func (m *metricda) GetAppID(ctx context.Context, appName string) (string, error) {
+	ctx, span := trace.StartSpan(ctx, "rda_get_app_id")
+	defer span.End()
+	return m.rda.GetAppID(ctx, appName)
+}
+
+func (m *metricda) GetAppByID(ctx context.Context, appID string) (*models.App, error) {
+	ctx, span := trace.StartSpan(ctx, "rda_get_app_by_id")
+	defer span.End()
+	return m.rda.GetAppByID(ctx, appID)
+}
+
+func (m *metricda) GetFnByID(ctx context.Context, fnID string) (*models.Fn, error) {
+	ctx, span := trace.StartSpan(ctx, "rda_get_fn_by_id")
+	defer span.End()
+	return m.rda.GetFnByID(ctx, fnID)
 }
 
 // CachedDataAccess wraps a DataAccess and caches the results of GetApp.

--- a/api/datastore/internal/datastoreutil/metrics.go
+++ b/api/datastore/internal/datastoreutil/metrics.go
@@ -3,9 +3,8 @@ package datastoreutil
 import (
 	"context"
 
-	"go.opencensus.io/trace"
-
 	"github.com/fnproject/fn/api/models"
+	"go.opencensus.io/trace"
 )
 
 func MetricDS(ds models.Datastore) models.Datastore {

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -57,12 +57,13 @@ func (s *Server) handleFnInvokeCall(c *gin.Context) {
 // handleTriggerHTTPFunctionCall2 executes the function and returns an error
 // Requires the following in the context:
 func (s *Server) handleFnInvokeCall2(c *gin.Context) error {
-	fn, err := s.lbReadAccess.GetFnByID(c, c.Param(api.FnID))
+	ctx := c.Request.Context()
+	fn, err := s.lbReadAccess.GetFnByID(ctx, c.Param(api.FnID))
 	if err != nil {
 		return err
 	}
 
-	app, err := s.lbReadAccess.GetAppByID(c, fn.AppID)
+	app, err := s.lbReadAccess.GetAppByID(ctx, fn.AppID)
 	if err != nil {
 		return err
 	}
@@ -71,7 +72,7 @@ func (s *Server) handleFnInvokeCall2(c *gin.Context) error {
 	if models.IsFuncError(err) || err == nil {
 		// report all user-directed errors and function responses from here, after submit has run.
 		// this is our never ending attempt to distinguish user and platform errors.
-		ctx, err := tag.New(c.Request.Context(),
+		ctx, err := tag.New(ctx,
 			tag.Insert(whodunitKey, "user"),
 		)
 		if err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -201,7 +201,6 @@ type Server struct {
 	// TODO: extend this to cover gRPC options.
 	svcConfigs map[string]*http.Server
 
-	// Agent enqueue  and read stores
 	lbReadAccess           agent.ReadDataAccess
 	noHTTTPTriggerEndpoint bool
 	noFnInvokeEndpoint     bool
@@ -335,8 +334,7 @@ func WithDBURL(dbURL string) Option {
 			if err != nil {
 				return err
 			}
-			s.datastore = ds
-			s.lbReadAccess = agent.NewCachedDataAccess(s.datastore)
+			return WithDatastore(ds)(ctx, s)
 		}
 		return nil
 	}
@@ -370,8 +368,10 @@ func WithReadDataAccess(ds agent.ReadDataAccess) Option {
 func WithDatastore(ds models.Datastore) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.datastore = ds
+		s.datastore = datastore.Wrap(s.datastore)
+		s.datastore = fnext.NewDatastore(s.datastore, s.appListeners, s.fnListeners, s.triggerListeners)
 		if s.lbReadAccess == nil {
-			s.lbReadAccess = agent.NewCachedDataAccess(ds)
+			s.lbReadAccess = agent.NewCachedDataAccess(s.datastore)
 		}
 		return nil
 	}
@@ -397,10 +397,6 @@ func (s *Server) defaultRunnerPool() (pool.RunnerPool, error) {
 func WithFullAgent() Option {
 	return func(ctx context.Context, s *Server) error {
 		s.nodeType = ServerTypeFull
-
-		if s.datastore == nil {
-			return errors.New("full nodes must configure FN_DB_URL")
-		}
 		s.agent = agent.New()
 		return nil
 	}
@@ -414,9 +410,6 @@ func WithAgentFromEnv() Option {
 		case ServerTypeAPI:
 			return errors.New("should not initialize an agent for an Fn API node")
 		case ServerTypePureRunner:
-			if s.datastore != nil {
-				return errors.New("pure runner nodes must not be configured with a datastore (FN_DB_URL)")
-			}
 			cancelCtx, cancel := context.WithCancel(ctx)
 			prAgent, err := agent.DefaultPureRunner(cancel, s.svcConfigs[GRPCServer].Addr, s.svcConfigs[GRPCServer].TLSConfig)
 			if err != nil {
@@ -429,9 +422,6 @@ func WithAgentFromEnv() Option {
 			runnerURL := getEnv(EnvRunnerURL, "")
 			if runnerURL == "" {
 				return errors.New("no FN_RUNNER_API_URL provided for an Fn NuLB node")
-			}
-			if s.datastore != nil {
-				return errors.New("lb nodes must not be configured with a datastore (FN_DB_URL)")
 			}
 
 			cl, err := hybrid.NewClient(runnerURL)
@@ -499,6 +489,7 @@ func WithAdminServer(port int) Option {
 	}
 }
 
+// WithHTTPConfig allows configuring specific http servers
 func WithHTTPConfig(service string, cfg *http.Server) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.svcConfigs[service] = cfg
@@ -528,6 +519,11 @@ func New(ctx context.Context, opts ...Option) *Server {
 			AdminServer: &http.Server{},
 			GRPCServer:  &http.Server{},
 		},
+		// MUST initialize these before opts
+		appListeners:     new(appListeners),
+		fnListeners:      new(fnListeners),
+		triggerListeners: new(triggerListeners),
+
 		// Almost everything else is configured through opts (see NewFromEnv for ex.) or below
 	}
 
@@ -595,14 +591,6 @@ func New(ctx context.Context, opts ...Option) *Server {
 	s.Router.Use(panicWrap)
 	s.AdminRouter.Use(panicWrap)
 	s.bindHandlers(ctx)
-
-	s.appListeners = new(appListeners)
-	s.fnListeners = new(fnListeners)
-	s.triggerListeners = new(triggerListeners)
-
-	// TODO it's not clear that this is always correct as the read store  won't  get wrapping
-	s.datastore = datastore.Wrap(s.datastore)
-	s.datastore = fnext.NewDatastore(s.datastore, s.appListeners, s.fnListeners, s.triggerListeners)
 
 	return s
 }


### PR DESCRIPTION
currently, the lb read cache only covers apps. however, the API itself can be [and is] used for fns, app ids and triggers, as well. without using the read cache, this means that we were hitting the datastore every invoke request to get the function and the app id, which resulted in added latency due to contention and costs there. get about a 20-30% throughput bump by doing this, and it seems like a pretty obvious thing to do - my load test has functions that run in about 1ms themselves in a not under duress fn environment, making the 5s window coverage a considerable reduction in db calls (like 10k less, in tests, since i'm running 10k in about 10s now it's about 2 db calls instead of 10k)

note that this does affect the service upstream, as the service uses this as well. this means that functions will have an additional worst case 5 second update latency from the sync update. from what I can tell, it's using bolt, so it's decent savings (at least, with sqlite3 it's about 20% for my load test) - if this is undesirable, it is one update in service code to stop wrapping the read access store with the cache (it's explicitly doing this atm). 

this also makes an update to the configuration dance, so that the read access actually shoots out metrics (and hits validator, which is pass through for get stuff, and uses the extensions), which helps for debugging things like this... from what I can tell, there are no other behavior changes here since we were previously doing the wrap for any datastore just later down the line than from the config option, this is just adding the same treatment to the read store pretty much. 