### PR TITLE
Support specifying image digest on functions

### DIFF
--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -265,17 +265,24 @@ type Config struct {
 }
 
 // https://github.com/fsouza/go-dockerclient/blob/master/misc.go#L166
-func parseRepositoryTag(repoTag string) (repository string, tag string) {
+func parseRepositoryTag(repoTag string) (repository, tag string) {
 	parts := strings.SplitN(repoTag, "@", 2)
+	var digest string
+	if len(parts) == 2 {
+		digest = parts[1]
+	}
 	repoTag = parts[0]
 	n := strings.LastIndex(repoTag, ":")
 	if n < 0 {
-		return repoTag, ""
+		return repoTag, digest
+	}
+	if digest != "" {
+		return repoTag[:n], digest
 	}
 	if tag := repoTag[n+1:]; !strings.Contains(tag, "/") {
 		return repoTag[:n], tag
 	}
-	return repoTag, ""
+	return repoTag, digest
 }
 
 func ParseImage(image string) (registry, repo, tag string) {

--- a/api/agent/drivers/driver_test.go
+++ b/api/agent/drivers/driver_test.go
@@ -15,7 +15,16 @@ func TestParseImage(t *testing.T) {
 		"quay.com/fnproject/fn-test-utils":                  {"quay.com", "fnproject/fn-test-utils", "latest"},
 		"quay.com:8080/fnproject/fn-test-utils:v2":          {"quay.com:8080", "fnproject/fn-test-utils", "v2"},
 		"localhost.localdomain:5000/samalba/hipache:latest": {"localhost.localdomain:5000", "samalba/hipache", "latest"},
-		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
+		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest":                                                                         {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
+		"fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                             {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"fnproject/fn-test-utils:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                          {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"my.registry/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                           {"my.registry", "fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"mongo@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                               {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"mongo:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                            {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"quay.com/fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                    {"quay.com", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"quay.com:8080/fnproject/fn-test-utils:v2@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                            {"quay.com:8080", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"localhost.localdomain:5000/samalba/hipache:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                   {"localhost.localdomain:5000", "samalba/hipache", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
 	}
 
 	for in, out := range cases {


### PR DESCRIPTION
Currently if image digest is specified on a function image the runner
will ignore it during the docker pull, then fail to execute the function
because the image is not present.
Add awareness of image digests to the pull process to resolve this.