### PR TITLE
Enforce more rigorous handling of input data and pipes.

### DIFF
--- a/api/agent/pure_runner.go
+++ b/api/agent/pure_runner.go
@@ -79,7 +79,9 @@ var (
 type callHandle struct {
 	engagement runner.RunnerProtocol_EngageServer
 	ctx        context.Context
-	c          *call // the agent's version of call
+	sctx       context.Context    // child context for submit
+	scancel    context.CancelFunc // child cancel for submit
+	c          *call              // the agent's version of call
 
 	// For implementing http.ResponseWriter:
 	headers http.Header
@@ -89,14 +91,17 @@ type callHandle struct {
 	shutOnce          sync.Once
 	pipeToFnCloseOnce sync.Once
 
-	outQueue  chan *runner.RunnerMsg
-	doneQueue chan struct{}
-	errQueue  chan error
-	inQueue   chan *runner.ClientMsg
+	outQueue     chan *runner.RunnerMsg
+	doneQueue    chan struct{}
+	errQueue     chan error
+	callErrQueue chan error
+	inQueue      chan *runner.ClientMsg
 
 	// Pipe to push data to the agent Function container
 	pipeToFnW *io.PipeWriter
 	pipeToFnR *io.PipeReader
+
+	eofSeen uint64 // Has pipe sender seen eof?
 }
 
 func NewCallHandle(engagement runner.RunnerProtocol_EngageServer) *callHandle {
@@ -105,17 +110,23 @@ func NewCallHandle(engagement runner.RunnerProtocol_EngageServer) *callHandle {
 	pipeR, pipeW := io.Pipe()
 
 	state := &callHandle{
-		engagement: engagement,
-		ctx:        engagement.Context(),
-		headers:    make(http.Header),
-		status:     200,
-		outQueue:   make(chan *runner.RunnerMsg),
-		doneQueue:  make(chan struct{}),
-		errQueue:   make(chan error, 1), // always allow one error (buffered)
-		inQueue:    make(chan *runner.ClientMsg),
-		pipeToFnW:  pipeW,
-		pipeToFnR:  pipeR,
+		engagement:   engagement,
+		ctx:          engagement.Context(),
+		headers:      make(http.Header),
+		status:       200,
+		outQueue:     make(chan *runner.RunnerMsg),
+		doneQueue:    make(chan struct{}),
+		errQueue:     make(chan error, 1), // always allow one error (buffered)
+		callErrQueue: make(chan error, 1), // only buffer one error
+		inQueue:      make(chan *runner.ClientMsg),
+		pipeToFnW:    pipeW,
+		pipeToFnR:    pipeR,
+		eofSeen:      0,
 	}
+
+	// Wrap parent ctx with a cancel function so we can abort the call if
+	// necessary.
+	state.sctx, state.scancel = context.WithCancel(engagement.Context())
 
 	// spawn one receiver and one sender go-routine.
 	// See: https://grpc.io/docs/reference/go/generated-code.html, which reads:
@@ -222,13 +233,22 @@ func (ch *callHandle) enqueueCallResponse(err error) {
 	var errCode int
 	var errStr string
 	var errUser bool
+	var nErr error
 
 	log := common.Logger(ch.ctx)
 
-	if err != nil {
-		errCode = models.GetAPIErrorCode(err)
-		errStr = err.Error()
-		errUser = models.IsFuncError(err)
+	// If an error was queued to callErrQueue let it take precedence over
+	// the inbound error.
+	select {
+	case nErr = <-ch.callErrQueue:
+	default:
+		nErr = err
+	}
+
+	if nErr != nil {
+		errCode = models.GetAPIErrorCode(nErr)
+		errStr = nErr.Error()
+		errUser = models.IsFuncError(nErr)
 	}
 
 	schedulerDuration, executionDuration := GetCallLatencies(ch.c)
@@ -259,7 +279,7 @@ func (ch *callHandle) enqueueCallResponse(err error) {
 
 	errTmp := ch.enqueueMsgStrict(&runner.RunnerMsg{
 		Body: &runner.RunnerMsg_Finished{Finished: &runner.CallFinished{
-			Success:           err == nil,
+			Success:           nErr == nil,
 			Details:           details,
 			ErrorCode:         int32(errCode),
 			ErrorStr:          errStr,
@@ -280,6 +300,27 @@ func (ch *callHandle) enqueueCallResponse(err error) {
 	if errTmp != nil {
 		log.WithError(errTmp).Infof("enqueueCallResponse Finalize Error details=%v err=%v:%v", details, errCode, errStr)
 	}
+}
+
+// Used to short circuit the error path when its necessary to return a well
+// formed error to the LB and we don't want to complete the call.  Errors
+// qeueued here will supercede any errors returned by the function invocation,
+// so use it carefully.
+func (ch *callHandle) enqueueCallErrorResponse(err error) {
+
+	if err == nil {
+		return
+	}
+
+	// Queue buffers a single error. If it's full, let whatever error arrived
+	// first take precedence.
+	select {
+	case ch.callErrQueue <- err:
+	default:
+	}
+
+	// Cancel the pending call to cause response to get generated faster.
+	ch.scancel()
 }
 
 // spawnPipeToFn pumps data to Function via callHandle io.PipeWriter (pipeToFnW)
@@ -303,11 +344,16 @@ func (ch *callHandle) spawnPipeToFn() chan *runner.DataFrame {
 				if len(data.Data) > 0 {
 					_, err := io.CopyN(ch.pipeToFnW, bytes.NewReader(data.Data), int64(len(data.Data)))
 					if err != nil {
-						ch.shutdown(err)
+						if err == io.ErrClosedPipe || err == io.ErrShortWrite {
+							ch.enqueueCallErrorResponse(models.ErrFunctionWriteRequest)
+						} else {
+							ch.shutdown(err)
+						}
 						return
 					}
 				}
 				if data.Eof {
+					atomic.StoreUint64(&ch.eofSeen, 1)
 					return
 				}
 			}
@@ -381,6 +427,20 @@ func (ch *callHandle) Header() http.Header {
 func (ch *callHandle) WriteHeader(status int) {
 	ch.status = status
 	var err error
+
+	// Ensure that writes occur after all of the incoming data has been
+	// consumed.  If the user's container attempts to write before a Eof
+	// frame has been seen, then return an error.  Only perform this check
+	// for HTTP 200s so that it does not trip on errors or detach mode accept
+	// invocations.
+	if status == http.StatusOK {
+		eofSeen := atomic.LoadUint64(&ch.eofSeen)
+		if eofSeen == 0 {
+			ch.enqueueCallErrorResponse(models.ErrFunctionPrematureWrite)
+			return
+		}
+	}
+
 	ch.headerOnce.Do(func() {
 		// WARNING: we do fetch Status and Headers without
 		// a lock below. This is a problem in agent in general, and needs
@@ -439,6 +499,8 @@ func (ch *callHandle) Write(data []byte) (int, error) {
 	// as there is no point to proceed with the Write
 	select {
 
+	case <-ch.sctx.Done():
+		return 0, io.EOF
 	case <-ch.ctx.Done():
 		return 0, io.EOF
 	case <-ch.doneQueue:
@@ -669,7 +731,7 @@ func (pr *pureRunner) handleTryCall(tc *runner.TryCall, state *callHandle) error
 	agentCall, err := pr.a.GetCall(FromModelAndInput(&c, state.pipeToFnR),
 		WithLogger(common.NoopReadWriteCloser{}),
 		WithWriter(state),
-		WithContext(state.ctx),
+		WithContext(state.sctx),
 		WithExtensions(tc.GetExtensions()),
 	)
 	if err != nil {
@@ -720,6 +782,7 @@ func (pr *pureRunner) Engage(engagement runner.RunnerProtocol_EngageServer) erro
 		log.Debug("MD is ", md)
 	}
 	state := NewCallHandle(engagement)
+	defer state.scancel()
 
 	tryMsg := state.getTryMsg()
 	if tryMsg != nil {

--- a/api/models/error.go
+++ b/api/models/error.go
@@ -188,6 +188,14 @@ var (
 		code:  http.StatusBadGateway,
 		error: fmt.Errorf("invalid function response"),
 	}
+	ErrFunctionPrematureWrite = ferr{
+		code:  http.StatusBadGateway,
+		error: fmt.Errorf("function invoked write before receiving entire request"),
+	}
+	ErrFunctionWriteRequest = ferr{
+		code:  http.StatusBadGateway,
+		error: fmt.Errorf("function closed pipe while receiving request"),
+	}
 	ErrRequestContentTooBig = ferr{
 		code:  http.StatusRequestEntityTooLarge,
 		error: fmt.Errorf("Request content too large"),


### PR DESCRIPTION
Catches and generates function errors for two new cases.  The first
occurs due to a function/FDK error.  If the function closes the read end
of the pipe that the hostagent uses to write data before the hostagent
has finished writing the data, generate an error.  This ensures that
any premature close of the input stream is detected and handled by the
hostagent.

Second, catch any cases where the function attempts to respond before
reading all of the input data from the stream.  This is safe because we
already enforce a maximum upper bound on the request body, so a function
or fdk will not have to read for an unbounded amount of time to consume
the outstanding data.  Since the container contract enforces HTTP-like
semantics, and HTTP expects the server side to wait for the response
body to arrive before responding, this is not unreasonable.  If the
function or fdk attempts to write before the end of the input stream has
been processed by the hostagent, return a different function error
indicating that a premature write has been detected.