### PR TITLE
Backout #1509; needs more work.

### DIFF
--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -265,24 +265,17 @@ type Config struct {
 }
 
 // https://github.com/fsouza/go-dockerclient/blob/master/misc.go#L166
-func parseRepositoryTag(repoTag string) (repository, tag string) {
+func parseRepositoryTag(repoTag string) (repository string, tag string) {
 	parts := strings.SplitN(repoTag, "@", 2)
-	var digest string
-	if len(parts) == 2 {
-		digest = parts[1]
-	}
 	repoTag = parts[0]
 	n := strings.LastIndex(repoTag, ":")
 	if n < 0 {
-		return repoTag, digest
-	}
-	if digest != "" {
-		return repoTag[:n], digest
+		return repoTag, ""
 	}
 	if tag := repoTag[n+1:]; !strings.Contains(tag, "/") {
 		return repoTag[:n], tag
 	}
-	return repoTag, digest
+	return repoTag, ""
 }
 
 func ParseImage(image string) (registry, repo, tag string) {

--- a/api/agent/drivers/driver_test.go
+++ b/api/agent/drivers/driver_test.go
@@ -15,16 +15,7 @@ func TestParseImage(t *testing.T) {
 		"quay.com/fnproject/fn-test-utils":                  {"quay.com", "fnproject/fn-test-utils", "latest"},
 		"quay.com:8080/fnproject/fn-test-utils:v2":          {"quay.com:8080", "fnproject/fn-test-utils", "v2"},
 		"localhost.localdomain:5000/samalba/hipache:latest": {"localhost.localdomain:5000", "samalba/hipache", "latest"},
-		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest":                                                                         {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
-		"fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                             {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"fnproject/fn-test-utils:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                          {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"my.registry/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                           {"my.registry", "fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"mongo@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                               {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"mongo:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                            {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"quay.com/fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                    {"quay.com", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"quay.com:8080/fnproject/fn-test-utils:v2@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                            {"quay.com:8080", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"localhost.localdomain:5000/samalba/hipache:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                   {"localhost.localdomain:5000", "samalba/hipache", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
-		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
 	}
 
 	for in, out := range cases {


### PR DESCRIPTION
The commit "Support specifying image digest on functions (#1509)"
attempted to fix a problem in the runner that occurs when functions that
include both a digest and a tag are invoked.  In certain cases, the
invocation will fail.  This change fixes one aspect of the problem: the
image string parsing.  However, it overlooks other areas where support
for image digests are needed.  This includes the image cache and the
inspection logic.

To further confuse matters, this change makes it harder to observe and
reproduce the original problem.  This makes it difficult to fully
understand both all of the causes and all of the places that require
fixing up.  Remove this for now with the understanding that it will
probably be required as part of a larger fix to simultaneously handle
tags and digests correctly.