### PR TITLE
Remove conflicting structured logging

### DIFF
--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -298,13 +298,13 @@ func runImageCleaner(ctx context.Context, driver *DockerDriver) {
 
 		img := driver.imgCache.Pop()
 		if img != nil {
-			log.WithField("image", img).Info("Removing image")
+			log.WithField("removedImage", img).Info("Removing image")
 
 			ctx, cancel := context.WithTimeout(ctx, removeImgTimeout)
 			err := driver.docker.RemoveImage(img.ID, docker.RemoveImageOptions{Context: ctx})
 			cancel()
 			if err != nil && err != docker.ErrNoSuchImage {
-				log.WithError(err).WithField("image", img).Error("Removing image failed")
+				log.WithError(err).WithField("removedImage", img).Error("Removing image failed")
 				// in-use or can't be removed or docker just timed out, try to add it back to the cache
 				driver.imgCache.Update(img)
 			}


### PR DESCRIPTION
The image field is used to log the name of the image tag during pulls and in a few other places, this change just renames it so we don't conflict with it being both a string and a complex object.