### PR TITLE
fix init logging

### DIFF
--- a/api/agent/drivers/register.go
+++ b/api/agent/drivers/register.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 )
 
 type DriverFunc func(config Config) (Driver, error)
@@ -11,7 +10,6 @@ var drivers = make(map[string]DriverFunc)
 
 // Register adds  a container driver by name to this process
 func Register(name string, driverFunc DriverFunc) {
-	logrus.Infof("Registering container driver '%s'", name)
 	drivers[name] = driverFunc
 }
 

--- a/api/common/env.go
+++ b/api/common/env.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetEnv looks up a key under its name in env or name+_FILE to read the value
+// from a file. fallback will be defaulted to if a value is not found.
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	} else if value, ok := os.LookupEnv(key + "_FILE"); ok {
+		dat, err := ioutil.ReadFile(filepath.Clean(value))
+		if err == nil {
+			return string(dat)
+		}
+	}
+	return fallback
+}
+
+// GetEnvInt looks up a key under its name in env or name+_FILE to read the
+// value from a file. fallback will be defaulted to if a value is not found.
+func GetEnvInt(key string, fallback int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		// linter liked this better than if/else
+		var err error
+		var i int
+		if i, err = strconv.Atoi(value); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{"string": value, "environment_key": key}).Fatal("Failed to convert string to int")
+		}
+		return i
+	} else if value, ok := os.LookupEnv(key + "_FILE"); ok {
+		dat, err := ioutil.ReadFile(filepath.Clean(value))
+		if err == nil {
+			var err error
+			var i int
+			if i, err = strconv.Atoi(strings.TrimSpace(string(dat))); err != nil {
+				logrus.WithError(err).WithFields(logrus.Fields{"string": dat, "environment_key": key}).Fatal("Failed to convert string to int")
+			}
+			return i
+		}
+	}
+	return fallback
+}
+
+// GetEnvDuration looks up a key under its name in env or name+_FILE to read
+// the value from a file. fallback will be defaulted to if a value is not
+// found. if an integer is provided, the value will be returned in seconds
+// (value * time.Second)
+func GetEnvDuration(key string, fallback time.Duration) time.Duration {
+	var err error
+	res := fallback
+	if tmp := os.Getenv(key); tmp != "" {
+		// if the returned value is not null it needs to be either an integral value in seconds or a parsable duration-format string
+		res, err = time.ParseDuration(tmp)
+		if err != nil {
+			// try to parse an int
+			s, perr := strconv.Atoi(tmp)
+			if perr != nil {
+				logrus.WithError(err).WithFields(logrus.Fields{"duration_string": tmp, "environment_key": key}).Fatal("Failed to parse duration from env")
+			} else {
+				res = time.Duration(s) * time.Second
+			}
+		}
+	}
+	return res
+}

--- a/api/datastore/sql/dbhelper/dbhelper.go
+++ b/api/datastore/sql/dbhelper/dbhelper.go
@@ -12,7 +12,6 @@ var sqlHelpers []Helper
 
 // Register registers a new SQL helper
 func Register(helper Helper) {
-	logrus.Infof("Registering sql helper '%s'", helper)
 	sqlHelpers = append(sqlHelpers, helper)
 }
 

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -21,12 +21,18 @@ import (
 )
 
 func init() {
+	// init logging stuff in init, in case any packages log stuff on startup
+	common.SetLogFormat(getEnv(EnvLogFormat, DefaultLogFormat))
+	common.SetLogLevel(getEnv(EnvLogLevel, DefaultLogLevel))
+	common.SetLogDest(getEnv(EnvLogDest, DefaultLogDest), getEnv(EnvLogPrefix, ""))
+
 	// gin is not nice by default, this can get set in logging initialization
 	gin.SetMode(gin.ReleaseMode)
 
 	// set machine id in init() before any packages are initialized that may use it
 	// (you may change this to seed the id another way but be wary of package initialization)
 	setMachineID()
+
 }
 
 func setMachineID() {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -244,9 +244,6 @@ func NewFromEnv(ctx context.Context, opts ...Option) *Server {
 	}
 	opts = append(opts, WithWebPort(getEnvInt(EnvPort, DefaultPort)))
 	opts = append(opts, WithGRPCPort(getEnvInt(EnvGRPCPort, DefaultGRPCPort)))
-	opts = append(opts, WithLogFormat(getEnv(EnvLogFormat, DefaultLogFormat)))
-	opts = append(opts, WithLogLevel(getEnv(EnvLogLevel, DefaultLogLevel)))
-	opts = append(opts, WithLogDest(getEnv(EnvLogDest, DefaultLogDest), getEnv(EnvLogPrefix, "")))
 	opts = append(opts, WithZipkin(getEnv(EnvZipkinURL, "")))
 	opts = append(opts, WithJaeger(getEnv(EnvJaegerURL, "")))
 	opts = append(opts, WithPrometheus()) // TODO option to turn this off?
@@ -303,6 +300,7 @@ func WithGRPCPort(port int) Option {
 }
 
 // WithLogFormat maps EnvLogFormat
+// TODO(deprecate): caller should just call SetLogFormat
 func WithLogFormat(format string) Option {
 	return func(ctx context.Context, s *Server) error {
 		common.SetLogFormat(format)
@@ -311,6 +309,7 @@ func WithLogFormat(format string) Option {
 }
 
 // WithLogLevel maps EnvLogLevel
+// TODO(deprecate): caller should just call WithLogLevel
 func WithLogLevel(ll string) Option {
 	return func(ctx context.Context, s *Server) error {
 		common.SetLogLevel(ll)
@@ -319,6 +318,7 @@ func WithLogLevel(ll string) Option {
 }
 
 // WithLogDest maps EnvLogDest
+// TODO(deprecate): caller should just call SetLogDest
 func WithLogDest(dst, prefix string) Option {
 	return func(ctx context.Context, s *Server) error {
 		common.SetLogDest(dst, prefix)
@@ -811,16 +811,15 @@ func (s *Server) Start(ctx context.Context) {
 
 func (s *Server) startGears(ctx context.Context, cancel context.CancelFunc) {
 
-	const runHeader = `
+	logrus.Info(`
         ______
        / ____/___
       / /_  / __ \
      / __/ / / / /
-    /_/   /_/ /_/`
-	fmt.Println(runHeader)
-	fmt.Printf("        v%s\n\n", version.Version)
+    /_/   /_/ /_/
+`)
 
-	logrus.WithField("type", s.nodeType).Infof("Fn serving on `%v`", s.svcConfigs[WebServer].Addr)
+	logrus.WithFields(logrus.Fields{"type": s.nodeType, "version": version.Version}).Infof("Fn serving on `%v`", s.svcConfigs[WebServer].Addr)
 
 	installChildReaper()
 

--- a/cmd/fnserver/main.go
+++ b/cmd/fnserver/main.go
@@ -6,12 +6,13 @@ import (
 	"github.com/fnproject/fn/api/agent"
 	"github.com/fnproject/fn/api/agent/drivers/docker"
 	"github.com/fnproject/fn/api/server"
+
 	// The trace package is imported in several places by different dependencies and if we don't import explicity here it is
 	// initialized every time it is imported and that creates a panic at run time as we register multiple time the handler for
 	// /debug/requests. For example see: https://github.com/GoogleCloudPlatform/google-cloud-go/issues/663 and https://github.com/bradleyfalzon/gopherci/issues/101
 	_ "golang.org/x/net/trace"
-	// EXTENSIONS: Add extension imports here or use `fn build-server`. Learn more: https://github.com/fnproject/fn/blob/master/docs/operating/extending.md
 
+	// EXTENSIONS: Add extension imports here or use `fn build-server`. Learn more: https://github.com/fnproject/fn/blob/master/docs/operating/extending.md
 	_ "github.com/fnproject/fn/api/server/defaultexts"
 )
 


### PR DESCRIPTION
we're using json as the log format, and there were various issues in startup
where when setting FN_LOG_FORMAT, a few messages would not be in json format.
this fixes those cases in this repo, but may not for any packages that extend
fn due to initialization order of go (in particular, packages that log
anything in init() may or may not come before this is set, we have little
control over this except for playing with package names, yes, it's mad)

* we were logging a giant ascii fn. i guess this is cool but it doesn't really
matter, just moved it into a logrus line so that we don't have to fight over
it. call me a peace maker
* we were setting the log level/format/destination when initializing the
server, but many packages initialize themselves before calling server.New, and
those may log (particularly if they fail, which we want...)
* particularly hairy were our registration of the various dbs and container
drivers, since these logged in init(). I tried to hack around this but did not
have any luck. I'm proposing that we just get rid of these lines, there is no
easy fix here as setting to debug will result in them not getting logged
either, since we can't set debug level until after they've been logged. users
that attempt to use any of the drivers or dbs without registering them will
still see an error message, so this should be okay overall, we just basically
lose the warning that we may have accidentally pulled in one we don't need.

