### PR TITLE
Add PID limit

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1133,6 +1133,7 @@ type container struct {
 	memory     uint64
 	cpus       uint64
 	fsSize     uint64
+	pids       uint64
 	tmpFsSize  uint64
 	disableNet bool
 	iofs       iofs
@@ -1221,6 +1222,7 @@ func newHotContainer(ctx context.Context, evictor Evictor, call *call, cfg *Conf
 		memory:     call.Memory,
 		cpus:       uint64(call.CPUs),
 		fsSize:     cfg.MaxFsSize,
+		pids:       uint64(cfg.MaxPIDs),
 		tmpFsSize:  uint64(call.TmpFsSize),
 		disableNet: call.disableNet,
 		iofs:       iofs,
@@ -1303,6 +1305,7 @@ func (c *container) EnvVars() map[string]string         { return c.env }
 func (c *container) Memory() uint64                     { return c.memory * 1024 * 1024 } // convert MB
 func (c *container) CPUs() uint64                       { return c.cpus }
 func (c *container) FsSize() uint64                     { return c.fsSize }
+func (c *container) PIDs() uint64                       { return c.pids }
 func (c *container) TmpFsSize() uint64                  { return c.tmpFsSize }
 func (c *container) Extensions() map[string]string      { return c.extensions }
 func (c *container) LoggerConfig() drivers.LoggerConfig { return c.logCfg }

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	MaxTotalCPU             uint64        `json:"max_total_cpu_mcpus"`
 	MaxTotalMemory          uint64        `json:"max_total_memory_bytes"`
 	MaxFsSize               uint64        `json:"max_fs_size_mb"`
+	MaxPIDs                 uint64        `json:"max_pids"`
 	PreForkPoolSize         uint64        `json:"pre_fork_pool_size"`
 	PreForkImage            string        `json:"pre_fork_image"`
 	PreForkCmd              string        `json:"pre_fork_pool_cmd"`
@@ -81,6 +82,8 @@ const (
 	EnvMaxTotalMemory = "FN_MAX_TOTAL_MEMORY_BYTES"
 	// EnvMaxFsSize is the maximum filesystem size that a function may use
 	EnvMaxFsSize = "FN_MAX_FS_SIZE_MB"
+	// EnvMaxPIDs is the maximum number of PIDs that a function is allowed to create
+	EnvMaxPIDs = "FN_MAX_PIDS"
 	// EnvPreForkPoolSize is the number of containers pooled to steal network from, this may reduce latency
 	EnvPreForkPoolSize = "FN_EXPERIMENTAL_PREFORK_POOL_SIZE"
 	// EnvPreForkImage is the image to use for the pre-fork pool
@@ -152,6 +155,7 @@ func NewConfig() (*Config, error) {
 	err = setEnvUint(err, EnvMaxTotalCPU, &cfg.MaxTotalCPU)
 	err = setEnvUint(err, EnvMaxTotalMemory, &cfg.MaxTotalMemory)
 	err = setEnvUint(err, EnvMaxFsSize, &cfg.MaxFsSize)
+	err = setEnvUint(err, EnvMaxPIDs, &cfg.MaxPIDs)
 	err = setEnvUint(err, EnvPreForkPoolSize, &cfg.PreForkPoolSize)
 	err = setEnvStr(err, EnvPreForkImage, &cfg.PreForkImage)
 	err = setEnvStr(err, EnvPreForkCmd, &cfg.PreForkCmd)

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -115,6 +115,17 @@ func (c *cookie) configureFsSize(log logrus.FieldLogger) {
 	c.opts.HostConfig.StorageOpt["size"] = opt
 }
 
+func (c *cookie) configurePIDs(log logrus.FieldLogger) {
+	pids := c.task.PIDs()
+	if pids == 0 {
+		return
+	}
+
+	pids64 := int64(pids)
+	log.WithFields(logrus.Fields{"pids": pids64, "call_id": c.task.Id()}).Debug("setting PIDs")
+	c.opts.HostConfig.PidsLimit = pids64
+}
+
 func (c *cookie) configureTmpFs(log logrus.FieldLogger) {
 	// if RO Root is NOT enabled and TmpFsSize does not have any limit, then we do not need
 	// any tmpfs in the container since function can freely write whereever it wants.

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -404,6 +404,7 @@ func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.Containe
 	cookie.configureEnv(log)
 	cookie.configureCPU(log)
 	cookie.configureFsSize(log)
+	cookie.configurePIDs(log)
 	cookie.configureTmpFs(log)
 	cookie.configureVolumes(log)
 	cookie.configureWorkDir(log)

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -38,6 +38,7 @@ func (f *taskDockerTest) Volumes() [][2]string                                  
 func (f *taskDockerTest) Memory() uint64                                             { return 256 * 1024 * 1024 }
 func (f *taskDockerTest) CPUs() uint64                                               { return 0 }
 func (f *taskDockerTest) FsSize() uint64                                             { return 0 }
+func (f *taskDockerTest) PIDs() uint64                                               { return 0 }
 func (f *taskDockerTest) TmpFsSize() uint64                                          { return 0 }
 func (f *taskDockerTest) WorkDir() string                                            { return "" }
 func (f *taskDockerTest) Close()                                                     {}
@@ -46,6 +47,7 @@ func (f *taskDockerTest) WrapBeforeCall(func(drivers.BeforeCall) drivers.BeforeC
 func (f *taskDockerTest) WrapAfterCall(func(drivers.AfterCall) drivers.AfterCall)    {}
 func (f *taskDockerTest) Input() io.Reader                                           { return f.input }
 func (f *taskDockerTest) Extensions() map[string]string                              { return nil }
+
 func (f *taskDockerTest) LoggerConfig() drivers.LoggerConfig {
 	return drivers.LoggerConfig{URL: f.logURL}
 }

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -145,6 +145,10 @@ type ContainerTask interface {
 	// Filesystem size limit for the container, in megabytes.
 	FsSize() uint64
 
+	// PIDs defines the max number of PIDs allowed for the container to use. 0
+	// is unlimited.
+	PIDs() uint64
+
 	// Tmpfs Filesystem size limit for the container, in megabytes.
 	TmpFsSize() uint64
 

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -110,7 +110,7 @@ type Call struct {
 	// SyslogURL is a syslog URL to send all logs to.
 	SyslogURL string `json:"syslog_url,omitempty" db:"-"`
 
-	// Time when call completed, whether it was successul or failed. Always in UTC.
+	// Time when call completed, whether it was successful or failed. Always in UTC.
 	CompletedAt common.DateTime `json:"completed_at,omitempty" db:"completed_at"`
 
 	// Time when call was submitted. Always in UTC.


### PR DESCRIPTION
- What I did

Add ability to set a max number of PID's that a function is able to use. 

- How I did it

During the call to the Docker daemon to create a new container, a new parameter is passed along which limits the amount of PIDs. This in turn will make the Docker daemon create the new container in a PID namespace with the specified max number of PIDs.

- How to verify it

Start the fn server with a env file which contains the following envvar: `FN_MAX_PIDS=100` (change 100 to however much you want the max to be). If debug is turned on a new message which show up when invoking the function (see https://github.com/fnproject/fn/compare/pid_limit#diff-12105267fd0158c3cd4226a828827257R124)

- One line description for the changelog

Allow max number of PIDs to be specified