### PR TITLE
fix-1484: Fix racy test by fixing concurrent header read/write

### DIFF
--- a/test/fn-system-tests/exec_fn_test.go
+++ b/test/fn-system-tests/exec_fn_test.go
@@ -156,13 +156,20 @@ func TestCanExecuteDetachedFunction(t *testing.T) {
 	}
 	u.Path = path.Join(u.Path, "invoke", fn.ID)
 
-	body := `{"echoContent": "HelloWorld", "sleepTime": 0, "isDebug": true}`
+	body := `{"echoContent": "HelloWorld", "sleepTime": 60000, "isDebug": true}`
 	content := bytes.NewBuffer([]byte(body))
 	output := &bytes.Buffer{}
 
+	start := time.Now()
 	resp, err := callFN(ctx, u.String(), content, output, models.TypeDetached)
 	if err != nil {
 		t.Fatalf("Got unexpected error: %v", err)
+	}
+	end := time.Now()
+
+	// Verify that the detached call returns in less than 30 seconds irrespective of execution time.
+	if end.Sub(start) > time.Second*30 {
+		t.Fatal("Detached call took more than 30 seconds to return")
 	}
 
 	if resp.StatusCode != http.StatusAccepted {


### PR DESCRIPTION
The issue 1484 reported racy test due to concurrent read/write of response headers during TryExec. This PR fixes the issue by making a copy of header before we write and use the copy to read later.

This PR also enhances the system test for detached calls by also verifying that the call returns within 30 seconds even if the function execution takes more than 30 seconds.

- Link to issue this resolves
https://github.com/fnproject/fn/issues/1484

- What I did
This PR fixes the issue by making a copy of header before we write and use the copy to read later.

- How I did it
This PR fixes the issue by making a copy of header before we write and use the copy to read later.

- How to verify it
Run the tests and ensure it does not fail.

- One line description for the changelog
Fix 1484 by making a copy of header before read/write.

- One moving picture involving robots (not mandatory but encouraged)