### PR TITLE
Fix typos in Makefile from go mod migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Just builds
 .PHONY: mod
-dep:
+mod:
 	GO111MODULE=on GOFLAGS=-mod=vendor go mod vendor -v
 
 .PHONY: mod-up
-dep-up:
+mod-up:
 	go get -u
 
 .PHONY: build


### PR DESCRIPTION
When we migrated from dep to mod we updated the .PHONY targets but not
the actual target names in the Makefile. Fix this.