### PR TITLE
Clean up status checker error handling

### DIFF
--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -980,8 +980,8 @@ func (pr *pureRunner) Status(ctx context.Context, _ *empty.Empty) (*runner.Runne
 		}, nil
 	}
 	status, err := pr.handleStatusCall(ctx)
-	if err != nil {
-		common.Logger(ctx).WithError(err).Errorf("Status call failed result=%+v", status)
+	if err != nil && err != context.Canceled {
+		common.Logger(ctx).WithError(err).Warnf("Status call failed result=%+v", status)
 	}
 
 	cached := "error"


### PR DESCRIPTION
Some deployments page on errors in logs; let's make sure the errors are
really worth watching.

Ensure that we log nothing in the case that the remote side cancels its
context.  If the checker itself fails, log at warn level instead of
error.

- One line description for the changelog

Log status checker errors in pure runner as warnings and not errors.