### PR TITLE
Bump oomer limit to 120GB

### DIFF
--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -171,8 +171,8 @@ func TestFnInvokeRunnerExecution(t *testing.T) {
 	// Therefore, not testing for EndOfLogs for hot containers (which has complex I/O processing) anymore.
 	multiLogExpectHot := []string{"BeginOfLogs" /*, "EndOfLogs" */}
 
-	crasher := `{"echoContent": "_TRX_ID_", "isDebug": true, "isCrash": true}`           // crash container
-	oomer := `{"echoContent": "_TRX_ID_", "isDebug": true, "allocateMemory": 120000000}` // ask for 120MB
+	crasher := `{"echoContent": "_TRX_ID_", "isDebug": true, "isCrash": true}`              // crash container
+	oomer := `{"echoContent": "_TRX_ID_", "isDebug": true, "allocateMemory": 120000000000}` // ask for 120GB
 	// XXX(reed): do we have an invalid http response? no right?
 	ok := `{"echoContent": "_TRX_ID_", "responseContentType": "application/json; charset=utf-8", "isDebug": true}` // good response / ok
 	respTypeLie := `{"echoContent": "_TRX_ID_", "responseContentType": "foo/bar", "isDebug": true}`                // Content-Type: foo/bar

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -245,7 +245,7 @@ func TestTriggerRunnerExecution(t *testing.T) {
 	multiLogExpectHot := []string{"BeginOfLogs" /*, "EndOfLogs" */}
 
 	crasher := `{"echoContent": "_TRX_ID_", "isDebug": true, "isCrash": true}`                                     // crash container
-	oomer := `{"echoContent": "_TRX_ID_", "isDebug": true, "allocateMemory": 120000000}`                           // ask for 120MB
+	oomer := `{"echoContent": "_TRX_ID_", "isDebug": true, "allocateMemory": 120000000000}`                        // ask for 120GB
 	ok := `{"echoContent": "_TRX_ID_", "responseContentType": "application/json; charset=utf-8", "isDebug": true}` // good response / ok
 	respTypeLie := `{"echoContent": "_TRX_ID_", "responseContentType": "foo/bar", "isDebug": true}`                // Content-Type: foo/bar
 


### PR DESCRIPTION
- Why I did it

The test kept failing for me. The code in question kept "succeeding" by returning a `200`, instead of the expected `502`. My changes bump the size to `120GB`, though I'm not sure if this is actually triggering the OOM exception, or that there is some other check that already fails the request before actually running the function. 

I did notice this line: https://github.com/fnproject/fn/compare/bump_oomer?expand=1#diff-bb0376183f5d812769b683c93f9b3cc1L262 and https://github.com/fnproject/fn/compare/bump_oomer?expand=1#diff-b1e41947cb0f525a276bbaccc8bd6eb3L209 So this might be a goose chase. 

- What I did

Increase the size of the allocated memory of a test.

- How I did it

Change the `allocateMemory` property of a request to `120000000000`.

- How to verify it

Run the tests

- One line description for the changelog

Bump `oomer` to request 120GB

- Docker version

```
Client:
 Version:           18.09.5
 API version:       1.39
 Go version:        go1.10.8
 Git commit:        e8ff056
 Built:             Thu Apr 11 04:43:57 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          18.09.5
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.8
  Git commit:       e8ff056
  Built:            Thu Apr 11 04:10:53 2019
  OS/Arch:          linux/amd64
  Experimental:     false
```

- One moving picture involving robots (not mandatory but encouraged)

https://media.giphy.com/media/d2aIU85OBNgRy/giphy.gif