### PR TITLE
Revert the runner-side idle timeout to 1s

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1207,7 +1207,8 @@ func newHotContainer(ctx context.Context, evictor Evictor, call *call, cfg *Conf
 		MaxIdleConns:           1,
 		MaxIdleConnsPerHost:    1,
 		MaxResponseHeaderBytes: int64(cfg.MaxHdrResponseSize),
-		IdleConnTimeout:        120 * time.Second, // TODO(reed): since we only allow one, and we close them, this is gratuitous?
+		IdleConnTimeout:        1 * time.Second, // TODO(jang): revert this to 120s at the point all FDKs are known to be fixed
+		// TODO(reed): since we only allow one, and we close them, this is gratuitous?
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", filepath.Join(iofs.AgentPath(), udsFilename))


### PR DESCRIPTION
We stumbled over a problem where *some* FDKs are idling their UDS HTTP
connections at periods lower than the 120s that this was expecting.

This was giving rise to spurious errors (from older versions of the node
FDK, for instance) - where invocations beyond the first were seeing
502 gateway errors from a prematurely-closed UDS socket.

The notion of an idle timeout here is good, but we should check that all
FDKs have the appropriate behaviour and give users time to rev their
functions before reintroducing this.

- How to verify it

I used a node-FDK-based "hello world" from prior to the fix https://github.com/fnproject/fdk-node/pull/26 like this:

```
fn invoke jang node; sleep 6; fn invoke jang node
```

Before:
```
% fn invoke jang node; sleep 6; fn invoke jang node
{"message":"Hello World"}{"code":"StatusBadGateway","message":"error receiving function response"}
Fn: Error calling function: status 502

See 'fn <command> --help' for more information. Client version: 0.5.63
```

After:
```
% fn invoke jang node; sleep 6; fn invoke jang node
{"message":"Hello World"}{"message":"Hello World"}%
```

I'm a fan of tracking down any remaining duff timeouts in our FDKs (ideally, the FDK proabbly shouldn't time out connections at all) but we should give people time to adjust prior to shifting this value.