### PR TITLE
init CreateContainerOptions with empty NetworkingConfig

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -388,6 +388,7 @@ func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.Containe
 			ReadonlyRootfs: drv.conf.EnableReadOnlyRootFs,
 			Init:           true,
 		},
+		NetworkingConfig: &docker.NetworkingConfig{},
 	}
 
 	cookie := &cookie{


### PR DESCRIPTION
CreateContainerOptions are now initialized with empty NetworkingConfig, this allows changes to NetworkingConfig if needed.