### PR TITLE
Add default fnserver port to the docker image exposed ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ FROM fnproject/dind:latest
 WORKDIR /app
 COPY --from=build-env /tmp/fn-alpine /app/fnserver
 CMD ["./fnserver"]
+EXPOSE 8080


### PR DESCRIPTION
Docker images have the notion of exposed ports. This indicates the
ports on which a container listens for connections. For the current
fnserver image this is the port 2375 with it inherits from the
fnproject/dind base image.
This confuses end users and other software (reverse proxies) that
expect the fnserver api at this port when inspecting the image/container.

For now it is not possible to remove/unset ports exposed by a base
image but this mr at least adds the default fnserver port to the list
of exposed ports.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#expose
