### PR TITLE
Bugfix: use the most recent call for ephemeral data

### DIFF
--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -51,13 +51,14 @@ type slotCaller struct {
 // LIFO queue that exposes input/output channels along
 // with runner/waiter tracking for agent
 type slotQueue struct {
-	key       string
-	cond      *sync.Cond
-	slots     []*slotToken
-	nextId    uint64
-	signaller chan *slotCaller
-	statsLock sync.Mutex // protects stats below
-	stats     slotQueueStats
+	key        string
+	cond       *sync.Cond
+	slots      []*slotToken
+	nextId     uint64
+	signaller  chan *slotCaller
+	statsLock  sync.Mutex // protects stats below
+	stats      slotQueueStats
+	recentCall atomic.Value // pointer to the most recent Call object
 }
 
 func NewSlotQueueMgr() *slotQueueMgr {


### PR DESCRIPTION
Things like pull tokens (which can be attached to an incoming call) may
be effectively ephemeral - they have a shorter lifetime than the
slotQueue.

Rather than having hotLauncher use the *original* call that spawned it
for this metadata, we update the slotQueue to hold an atomic reference
to the *most recent* call.

Any tokens on new calls will be used by preference, therefore - meaning
that we won't see a spurious expired token used for image pulls, etc.

Cost here is a single atomic Store/Load, which is probably as good as
it can get. The call extensions should be immutable for this process.

- Link to issue this resolves

- What I did

- How I did it

- How to verify it

- One line description for the changelog

- One moving picture involving robots (not mandatory but encouraged)
