### PR TITLE
use a new slot if call extensions change

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -342,7 +342,8 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 	var isNew bool
 
 	if call.slotHashId == "" {
-		call.slotHashId = getSlotQueueKey(call)
+		slotExtns := a.driver.GetSlotKeyExtensions(call.Extensions())
+		call.slotHashId = getSlotQueueKey(call, slotExtns)
 	}
 
 	call.slots, isNew = a.slotMgr.getSlotQueue(call.slotHashId)

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -419,6 +419,10 @@ func (drv *DockerDriver) CreateCookie(ctx context.Context, task drivers.Containe
 	return cookie, nil
 }
 
+func (drv *DockerDriver) GetSlotKeyExtensions(extn map[string]string) string {
+	return ""
+}
+
 // Run executes the docker container. If task runs, drivers.RunResult will be returned. If something fails outside the task (ie: Docker), it will return error.
 // The docker driver will attempt to cast the task to a Auther. If that succeeds, private image support is available. See the Auther interface for how to implement this.
 func (drv *DockerDriver) run(ctx context.Context, container string, task drivers.ContainerTask) (drivers.WaitResult, error) {

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -75,6 +75,10 @@ type Driver interface {
 	// Set image pull retry policy and retriable error checker
 	SetPullImageRetryPolicy(policy common.BackOffConfig, checker RetryErrorChecker) error
 
+	// Get serialized string of fields in call extn that determines if we can use
+	// an existing hot container slot or pull a new image and start a container
+	GetSlotKeyExtensions(extn map[string]string) string
+
 	// close & shutdown the driver
 	Close() error
 }

--- a/api/agent/drivers/mock/mocker.go
+++ b/api/agent/drivers/mock/mocker.go
@@ -26,6 +26,10 @@ func (m *Mocker) SetPullImageRetryPolicy(policy common.BackOffConfig, checker dr
 	return nil
 }
 
+func (m *Mocker) GetSlotKeyExtensions(extn map[string]string) string {
+	return ""
+}
+
 func (m *Mocker) Close() error {
 	return nil
 }

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -173,7 +173,6 @@ func (a *lbAgent) GetCall(opts ...CallOpt) (Call, error) {
 
 	c.ct = a
 	c.stderr = common.NoopReadWriteCloser{}
-	c.slotHashId = getSlotQueueKey(&c)
 	return &c, nil
 }
 

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -281,7 +281,7 @@ var shapool = &sync.Pool{New: func() interface{} { return sha256.New() }}
 
 // TODO do better; once we have app+fn versions this function
 // can be simply app+fn ids & version
-func getSlotQueueKey(call *call) string {
+func getSlotQueueKey(call *call, slotExtns string) string {
 	// return a sha256 hash of a (hopefully) unique string of all the config
 	// values, to make map lookups quicker [than the giant unique string]
 
@@ -349,6 +349,11 @@ func getSlotQueueKey(call *call) string {
 		hash.Write(unsafeBytes("\x00"))
 		v, _ := call.Annotations.Get(k)
 		hash.Write(v)
+		hash.Write(unsafeBytes("\x00"))
+	}
+
+	if slotExtns != "" {
+		hash.Write(unsafeBytes(slotExtns))
 		hash.Write(unsafeBytes("\x00"))
 	}
 

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -304,6 +304,6 @@ func BenchmarkSlotKey(b *testing.B) {
 	call := &call{Call: cm}
 
 	for i := 0; i < b.N; i++ {
-		_ = getSlotQueueKey(call)
+		_ = getSlotQueueKey(call, "")
 	}
 }

--- a/test/fn-system-tests/system_test.go
+++ b/test/fn-system-tests/system_test.go
@@ -538,6 +538,11 @@ func (d *customDriver) SetPullImageRetryPolicy(policy common.BackOffConfig, chec
 }
 
 // implements Driver
+func (d *customDriver) GetSlotKeyExtensions(extn map[string]string) string {
+	return ""
+}
+
+// implements Driver
 func (d *customDriver) Close() error {
 	return d.drv.Close()
 }


### PR DESCRIPTION
When the same call is invoked with changes in the extensions, we end up using the old cached values if we reuse a slot 

Included call extensions in the slot key so that we match and reuse a slot only if the extensions do not change
