### PR TITLE
update tracing stuff

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -664,14 +664,15 @@ func WithoutFnInvokeEndpoints() Option {
 // WithJaeger maps EnvJaegerURL
 func WithJaeger(jaegerURL string) Option {
 	return func(ctx context.Context, s *Server) error {
-		// ex: "http://localhost:14268"
+		// ex: "http://localhost:14268/api/traces?format=jaeger.thrift"
 		if jaegerURL == "" {
 			return nil
 		}
 
 		exporter, err := jaeger.NewExporter(jaeger.Options{
-			Endpoint:    jaegerURL,
-			ServiceName: "fn",
+			CollectorEndpoint: jaegerURL,
+			Process:           jaeger.Process{ServiceName: "fnserver"},
+			OnError:           func(err error) { logrus.WithError(err).Error("Error when uploading spans to Jaeger") },
 		})
 		if err != nil {
 			return fmt.Errorf("error connecting to jaeger: %v", err)


### PR DESCRIPTION
* jaeger deprecated config stuff
* add call_id trace tag, proper app and fn trace span attributes

turns out the tag keys don't get added to the trace span attributes, have to
annotate them differently, kinda sucks but whatever... these are useful for
debugging (particularly call id for me right now, anyway)
