### PR TITLE
Expose the runner-reported execution duration

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -331,6 +331,9 @@ func (c *call) AddUserExecutionTime(dur time.Duration) {
 		c.userExecTime = new(time.Duration)
 	}
 	*c.userExecTime += dur
+	// We expose this on the upstream models.Call also.
+	// CallListeners have access to the latter, but not the internals of the agent, so any
+	// reporting or bean-counting that's going on from there will need access to this.
 	c.Model().ExecutionDuration = *c.userExecTime
 }
 

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -331,6 +331,7 @@ func (c *call) AddUserExecutionTime(dur time.Duration) {
 		c.userExecTime = new(time.Duration)
 	}
 	*c.userExecTime += dur
+	c.Model().ExecutionDuration = *c.userExecTime
 }
 
 func (c *call) GetUserExecutionTime() *time.Duration {

--- a/api/agent/lb_agent_test.go
+++ b/api/agent/lb_agent_test.go
@@ -138,6 +138,7 @@ func (c *mockRunnerCall) AddUserExecutionTime(dur time.Duration) {
 		c.userExecTime = new(time.Duration)
 	}
 	*c.userExecTime += dur
+	c.Model().ExecutionDuration = *c.userExecTime
 }
 
 func (c *mockRunnerCall) GetUserExecutionTime() *time.Duration {

--- a/api/models/call.go
+++ b/api/models/call.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/fnproject/fn/api/agent/drivers/stats"
 	"github.com/fnproject/fn/api/common"
@@ -118,6 +119,9 @@ type Call struct {
 
 	// Time when call started execution. Always in UTC.
 	StartedAt common.DateTime `json:"started_at,omitempty" db:"started_at"`
+
+	// Duration that user code was running for, in nanoseconds.
+	ExecutionDuration time.Duration `json:"execution_duration,omitempty" db:"execution_duration"`
 
 	// Stats is a list of metrics from this call's execution, possibly empty.
 	Stats stats.Stats `json:"stats,omitempty" db:"stats"`


### PR DESCRIPTION
We'd like a better picture of how long we spend running actual user
code. The pure_runner has a decent picture of this; pull that out of
the runner response and feed it back into the *models.Call structure.

- What I did

Captured actual function run time

- How I did it

Believed what the runner said and promoted that value to the models.Call

- One line description for the changelog
"Expose the runner-reported execution duration"
