### PR TITLE
Revert "safe responsewriter usage in TryExec (#1490)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,9 @@ test: checkfmt pull-images test-basic test-middleware test-extensions test-syste
 
 .PHONY: test-system
 test-system:
-	./system_test.sh sqlite3 $(run)
-	./system_test.sh mysql $(run)
-	./system_test.sh postgres $(run)
+	./system_test.sh sqlite3
+	./system_test.sh mysql
+	./system_test.sh postgres
 
 .PHONY: img-busybox
 img-busybox:

--- a/api/agent/lb_agent.go
+++ b/api/agent/lb_agent.go
@@ -28,18 +28,14 @@ type lbAgent struct {
 	callOpts      []CallOpt
 }
 
-// DetachedResponseWriter implements http.ResponseWriter without allowing
-// writes to the body or writing the headers from a call to Write or
-// WriteHeader, it is only intended to allow writing the status code in and
-// being able to fetch it later from Status()
 type DetachedResponseWriter struct {
-	headers http.Header
+	Headers http.Header
 	status  int
 	acked   chan struct{}
 }
 
 func (w *DetachedResponseWriter) Header() http.Header {
-	return w.headers
+	return w.Headers
 }
 
 func (w *DetachedResponseWriter) Write(data []byte) (int, error) {
@@ -55,9 +51,9 @@ func (w *DetachedResponseWriter) Status() int {
 	return w.status
 }
 
-func NewDetachedResponseWriter(statusCode int) *DetachedResponseWriter {
+func NewDetachedResponseWriter(h http.Header, statusCode int) *DetachedResponseWriter {
 	return &DetachedResponseWriter{
-		headers: make(http.Header),
+		Headers: h,
 		status:  statusCode,
 		acked:   make(chan struct{}, 1),
 	}

--- a/api/server/runner_fninvoke.go
+++ b/api/server/runner_fninvoke.go
@@ -96,7 +96,7 @@ func (s *Server) fnInvoke(resp http.ResponseWriter, req *http.Request, app *mode
 
 	isDetached := req.Header.Get("Fn-Invoke-Type") == models.TypeDetached
 	if isDetached {
-		writer = agent.NewDetachedResponseWriter(202)
+		writer = agent.NewDetachedResponseWriter(resp.Header(), 202)
 	} else {
 		writer = &syncResponseWriter{
 			headers: resp.Header(),

--- a/system_test.sh
+++ b/system_test.sh
@@ -6,7 +6,6 @@ source ./helpers.sh
 remove_containers ${CONTEXT}
 
 DB_NAME=$1
-shift # later usage
 export FN_DB_URL=$(spawn_${DB_NAME} ${CONTEXT})
 
 # avoid port conflicts with api_test.sh which are run in parallel
@@ -24,15 +23,8 @@ export FN_LOG_LEVEL=debug
 #
 export SYSTEM_TEST_PROMETHEUS_FILE=./prometheus.${DB_NAME}.txt
 
-run="$@"
-
-if [ ! -z "$run" ]
-then
-  run="-run $run"
-fi
-
 cd test/fn-system-tests
-go test $run -v ./...
+go test -v ./...
 cd ../../
 
 remove_containers ${CONTEXT}


### PR DESCRIPTION
This reverts commit 1fb78ed8362693105aee48a506129e6776d1a3a8.

- Link to issue this resolves
This PR  reverts #1490 

- What I did
git revert 1fb78ed8362693105aee48a506129e6776d1a3a8

- How I did it
git revert 1fb78ed8362693105aee48a506129e6776d1a3a8

- How to verify it
Ensure tests are passing.

- One line description for the changelog
Revert #1490 as this was breaking detached function calls. The new code was writing http response to a copy of response writer, which prevented the lbagent from responding to its client early.

- One moving picture involving robots (not mandatory but encouraged)