### PR TITLE
fix docker security options

### DIFF
--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -322,7 +322,7 @@ func (c *cookie) configureSecurity(log logrus.FieldLogger) {
 	}
 	c.opts.Config.User = FnDockerUser
 	c.opts.HostConfig.CapDrop = []string{"all"}
-	c.opts.HostConfig.SecurityOpt = []string{"no-new-privileges:true"}
+	c.opts.HostConfig.SecurityOpt = []string{"no-new-privileges"}
 	log.WithFields(logrus.Fields{"user": c.opts.Config.User,
 		"CapDrop": c.opts.HostConfig.CapDrop, "SecurityOpt": c.opts.HostConfig.SecurityOpt, "call_id": c.task.Id()}).Debug("setting security")
 }


### PR DESCRIPTION
This changes fixes the following logging message by docker:

`Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead.`

The message was coming from the error is coming from here:
https://github.com/docker/docker-ce/blob/2ba8f3d83c15d3cb018c80e724efe14e3726512f/components/engine/daemon/daemon_unix.go#L228

using security option as 
`c.opts.HostConfig.SecurityOpt = []string{"no-new-privileges"}`

removes the problem