### PR TITLE
Modify error messages

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -166,11 +166,11 @@ var (
 
 	ErrDockerPullTimeout = ferr{
 		code:  http.StatusGatewayTimeout,
-		error: errors.New("Docker pull timed out"),
+		error: errors.New("Image pull timed out"),
 	}
 	ErrFunctionResponseTooBig = ferr{
 		code:  http.StatusBadGateway,
-		error: fmt.Errorf("function response too large"),
+		error: fmt.Errorf("function response body too large"),
 	}
 	ErrFunctionResponseHdrTooBig = ferr{
 		code:  http.StatusBadGateway,
@@ -198,11 +198,11 @@ var (
 	}
 	ErrContainerInitFail = ferr{
 		code:  http.StatusBadGateway,
-		error: errors.New("container failed to initialize, please ensure you are using the latest fdk / format and check the logs"),
+		error: errors.New("Container failed to initialize, please ensure you are using the latest fdk and check the logs"),
 	}
 	ErrContainerInitTimeout = ferr{
 		code:  http.StatusGatewayTimeout,
-		error: errors.New("Container initialization timed out, please ensure you are using the latest fdk / format and check the logs"),
+		error: errors.New("Container initialization timed out, please ensure you are using the latest fdk and check the logs"),
 	}
 )
 

--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -207,15 +207,15 @@ func TestFnInvokeRunnerExecution(t *testing.T) {
 		{"/invoke/http_stream_fn_id", ok, nil, http.MethodPost, http.StatusOK, expHeaders, "", nil},
 		// NOTE: nil, we can't test bad response framing anymore easily (eg invalid http response), should we even worry about it?
 		{"/invoke/http_stream_fn_id", respTypeLie, nil, http.MethodPost, http.StatusOK, expCTHeaders, "", nil},
-		{"/invoke/http_stream_fn_id", crasher, nil, http.MethodPost, http.StatusBadGateway, expHeaders, "error receiving function response", nil},
+		{"/invoke/http_stream_fn_id", crasher, nil, http.MethodPost, http.StatusBadGateway, expHeaders, models.ErrFunctionResponse.Error(), nil},
 		// XXX(reed): nil, we could stop buffering function responses so that we can stream things?
-		{"/invoke/http_stream_fn_id", bighdroutput, nil, http.MethodPost, http.StatusBadGateway, nil, "function response header too large", nil},
+		{"/invoke/http_stream_fn_id", bighdroutput, nil, http.MethodPost, http.StatusBadGateway, nil, models.ErrFunctionResponseHdrTooBig.Error(), nil},
 		{"/invoke/http_stream_fn_id", striphdr, nil, http.MethodPost, http.StatusOK, expStripHeaders, "", nil},
 		{"/invoke/http_stream_fn_id", striphdrin, inStripHeaders, http.MethodPost, http.StatusOK, nil, "", nil},
-		{"/invoke/http_stream_fn_id", bigoutput, nil, http.MethodPost, http.StatusBadGateway, nil, "function response too large", nil},
+		{"/invoke/http_stream_fn_id", bigoutput, nil, http.MethodPost, http.StatusBadGateway, nil, models.ErrFunctionResponseTooBig.Error(), nil},
 		{"/invoke/http_stream_fn_id", smalloutput, nil, http.MethodPost, http.StatusOK, expHeaders, "", nil},
 		// XXX(reed): nil, meh we really should try to get oom out, but maybe it's better left to the logs?
-		{"/invoke/http_stream_fn_id", oomer, nil, http.MethodPost, http.StatusBadGateway, nil, "error receiving function response", nil},
+		{"/invoke/http_stream_fn_id", oomer, nil, http.MethodPost, http.StatusBadGateway, nil, models.ErrFunctionResponse.Error(), nil},
 		{"/invoke/http_stream_fn_id", bigbuf, nil, http.MethodPost, http.StatusRequestEntityTooLarge, nil, "", nil},
 
 		{"/invoke/dne_fn_id", ``, nil, http.MethodPost, http.StatusNotFound, nil, "pull access denied", nil},
@@ -224,9 +224,9 @@ func TestFnInvokeRunnerExecution(t *testing.T) {
 		// XXX(reed): nil, nil, what are these?
 		{"/invoke/http_stream_fn_id", multiLog, nil, http.MethodPost, http.StatusOK, nil, "", multiLogExpectHot},
 
-		{"/invoke/fail_fn_quick", ok, nil, http.MethodPost, http.StatusBadGateway, nil, "container failed to initialize", nil},
-		{"/invoke/fail_fn_timeout", ok, nil, http.MethodPost, http.StatusGatewayTimeout, nil, "Container initialization timed out", nil},
-		{"/invoke/fn_id", ok, nil, http.MethodPut, http.StatusMethodNotAllowed, nil, "Method not allowed", nil},
+		{"/invoke/fail_fn_quick", ok, nil, http.MethodPost, http.StatusBadGateway, nil, models.ErrContainerInitFail.Error(), nil},
+		{"/invoke/fail_fn_timeout", ok, nil, http.MethodPost, http.StatusGatewayTimeout, nil, models.ErrContainerInitTimeout.Error(), nil},
+		{"/invoke/fn_id", ok, nil, http.MethodPut, http.StatusMethodNotAllowed, nil, models.ErrMethodNotAllowed.Error(), nil},
 
 		{"/invoke/bigmem", ok, nil, http.MethodPost, http.StatusBadRequest, nil, "cannot be allocated", nil},
 	}

--- a/api/server/runner_httptrigger_test.go
+++ b/api/server/runner_httptrigger_test.go
@@ -293,13 +293,13 @@ func TestTriggerRunnerExecution(t *testing.T) {
 		{"/t/myapp/httpstream", fooHeader, expFooHeadersBody, "POST", http.StatusOK, expFooHeaders, "", nil},
 		// NOTE: we can't test bad response framing anymore easily (eg invalid http response), should we even worry about it?
 		{"/t/myapp/httpstream", nil, respTypeLie, "POST", http.StatusOK, expCTHeaders, "", nil},
-		{"/t/myapp/httpstream", nil, crasher, "POST", http.StatusBadGateway, expHeaders, "error receiving function response", nil},
+		{"/t/myapp/httpstream", nil, crasher, "POST", http.StatusBadGateway, expHeaders, models.ErrFunctionResponse.Error(), nil},
 		// XXX(reed): we could stop buffering function responses so that we can stream things?
-		{"/t/myapp/httpstream", nil, bigoutput, "POST", http.StatusBadGateway, nil, "function response too large", nil},
-		{"/t/myapp/httpstream", nil, bighdroutput, "POST", http.StatusBadGateway, nil, "function response header too large", nil},
+		{"/t/myapp/httpstream", nil, bigoutput, "POST", http.StatusBadGateway, nil, models.ErrFunctionResponseTooBig.Error(), nil},
+		{"/t/myapp/httpstream", nil, bighdroutput, "POST", http.StatusBadGateway, nil, models.ErrFunctionResponseHdrTooBig.Error(), nil},
 		{"/t/myapp/httpstream", nil, smalloutput, "POST", http.StatusOK, expHeaders, "", nil},
 		// XXX(reed): meh we really should try to get oom out, but maybe it's better left to the logs?
-		{"/t/myapp/httpstream", nil, oomer, "POST", http.StatusBadGateway, nil, "error receiving function response", nil},
+		{"/t/myapp/httpstream", nil, oomer, "POST", http.StatusBadGateway, nil, models.ErrFunctionResponse.Error(), nil},
 
 		{"/t/myapp/mydne", nil, ``, "GET", http.StatusNotFound, nil, "pull access denied", nil},
 		{"/t/myapp/mydneregistry", nil, ``, "GET", http.StatusBadGateway, nil, "connection refused", nil},

--- a/test/fn-system-tests/exec_fn_test.go
+++ b/test/fn-system-tests/exec_fn_test.go
@@ -275,7 +275,7 @@ func TestCanExecuteTooBigOutput(t *testing.T) {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
 
-	exp := "{\"message\":\"function response too large\"}\n"
+	exp := models.ErrFunctionResponseTooBig.Error()
 	actual := output.String()
 
 	if !strings.Contains(exp, actual) || len(exp) != len(actual) {

--- a/test/fn-system-tests/exec_fn_test.go
+++ b/test/fn-system-tests/exec_fn_test.go
@@ -275,7 +275,7 @@ func TestCanExecuteTooBigOutput(t *testing.T) {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
 
-	exp := models.ErrFunctionResponseTooBig.Error()
+	exp := fmt.Sprintf("{\"message\":\"%s\"}\n", models.ErrFunctionResponseTooBig.Error())
 	actual := output.String()
 
 	if !strings.Contains(exp, actual) || len(exp) != len(actual) {

--- a/test/fn-system-tests/exec_http_trigger_test.go
+++ b/test/fn-system-tests/exec_http_trigger_test.go
@@ -214,7 +214,7 @@ func TestCanExecuteTriggerTooBigOutput(t *testing.T) {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
 
-	exp := "{\"message\":\"function response too large\"}\n"
+	exp := models.ErrFunctionResponseTooBig.Error()
 	actual := output.String()
 
 	if !strings.Contains(exp, actual) || len(exp) != len(actual) {

--- a/test/fn-system-tests/exec_http_trigger_test.go
+++ b/test/fn-system-tests/exec_http_trigger_test.go
@@ -213,6 +213,7 @@ func TestCanExecuteTriggerTooBigOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
+
 	exp := fmt.Sprintf("{\"message\":\"%s\"}\n", models.ErrFunctionResponseTooBig.Error())
 	actual := output.String()
 

--- a/test/fn-system-tests/exec_http_trigger_test.go
+++ b/test/fn-system-tests/exec_http_trigger_test.go
@@ -213,8 +213,7 @@ func TestCanExecuteTriggerTooBigOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
-
-	exp := models.ErrFunctionResponseTooBig.Error()
+	exp := fmt.Sprintf("{\"message\":\"%s\"}\n", models.ErrFunctionResponseTooBig.Error())
 	actual := output.String()
 
 	if !strings.Contains(exp, actual) || len(exp) != len(actual) {


### PR DESCRIPTION
This small change makes some modifications to the error messages so as
they are more clear and reflect the new version of the code.

- What I did
changed some error messages. 
making the docker pull timeout more generic and change it to image pull timeout.
Remove the mention to function format as we don't have this concept anymre.
Report a more specific error in case of Request body too large.
