### PR TITLE
tidy up release file

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,6 @@ set -exuo pipefail
 
 user="fnproject"
 image="fnserver"
-image_deprecated="functions"
 
 # ensure working dir is clean
 git status
@@ -26,30 +25,15 @@ echo "Version: $version"
 
 make docker-build
 
-git add -u
-git commit -m "$image: $version release [skip ci]"
-git tag -f -a "$version" -m "version $version"
-git push
-git push origin $version
-
-git tag -f -a "v$version" -m "version $version"
-git push origin v$version
-
 # Push the version bump and tags laid down previously
-gtag=$image-$version
-git push
-git push origin $version
+git add -u
+git commit -m "$image: v$version release [skip ci]"
+git tag -f -a "v$version" -m "version v$version"
+git push --tags origin v$version
 
 # Finally, push docker images
 docker tag $user/$image:latest $user/$image:$version
-docker push $user/$image:$version
-docker push $user/$image:latest
-
-# Deprecated images, should remove this sometime in near future
-docker tag $user/$image:latest $user/$image_deprecated:$version
-docker tag $user/$image:latest $user/$image_deprecated:latest
-docker push $user/$image_deprecated:$version
-docker push $user/$image_deprecated:latest
+docker push $user/$image
 
 (cd images/fn-test-utils && ./release.sh)
 (cd images/fn-status-checker && ./release.sh)


### PR DESCRIPTION
this file was pushing to deprecated refs we don't really need anymore. we
started using the vX.Y.Z to make mod happy and that's widely tracked in VCS
now, whereas I doubt the naked versions are tracked anywhere without something
analogous existing (we've been on mod for some time now).

fnproject/functions was deprecated, and I was only able to find a couple of
stale references (some merely comments). I suspect we can safely remove this.

reduced git pushes from 5 to 1 (woo)
reduced docker pushes from 4 to 1 (yay)

