### PR TITLE
remove unused extensions cruft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ fn-test-volume:
 	cd images/fn-test-volume && ./build.sh
 
 .PHONY: test-middleware
-test-middleware: test-basic
+test-middleware:
 	cd examples/middleware && go build
 
 .PHONY: test-extensions
-test-extensions: test-basic
+test-extensions:
 	cd examples/extensions && go build
 
 .PHONY: test-basic

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -61,7 +61,7 @@ func HandleErrorResponse(ctx context.Context, w http.ResponseWriter, err error) 
 	WriteError(ctx, w, statuscode, err)
 }
 
-// WriteError easy way to do standard error response, but can set statuscode and error message easier than handleV1ErrorResponse
+// WriteError easy way to do standard error response, but can set statuscode and error message easier than handleErrorResponse
 func WriteError(ctx context.Context, w http.ResponseWriter, statuscode int, err error) {
 	log := common.Logger(ctx)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/api/server/extension_points.go
+++ b/api/server/extension_points.go
@@ -1,12 +1,8 @@
 package server
 
-// TODO: it would be nice to move these into the top level folder so people can use these with the "functions" package, eg: functions.ApiHandler
-
 import (
 	"net/http"
 
-	"github.com/fnproject/fn/api"
-	"github.com/fnproject/fn/api/models"
 	"github.com/fnproject/fn/fnext"
 	"github.com/gin-gonic/gin"
 )
@@ -17,46 +13,13 @@ func (s *Server) apiHandlerWrapperFn(apiHandler fnext.APIHandler) gin.HandlerFun
 	}
 }
 
-func (s *Server) apiAppHandlerWrapperFn(apiHandler fnext.APIAppHandler) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// get the app
-		appID := c.MustGet(api.AppID).(string)
-		app, err := s.datastore.GetAppByID(c.Request.Context(), appID)
-		if err != nil {
-			handleErrorResponse(c, err)
-			c.Abort()
-			return
-		}
-		if app == nil {
-			handleErrorResponse(c, models.ErrAppsNotFound)
-			c.Abort()
-			return
-		}
-
-		apiHandler.ServeHTTP(c.Writer, c.Request, app)
-	}
-}
-
-// AddEndpoint adds an endpoint to /v1/x
+// AddEndpoint adds an endpoint to /v2/x
 func (s *Server) AddEndpoint(method, path string, handler fnext.APIHandler) {
-	// TODO(reed): these need to change to v2
-	v1 := s.Router.Group("/v1")
-	v1.Handle(method, path, s.apiHandlerWrapperFn(handler))
+	v2 := s.Router.Group("/v2")
+	v2.Handle(method, path, s.apiHandlerWrapperFn(handler))
 }
 
-// AddEndpointFunc adds an endpoint to /v1/x
+// AddEndpointFunc adds an endpoint to /v2/x
 func (s *Server) AddEndpointFunc(method, path string, handler func(w http.ResponseWriter, r *http.Request)) {
 	s.AddEndpoint(method, path, fnext.APIHandlerFunc(handler))
-}
-
-// AddAppEndpoint adds an endpoints to /v1/apps/:app/x
-func (s *Server) AddAppEndpoint(method, path string, handler fnext.APIAppHandler) {
-	v1 := s.Router.Group("/v1")
-	v1.Use(s.checkAppPresenceByName())
-	v1.Handle(method, "/apps/:app"+path, s.apiAppHandlerWrapperFn(handler))
-}
-
-// AddAppEndpointFunc adds an endpoints to /v1/apps/:app/x
-func (s *Server) AddAppEndpointFunc(method, path string, handler func(w http.ResponseWriter, r *http.Request, app *models.App)) {
-	s.AddAppEndpoint(method, path, fnext.APIAppHandlerFunc(handler))
 }

--- a/api/server/gin_middlewares.go
+++ b/api/server/gin_middlewares.go
@@ -5,14 +5,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fnproject/fn/api"
 	"github.com/fnproject/fn/api/common"
-	"github.com/fnproject/fn/api/models"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -125,7 +123,7 @@ func RegisterAPIViews(tagKeys []string, dist []float64) {
 }
 
 func DefaultAPIViewsGetPath(routes gin.RoutesInfo, c *gin.Context) string {
-	// get the handler url, example: /v1/apps/:app
+	// get the handler url, example: /v2/apps/:app
 	url := "invalid"
 	for _, r := range routes {
 		if r.Handler == c.HandlerName() {
@@ -194,11 +192,6 @@ func panicWrap(c *gin.Context) {
 func loggerWrap(c *gin.Context) {
 	ctx, _ := common.LoggerWithFields(c.Request.Context(), extractFields(c))
 
-	if appName := c.Param(api.AppName); appName != "" {
-		c.Set(api.AppName, appName)
-		ctx = ContextWithApp(ctx, appName)
-	}
-
 	if appID := c.Param(api.AppID); appID != "" {
 		c.Set(api.AppID, appID)
 		ctx = ContextWithAppID(ctx, appID)
@@ -235,60 +228,4 @@ func ContextWithAppID(ctx context.Context, appID string) context.Context {
 func AppIDFromContext(ctx context.Context) string {
 	r, _ := ctx.Value(ctxAppIDKey(api.AppID)).(string)
 	return r
-}
-
-type ctxAppKey string
-
-// ContextWithApp sets the app name value on a context, it may be retrieved
-// using AppFromContext.
-// TODO this is also used as a gin.Key -- stop one of these two things.
-func ContextWithApp(ctx context.Context, app string) context.Context {
-	return context.WithValue(ctx, ctxAppKey(api.AppName), app)
-}
-
-// AppFromContext returns the app from a context, if set.
-func AppFromContext(ctx context.Context) string {
-	r, _ := ctx.Value(ctxAppKey(api.AppName)).(string)
-	return r
-}
-
-func (s *Server) checkAppPresenceByName() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ctx, _ := common.LoggerWithFields(c.Request.Context(), extractFields(c))
-
-		appName := c.MustGet(api.AppName).(string)
-		if appName != "" {
-			appID, err := s.datastore.GetAppID(ctx, appName)
-			if err != nil {
-				handleErrorResponse(c, err)
-				c.Abort()
-				return
-			}
-			c.Set(api.AppID, appID)
-		}
-
-		c.Request = c.Request.WithContext(ctx)
-		c.Next()
-	}
-}
-
-func setAppIDInCtx(c *gin.Context) {
-	// add appName to context
-	appID := c.Param(api.AppID)
-
-	if appID != "" {
-		c.Set(api.AppID, appID)
-		c.Request = c.Request.WithContext(c)
-	}
-	c.Next()
-}
-
-func appIDCheck(c *gin.Context) {
-	appID := c.GetString(api.AppID)
-	if appID == "" {
-		handleErrorResponse(c, models.ErrAppsMissingID)
-		c.Abort()
-		return
-	}
-	c.Next()
 }

--- a/api/server/hybrid.go
+++ b/api/server/hybrid.go
@@ -15,7 +15,7 @@ import (
 func (s *Server) handleRunnerGetTriggerBySource(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	appId := c.MustGet(api.AppID).(string)
+	appID := c.Param(api.AppID)
 
 	triggerType := c.Param(api.TriggerType)
 	if triggerType == "" {
@@ -24,7 +24,7 @@ func (s *Server) handleRunnerGetTriggerBySource(c *gin.Context) {
 	}
 	triggerSource := strings.TrimPrefix(c.Param(api.TriggerSource), "/")
 
-	trigger, err := s.datastore.GetTriggerBySource(ctx, appId, triggerType, triggerSource)
+	trigger, err := s.datastore.GetTriggerBySource(ctx, appID, triggerType, triggerSource)
 
 	if err != nil {
 		handleErrorResponse(c, err)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -956,11 +956,9 @@ func (s *Server) bindHandlers(ctx context.Context) {
 		v2.GET("/fns/:fn_id/calls/:call_id", s.goneResponse)
 		v2.GET("/fns/:fn_id/calls/:call_id/log", s.goneResponse)
 
-		runner := cleanv2.Group("/runner")
-
-		runnerAppAPI := runner.Group("/apps/:app_id")
-		runnerAppAPI.Use(setAppIDInCtx)
 		// TODO figure out how to deprecate
+		runner := cleanv2.Group("/runner")
+		runnerAppAPI := runner.Group("/apps/:app_id")
 		runnerAppAPI.GET("/triggerBySource/:trigger_type/*trigger_source", s.handleRunnerGetTriggerBySource)
 	}
 

--- a/examples/extensions/main.go
+++ b/examples/extensions/main.go
@@ -22,13 +22,6 @@ func main() {
 		fmt.Fprintf(w, "Hello func, %q", html.EscapeString(r.URL.Path))
 	})
 
-	// the following will be at /v1/apps/:app_name/custom2
-	funcServer.AddAppEndpoint("GET", "/custom3", &custom3Handler{})
-	funcServer.AddAppEndpointFunc("GET", "/custom4", func(w http.ResponseWriter, r *http.Request, app *models.App) {
-		// fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
-		fmt.Println("custom4Handler called")
-		fmt.Fprintf(w, "Hello app %v func, %q", app.Name, html.EscapeString(r.URL.Path))
-	})
 	funcServer.Start(ctx)
 }
 

--- a/fnext/api.go
+++ b/fnext/api.go
@@ -2,8 +2,6 @@ package fnext
 
 import (
 	"net/http"
-
-	"github.com/fnproject/fn/api/models"
 )
 
 // APIHandlerFunc is a convenience to make an APIHandler.
@@ -16,21 +14,5 @@ func (f APIHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // APIHandler may be used to add an http endpoint on the versioned route of the Fn API.
 type APIHandler interface {
-	// Handle(ctx context.Context)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
-}
-
-// APIAppHandler may be used to add an http endpoint on the versioned route of fn API,
-// at /:version/apps/:app
-type APIAppHandler interface {
-	// Handle(ctx context.Context)
-	ServeHTTP(w http.ResponseWriter, r *http.Request, app *models.App)
-}
-
-// APIAppHandlerFunc is a convenience for getting an APIAppHandler.
-type APIAppHandlerFunc func(w http.ResponseWriter, r *http.Request, app *models.App)
-
-// ServeHTTP calls f(w, r).
-func (f APIAppHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, app *models.App) {
-	f(w, r, app)
 }

--- a/fnext/context.go
+++ b/fnext/context.go
@@ -3,15 +3,9 @@ package fnext
 // good reading on this: https://twitter.com/sajma/status/757217773852487680
 type contextKey string
 
-// func (c contextKey) String() string {
-// 	return "fnext context key " + string(c)
-// }
-
 // Keys for extensions to get things out of the context
 var (
 	// MiddlewareControllerKey is a context key. It can be used in handlers with context.WithValue to
 	// access the MiddlewareContext.
 	MiddlewareControllerKey = contextKey("middleware_controller")
-	// AppNameKey
-	AppNameKey = contextKey("app_name")
 )

--- a/fnext/listeners.go
+++ b/fnext/listeners.go
@@ -57,7 +57,7 @@ type FnListener interface {
 	AfterFnDelete(ctx context.Context, fnID string) error
 }
 
-//// TriggerListener enables callbacks around Trigger events
+// TriggerListener enables callbacks around Trigger events
 type TriggerListener interface {
 	// BeforeTriggerCreate called before trigger created in the datastore
 	BeforeTriggerCreate(ctx context.Context, trigger *models.Trigger) error

--- a/fnext/setup.go
+++ b/fnext/setup.go
@@ -30,14 +30,10 @@ type ExtServer interface {
 	// AddRootMiddlewareFunc add middleware for end user applications
 	AddRootMiddlewareFunc(m MiddlewareFunc)
 
-	// AddEndpoint adds an endpoint to /v1/x
+	// AddEndpoint adds an endpoint to /v2/x
 	AddEndpoint(method, path string, handler APIHandler)
-	// AddEndpoint adds an endpoint to /v1/x
+	// AddEndpoint adds an endpoint to /v2/x
 	AddEndpointFunc(method, path string, handler func(w http.ResponseWriter, r *http.Request))
-	// AddAppEndpoint adds an endpoints to /v1/apps/:app/x
-	AddAppEndpoint(method, path string, handler APIAppHandler)
-	// AddAppEndpoint adds an endpoints to /v1/apps/:app/x
-	AddAppEndpointFunc(method, path string, handler func(w http.ResponseWriter, r *http.Request, app *models.App))
 
 	// Datastore returns the Datastore Fn is using
 	Datastore() models.Datastore


### PR DESCRIPTION
* changes v1 to v2 for adding an endpoint
* removed the handler funcs for adding handlers onto eg /apps/:app_id/x, we
don't have them for funcs or triggers, and they honestly seem useless as it's
easy to build it with the ability to add a handler and to access the fnext
datastore which we offer, as they were they are really expensive since they
yank the app out of the db even if the operation may not even need it in that
handler. so instead of adding for the rest, remove all of these. none of our
example extensions, which aren't working at the moment, use these either
(that's why I'm here anyway).
* removes dead code helpers and references to app name url param which is no
longer a thing. these were just hanging around bugging me when I ran into
them, so killing them..