### PR TITLE
make detached writer concurrency safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,9 @@ test: checkfmt pull-images test-basic test-middleware test-extensions test-syste
 
 .PHONY: test-system
 test-system:
-	./system_test.sh sqlite3
-	./system_test.sh mysql
-	./system_test.sh postgres
+	./system_test.sh sqlite3 $(run)
+	./system_test.sh mysql $(run)
+	./system_test.sh postgres $(run)
 
 .PHONY: img-busybox
 img-busybox:

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -96,7 +96,7 @@ func (s *Server) fnInvoke(resp http.ResponseWriter, req *http.Request, app *mode
 
 	isDetached := req.Header.Get("Fn-Invoke-Type") == models.TypeDetached
 	if isDetached {
-		writer = agent.NewDetachedResponseWriter(resp.Header(), 202)
+		writer = agent.NewDetachedResponseWriter(202)
 	} else {
 		writer = &syncResponseWriter{
 			headers: resp.Header(),

--- a/system_test.sh
+++ b/system_test.sh
@@ -6,6 +6,7 @@ source ./helpers.sh
 remove_containers ${CONTEXT}
 
 DB_NAME=$1
+shift # later usage
 export FN_DB_URL=$(spawn_${DB_NAME} ${CONTEXT})
 
 # avoid port conflicts with api_test.sh which are run in parallel
@@ -23,8 +24,15 @@ export FN_LOG_LEVEL=debug
 #
 export SYSTEM_TEST_PROMETHEUS_FILE=./prometheus.${DB_NAME}.txt
 
+run="$@"
+
+if [ ! -z "$run" ]
+then
+  run="-run $run"
+fi
+
 cd test/fn-system-tests
-go test -v ./...
+go test $run -v ./...
 cd ../../
 
 remove_containers ${CONTEXT}


### PR DESCRIPTION
in detached mode we're handing off execution but not interested in the headers
or body that the function writes at all. at present however, we're handing
over the original response headers for the detached writer to use, which could
happen concurrently when we're writing headers back to the client response.
since we're not interested in them, this just stops passing them from the
client response headers down into the agent for the func to write to, so there
should no longer be a race with the front end at least. the other piece was
that writing the status code in and reading it out is also not safe, exactly,
so made this explicitly safe - the case here would be that the function writes
a response code while we're going to write the response code in the front end.

I am not sure whether I like the way we're doing this or not, overall (prior
to the modifications here even). open to ideas.

updated the makefile/system test script so that I could run these faster to
repro, pretty handy, should add to other stuff too...

closes #1484 
