### PR TITLE
Changing lb_agent span name, attrib (#1517)

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -258,7 +258,7 @@ func (a *agent) Submit(callI Call) error {
 	rid := common.RequestIDFromContext(ctx)
 	if rid != "" {
 		span.AddAttributes(
-			trace.StringAttribute("fn.rid", common.RequestIDFromContext(ctx)),
+			trace.StringAttribute("fn.rid", rid),
 		)
 	}
 

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -250,7 +250,14 @@ func (a *agent) Submit(callI Call) error {
 	ctx, span := trace.StartSpan(ctx, "agent_submit")
 	defer span.End()
 
-	span.AddAttributes(trace.StringAttribute("agent.call_id", call.ID))
+	span.AddAttributes(
+		trace.StringAttribute("fn.id", call.ID),
+		trace.StringAttribute("fn.app_id", call.AppID),
+		trace.StringAttribute("fn.fn_id", call.FnID),
+		trace.StringAttribute("fn.app_name", call.AppName),
+		trace.StringAttribute("fn.fn_id", call.FnID),
+		trace.StringAttribute("fn.rid", common.RequestIDFromContext(ctx)),
+	)
 
 	return a.submit(ctx, call)
 }

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -251,13 +251,16 @@ func (a *agent) Submit(callI Call) error {
 	defer span.End()
 
 	span.AddAttributes(
-		trace.StringAttribute("fn.id", call.ID),
+		trace.StringAttribute("fn.call_id", call.ID),
 		trace.StringAttribute("fn.app_id", call.AppID),
 		trace.StringAttribute("fn.fn_id", call.FnID),
-		trace.StringAttribute("fn.app_name", call.AppName),
-		trace.StringAttribute("fn.fn_id", call.FnID),
-		trace.StringAttribute("fn.rid", common.RequestIDFromContext(ctx)),
 	)
+	rid := common.RequestIDFromContext(ctx)
+	if rid != "" {
+		span.AddAttributes(
+			trace.StringAttribute("fn.rid", common.RequestIDFromContext(ctx)),
+		)
+	}
 
 	return a.submit(ctx, call)
 }

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -207,7 +207,7 @@ func (a *lbAgent) Submit(callI Call) error {
 	rid := common.RequestIDFromContext(ctx)
 	if rid != "" {
 		span.AddAttributes(
-			trace.StringAttribute("fn.rid", common.RequestIDFromContext(ctx)),
+			trace.StringAttribute("fn.rid", rid),
 		)
 	}
 	statsCalls(ctx)


### PR DESCRIPTION
https://github.com/fnproject/fn/issues/1517

Added fn appid and fnid (needed for internal tracing), and corrected span name in lb_agent.go to avoid duplicate span conflict with span in agent.go
https://github.com/fnproject/fn/blob/1fb78ed8362693105aee48a506129e6776d1a3a8/api/agent/lb_agent.go#L200
https://github.com/fnproject/fn/blob/4ccd8fa0c63e65aa4b35c1f76cbd7db919f59c7c/api/agent/agent.go#L250

It's gonna look like this
![Screen Shot 2019-06-27 at 11 00 22 AM](https://user-images.githubusercontent.com/25177182/60289790-226f9880-98cc-11e9-87b5-1c542d09e733.png)

Changing duplicate span name

