### PR TITLE
remove usage of time.After

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -433,6 +433,9 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 	var notifyChans []chan struct{}
 	var tok ResourceToken
 
+	timer := time.NewTimer(a.cfg.HotPoll)
+	defer timer.Stop()
+
 	// WARNING: Tricky flow below. We are here because: isNewContainerNeeded is true,
 	// in other words, we need to launch a new container at this time due to high load.
 	//
@@ -452,7 +455,7 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 	// need to start a new container, then waiters will wait.
 	select {
 	case tok = <-a.resources.GetResourceToken(ctx, mem, call.CPUs, isNB):
-	case <-time.After(a.cfg.HotPoll):
+	case <-timer.C:
 		// Request routines are polling us with this a.cfg.HotPoll frequency. We can use this
 		// same timer to assume that we waited for cpu/mem long enough. Let's try to evict an
 		// idle container. We do this by submitting a non-blocking request and evicting required
@@ -520,7 +523,9 @@ func (a *agent) waitHot(ctx context.Context, call *call, caller *slotCaller) (Sl
 	// 1) if we can get a slot immediately, grab it.
 	// 2) if we don't, send a signaller every x msecs until we do.
 
-	sleep := 1 * time.Microsecond // pad, so time.After doesn't send immediately
+	timer := time.NewTimer(1 * time.Microsecond) // pad, so time.After doesn't send immediately
+	defer timer.Stop()
+
 	for {
 		select {
 		case err := <-caller.notify:
@@ -538,12 +543,12 @@ func (a *agent) waitHot(ctx context.Context, call *call, caller *slotCaller) (Sl
 			return nil, ctx.Err()
 		case <-a.shutWg.Closer(): // server shutdown
 			return nil, models.ErrCallTimeoutServerBusy
-		case <-time.After(sleep):
+		case <-timer.C:
 			// ping dequeuer again
 		}
 
 		// set sleep to x msecs after first iteration
-		sleep = a.cfg.HotPoll
+		timer.Reset(a.cfg.HotPoll)
 		// send a notification to launchHot()
 		select {
 		case call.slots.signaller <- caller:
@@ -893,6 +898,9 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		// because monitoring go-routine may pick these events earlier and cancel the ctx.
 		initStart := time.Now()
 
+		timer := time.NewTimer(a.cfg.HotStartTimeout)
+		defer timer.Stop()
+
 		// INIT BARRIER HERE. Wait for the initialization go-routine signal
 		select {
 		case <-initialized:
@@ -903,11 +911,13 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		case <-ctx.Done():
 			statsContainerUDSInitLatency(ctx, initStart, time.Now(), "canceled")
 			return
-		case <-time.After(a.cfg.HotStartTimeout):
+		case <-timer.C:
 			statsContainerUDSInitLatency(ctx, initStart, time.Now(), "timedout")
 			tryQueueErr(models.ErrContainerInitTimeout, errQueue)
 			return
 		}
+
+		timer.Stop() // no longer needed
 
 		for ctx.Err() == nil {
 			slot := &hotSlot{

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -433,7 +433,7 @@ func (a *agent) checkLaunch(ctx context.Context, call *call, caller slotCaller) 
 	var notifyChans []chan struct{}
 	var tok ResourceToken
 
-	timer := time.NewTimer(a.cfg.HotPoll)
+	timer := common.NewTimer(a.cfg.HotPoll)
 	defer timer.Stop()
 
 	// WARNING: Tricky flow below. We are here because: isNewContainerNeeded is true,
@@ -523,7 +523,7 @@ func (a *agent) waitHot(ctx context.Context, call *call, caller *slotCaller) (Sl
 	// 1) if we can get a slot immediately, grab it.
 	// 2) if we don't, send a signaller every x msecs until we do.
 
-	timer := time.NewTimer(1 * time.Microsecond) // pad, so time.After doesn't send immediately
+	timer := common.NewTimer(1 * time.Microsecond) // pad, so time.After doesn't send immediately
 	defer timer.Stop()
 
 	for {
@@ -898,7 +898,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		// because monitoring go-routine may pick these events earlier and cancel the ctx.
 		initStart := time.Now()
 
-		timer := time.NewTimer(a.cfg.HotStartTimeout)
+		timer := common.NewTimer(a.cfg.HotStartTimeout)
 		defer timer.Stop()
 
 		// INIT BARRIER HERE. Wait for the initialization go-routine signal
@@ -1049,8 +1049,8 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 	var err error
 	isFrozen := false
 
-	freezeTimer := time.NewTimer(a.cfg.FreezeIdle)
-	idleTimer := time.NewTimer(time.Duration(call.IdleTimeout) * time.Second)
+	freezeTimer := common.NewTimer(a.cfg.FreezeIdle)
+	idleTimer := common.NewTimer(time.Duration(call.IdleTimeout) * time.Second)
 
 	defer func() {
 		freezeTimer.Stop()

--- a/api/agent/drivers/docker/image_puller.go
+++ b/api/agent/drivers/docker/image_puller.go
@@ -103,7 +103,7 @@ func (i *imagePuller) newTransfer(ctx context.Context, cfg *docker.AuthConfigura
 
 func (i *imagePuller) pullWithRetry(trx *transfer) error {
 	backoff := common.NewBackOff(i.backOffCfg)
-	timer := time.NewTimer(time.Duration(i.backOffCfg.MinDelay) * time.Millisecond)
+	timer := common.NewTimer(time.Duration(i.backOffCfg.MinDelay) * time.Millisecond)
 	defer timer.Stop()
 
 	for {

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -132,7 +132,7 @@ func (cl *client) do(ctx context.Context, request, result interface{}, method st
 		MinDelay:   25,
 	})
 
-	timer := time.NewTimer(25 * time.Millisecond)
+	timer := common.NewTimer(25 * time.Millisecond)
 	defer timer.Stop()
 
 	for {

--- a/api/agent/hybrid/client.go
+++ b/api/agent/hybrid/client.go
@@ -132,6 +132,9 @@ func (cl *client) do(ctx context.Context, request, result interface{}, method st
 		MinDelay:   25,
 	})
 
+	timer := time.NewTimer(25 * time.Millisecond)
+	defer timer.Stop()
+
 	for {
 		// TODO this isn't re-using buffers very efficiently, but retries should be rare...
 		err := cl.once(ctx, request, result, method, query, url...)
@@ -153,10 +156,12 @@ func (cl *client) do(ctx context.Context, request, result interface{}, method st
 			return err
 		}
 
+		timer.Reset(delay)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 	}
 }

--- a/api/common/time.go
+++ b/api/common/time.go
@@ -159,12 +159,12 @@ func NewTimer(d time.Duration) Timer {
 // Reset behaves as both Stop and Reset, draining its channel before calling
 // reset.  It differs from the stdlib Timer.Reset by being safe to call on an
 // 'active' timer, that is, a timer that has not yet fired. see
-// https://golang.org/pkg/time/#Timer.Reset for more details.
+// https://golang.org/pkg/time/#Timer.Reset for more details. Reset must
+// not be called while while any other goroutine is receiving from t.C.
 func (t *Timer) Reset(d time.Duration) bool {
-	t.Stop()
-	select {
-	case <-t.C:
-	default:
-	}
-	return t.Timer.Reset(d)
+	// stop the old timer, we do not need to drain the channel as it will get GC'd
+	active := t.Stop()
+	// since reset sucks, just make
+	t.Timer = time.NewTimer(d)
+	return active
 }

--- a/api/common/time.go
+++ b/api/common/time.go
@@ -142,3 +142,29 @@ func (t *DateTime) Scan(raw interface{}) error {
 func (t DateTime) Value() (driver.Value, error) {
 	return driver.Value(t.String()), nil
 }
+
+// Timer is exactly the same semantics as time.Timer, except for Reset, which
+// fixes a deficiency from the stdlib that would have resulted in our case as a
+// desirable behavior change to fix. See Reset for details. NewTimer must be
+// called in order to get a Timer or there will be panics.
+type Timer struct {
+	*time.Timer
+}
+
+// NewTimer starts a new Timer with the given duration.
+func NewTimer(d time.Duration) Timer {
+	return Timer{time.NewTimer(d)}
+}
+
+// Reset behaves as both Stop and Reset, draining its channel before calling
+// reset.  It differs from the stdlib Timer.Reset by being safe to call on an
+// 'active' timer, that is, a timer that has not yet fired. see
+// https://golang.org/pkg/time/#Timer.Reset for more details.
+func (t *Timer) Reset(d time.Duration) bool {
+	t.Stop()
+	select {
+	case <-t.C:
+	default:
+	}
+	return t.Timer.Reset(d)
+}

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -216,15 +216,20 @@ func pingWithRetry(ctx context.Context, db *sqlx.DB) (err error) {
 		return ctx.Err()
 	}
 
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+
 	for i := int64(0); i < attempts; i++ {
 		err = db.PingContext(ctx)
 		if err == nil {
 			return nil
 		}
+
+		timer.Reset(1 * time.Second)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Second * 1):
+		case <-timer.C:
 		}
 	}
 	return err

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -216,7 +216,7 @@ func pingWithRetry(ctx context.Context, db *sqlx.DB) (err error) {
 		return ctx.Err()
 	}
 
-	timer := time.NewTimer(1 * time.Second)
+	timer := common.NewTimer(1 * time.Second)
 	defer timer.Stop()
 
 	for i := int64(0); i < attempts; i++ {

--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -2,7 +2,6 @@ package runnerpool
 
 import (
 	"context"
-	"time"
 
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
@@ -122,7 +121,7 @@ func (tr *placerTracker) RetryAllBackoff(numOfRunners int) bool {
 		stats.Record(tr.requestCtx, emptyPoolCountMeasure.M(0))
 	}
 
-	t := time.NewTimer(tr.cfg.RetryAllDelay)
+	t := common.NewTimer(tr.cfg.RetryAllDelay)
 	defer t.Stop()
 
 	select {

--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -122,12 +122,15 @@ func (tr *placerTracker) RetryAllBackoff(numOfRunners int) bool {
 		stats.Record(tr.requestCtx, emptyPoolCountMeasure.M(0))
 	}
 
+	t := time.NewTimer(tr.cfg.RetryAllDelay)
+	defer t.Stop()
+
 	select {
 	case <-tr.requestCtx.Done(): // client side timeout/cancel
 		return false
 	case <-tr.placerCtx.Done(): // placer wait timeout
 		return false
-	case <-time.After(tr.cfg.RetryAllDelay):
+	case <-t.C:
 	}
 
 	return true


### PR DESCRIPTION
these little guys leak in the background, it's easy enough to remove usage of
them altogether. this reduces cpu load on fn, the main culprit was the one in
waitHot which polls every 200ms. if you run a load test where functions get a
slot and exec a lot faster than 200ms then these things pile up kinda quickly.
