### PR TITLE
Adding back the change to pull image by digest

### DIFF
--- a/api/agent/drivers/docker/image_cache.go
+++ b/api/agent/drivers/docker/image_cache.go
@@ -17,9 +17,9 @@ import (
 // in use.
 
 type CachedImage struct {
-	ID       string
+	ID       string // Image Cache key
 	ParentID string
-	RepoTags []string
+	RepoTags []string // RepoTags are used to match special/status images that are exempt from image cache
 	Size     uint64
 }
 

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -269,17 +269,24 @@ type Config struct {
 }
 
 // https://github.com/fsouza/go-dockerclient/blob/master/misc.go#L166
-func parseRepositoryTag(repoTag string) (repository string, tag string) {
-	parts := strings.SplitN(repoTag, "@", 2)
+func parseRepositoryTag(repoTag string) (repository, tag string) {
+	parts := strings.Split(repoTag, "@")
+	var digest string
+	if len(parts) == 2 {
+		digest = parts[1]
+	}
 	repoTag = parts[0]
 	n := strings.LastIndex(repoTag, ":")
 	if n < 0 {
-		return repoTag, ""
+		return repoTag, digest
+	}
+	if digest != "" {
+		return repoTag[:n], digest
 	}
 	if tag := repoTag[n+1:]; !strings.Contains(tag, "/") {
 		return repoTag[:n], tag
 	}
-	return repoTag, ""
+	return repoTag, digest
 }
 
 func ParseImage(image string) (registry, repo, tag string) {

--- a/api/agent/drivers/driver_test.go
+++ b/api/agent/drivers/driver_test.go
@@ -15,7 +15,16 @@ func TestParseImage(t *testing.T) {
 		"quay.com/fnproject/fn-test-utils":                  {"quay.com", "fnproject/fn-test-utils", "latest"},
 		"quay.com:8080/fnproject/fn-test-utils:v2":          {"quay.com:8080", "fnproject/fn-test-utils", "v2"},
 		"localhost.localdomain:5000/samalba/hipache:latest": {"localhost.localdomain:5000", "samalba/hipache", "latest"},
-		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
+		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest":                                                                         {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "latest"},
+		"fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                             {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"fnproject/fn-test-utils:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                          {"", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"my.registry/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                           {"my.registry", "fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"mongo@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                               {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"mongo:v1@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                                            {"", "library/mongo", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"quay.com/fnproject/fn-test-utils@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                                    {"quay.com", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"quay.com:8080/fnproject/fn-test-utils:v2@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                            {"quay.com:8080", "fnproject/fn-test-utils", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"localhost.localdomain:5000/samalba/hipache:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10":                   {"localhost.localdomain:5000", "samalba/hipache", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
+		"localhost.localdomain:5000/samalba/hipache/isthisallowedeven:latest@sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10": {"localhost.localdomain:5000", "samalba/hipache/isthisallowedeven", "sha256:066978f9d271cfde1586ee5c6a3904a683a228252d6bc831e9c64a6fb823bc10"},
 	}
 
 	for in, out := range cases {


### PR DESCRIPTION
- What I did
Added back the change to pull image using digest. This was reverted temporarily to debug token caching issues in runner

Image name is used in image puller, image cache, image cleaner and slot hash. In most of these place an inspect image is called to get image details from docker daemon. Inspect image api returns the image corresponding to the digest if present in the image name. Image cache code uses the repotags only to identify any special images that should not be cached or expired. Slot Hash will use different containers for functions invoked by tag-only and functions invoked with tag+digest. Overall, the code doesn't seem to use image tags for indexing, but use ID instead. 

Test case summary

Case 1: Pull older digest than repo latest
 Invoked a function (image:tag@digest) with an older digest than the latest in registry. The pulled image in runner will not have RepoTags associated with it. The RepoDigest field will have the digest of the image.  

Case 2: Pull the latest image digest in repo
 Invoked a function (image:tag@digest) with latest digest in registry associated with the tag. The pulled image in runner will not have RepoTags associated with it, as we pull it using the digest only. The RepoDigest field will have the digest of the image.  

Case 3: Update registry image with same tag. Pull using new digest
Invoked a function with the updated digest in registry.  The pulled image in runner will not have RepoTags associated with it. The RepoDigest field will have the digest of the image.  

Case 4: Pull image with tag only
 Invoked a function with the tag in registry. The image will be updated with RepoTags. The RepoDigest field will have the digest of the image.  

Case 5: Update the image after pulling with tag
Invoked a function with the new digest in registry, after image was pulled with tag. The new image will not have RepoTags. The RepoDigest field will have the digest of the image. The older image which was pulled by tag will continue to have the tag. Invoking a function with tag at this point executes the older tagged version of the function 