### PR TITLE
Normalize the image format in runner

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -1236,7 +1236,7 @@ func newHotContainer(ctx context.Context, evictor Evictor, call *call, cfg *Conf
 
 	return &container{
 		id:             id, // XXX we could just let docker generate ids...
-		image:          call.Image,
+		image:          drivers.NormalizeImage(call.Image),
 		env:            cloneStrMap(call.Config),     // avoid data race
 		extensions:     cloneStrMap(call.extensions), // avoid date race
 		memory:         call.Memory,

--- a/api/agent/drivers/driver_test.go
+++ b/api/agent/drivers/driver_test.go
@@ -25,3 +25,22 @@ func TestParseImage(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeImage(t *testing.T) {
+	cases := map[string]string{
+		"quay.io/fnproject/fn-test-utils":                                      "quay.io/fnproject/fn-test-utils:latest",
+		"quay.io/fnproject/fn-test-utils:v1":                                   "quay.io/fnproject/fn-test-utils:v1",
+		"quay.io/my.registry/fn-test-utils@sha256:44e85cf666cd3ab":             "quay.io/my.registry/fn-test-utils@sha256:44e85cf666cd3ab",
+		"quay.io/my.registry/fn-test-utils:0.0.1@sha256:44e85cf666cd3ab":       "quay.io/my.registry/fn-test-utils@sha256:44e85cf666cd3ab",
+		"localhost.localdomain:5000/samalba/hipache:latest":                    "localhost.localdomain:5000/samalba/hipache:latest",
+		"localhost.localdomain:5000/samalba/hipache:v1@sha256:44e85cf666cd3ab": "localhost.localdomain:5000/samalba/hipache@sha256:44e85cf666cd3ab",
+		"localhost.localdomain:5000/samalba/hipache@sha256:44e85cf666cd3ab":    "localhost.localdomain:5000/samalba/hipache@sha256:44e85cf666cd3ab",
+	}
+
+	for in, out := range cases {
+		image := NormalizeImage(in)
+		if image != out {
+			t.Errorf("Test input %q wasn't normalized as expected. Expected %q, got %q", in, out, image)
+		}
+	}
+}

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"unsafe"
+
+	"github.com/fnproject/fn/api/agent/drivers"
 )
 
 //
@@ -295,7 +297,7 @@ func getSlotQueueKey(call *call) string {
 	hash.Write(unsafeBytes("\x00"))
 	hash.Write(unsafeBytes(call.FnID))
 	hash.Write(unsafeBytes("\x00"))
-	hash.Write(unsafeBytes(call.Image))
+	hash.Write(unsafeBytes(drivers.NormalizeImage(call.Image)))
 	hash.Write(unsafeBytes("\x00"))
 
 	// these are all static in size we only need to delimit the whole block of them

--- a/api/agent/state_trackers.go
+++ b/api/agent/state_trackers.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fnproject/fn/api/agent/drivers"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 )
@@ -140,7 +141,7 @@ func (c *containerState) UpdateState(ctx context.Context, newState ContainerStat
 	ctx, _ = tag.New(ctx,
 		tag.Upsert(AppIDMetricKey, call.AppID),
 		tag.Upsert(FnIDMetricKey, call.FnID),
-		tag.Upsert(ImageNameMetricKey, call.Image),
+		tag.Upsert(ImageNameMetricKey, drivers.NormalizeImage(call.Image)),
 	)
 
 	c.lock.Lock()

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
+github.com/apache/thrift v0.12.0 h1:ymFY8b00T66exzV1OxAnIA8mawFjPyH6l0wjuv8zTxY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.57/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -40,7 +40,7 @@ github.com/dchest/siphash v1.2.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBl
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16 h1:dmUn0SuGx7unKFwxyeQ/oLUHhEfZosEDrpmYM+6MTuc=
+github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16 h1:+5IoM9hUAFS6tz8DTQpC75HOIDVb1qoWjt1Jf4v2Fa8=
 github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -104,7 +104,7 @@ github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
 github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:BWIsLfhgKhV5g/oF34aRjniBHLTZe5DNekSjbAjIS6c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=


### PR DESCRIPTION
- What I did
Normalize image names for functions to repo@digest or repo@tag

- How I did it
Converted repo:tag@digest in call.Image to the format repo@digest when container/task is created. After this we use the image name in the container to pull the image and cache it. Docker inspect is also using this format

- How to verify it
Invoked function using tag and digest

- One line description for the changelog
Normalize the image format in runner
