### PR TITLE
Prevent long timeout when invoking a function and the user has misconfigured the environment.

### DIFF
--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -55,7 +55,7 @@ func (p *chPlacer) PlaceCall(ctx context.Context, rp RunnerPool, call RunnerCall
 			i = (i + 1) % len(runners)
 		}
 
-		if !state.RetryAllBackoff(len(runners)) {
+		if !state.RetryAllBackoff(len(runners), runnerPoolErr) {
 			break
 		}
 	}

--- a/api/runnerpool/naive_placer.go
+++ b/api/runnerpool/naive_placer.go
@@ -47,7 +47,7 @@ func (sp *naivePlacer) PlaceCall(ctx context.Context, rp RunnerPool, call Runner
 			}
 		}
 
-		if !state.RetryAllBackoff(len(runners)) {
+		if !state.RetryAllBackoff(len(runners), runnerPoolErr) {
 			break
 		}
 	}

--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -121,7 +121,7 @@ func (tr *placerTracker) RetryAllBackoff(numOfRunners int, err error) bool {
 		// See: runner_fninvoke.handleFnInvokeCall2
 		if models.IsFuncError(err) {
 			// We also sanity check for a 502 before returning.
-			w, ok := err.(models.APIErrorWrapper)
+			w, ok := err.(models.APIError)
 			if ok {
 				if 502 == w.Code() {
 					return false

--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -114,15 +114,13 @@ func (tr *placerTracker) HandleDone() {
 // RetryAllBackoff blocks until it is time to try the runner list again. Returns
 // false if the placer should stop trying.
 func (tr *placerTracker) RetryAllBackoff(numOfRunners int, err error) bool {
-
-	// If the last call to obtain runners failed due to a user error or
-	// misconfiguration then do not re-attempt to obtain a runner.
-	if err != nil {
-		tr.HandleFindRunnersFailure(err)
+	// If there are no runners and last call to provision runners failed due
+	// to a user error (or misconfiguration) then fail fast.
+	if numOfRunners == 0 && err != nil {
 		// IsFuncError currently synonymous with tag: 'blame == user'
 		// See: runner_fninvoke.handleFnInvokeCall2
 		if models.IsFuncError(err) {
-			// We also santiy check for a 502 before returning.
+			// We also sanity check for a 502 before returning.
 			w, ok := err.(models.APIErrorWrapper)
 			if ok {
 				if 502 == w.Code() {


### PR DESCRIPTION
Updates the RetryAllBackOff function to fail early when a request to obtain Runners cannot succeed due to an Fn misconfiguration error. This prevents a user having to wait for the maximum timeout (~180s) when the system is misconfigured.

- Link to issue this resolves

- What I did

    1. Updated the `RetryAllBackOff` to accept the error returned by `rp.Runners(ctx, call)`.

    2. Added check to not re-try when the error returned by `rp.Runners(ctx, call)` returns a `user configuration error`.

        1.  The error is checked to see if it a user configuration error with the ` models.IsFuncError(err)`. This is the same function used to create the `blame user` tag in the existing middleware (with the exception we do not need to check for nullity).

        2. Additionally check for an error status of `502` (which also denotes a user error).

- How I did it

    1. Worked with Jan Grant (already a comitter).

    2. Replicated the issue tests against a development version of the Fn platform.

    3. Dynamically checked that `tr.requestCtx` and `tr.placerCtx` did not have the required information at the point of early return.

    4. Statically examined the Fn code to see how the `user blame` mechanism worked.

    5. Added a small piece of code to replicate the `user blame` functionality in `RetryAllBackOff` and return early if necessary.


- How to verify it

    > NB: This was tested against an OCI backend. 

    1. Create OCI test resources, Application, and Function.

    2. Remove the VCN Policy permissions from the invoking Function compartment.

    3. Attempt to invoke the Function.

    Without the changes it will take around 180s to fail.

    Manual Integration Test

    1. Show invoke fails after 180s when miss-configured.

    ```
    $> time fn invoke test-app test-fn-01
    Error invoking function. status: 502 message: subnet ocid1.subnet.oc1.iad.aaaaaaaa3zi47ktmvvoqjltnw2kksgbedfcdzqrocvuxeonaz4rs3vped6gq does not exist or Oracle Functions is not authorized to use it

    real	3m2.990s
    user	0m0.065s
    sys	0m0.032s
    ```

    2. PR - Invoke fails fast when miss-configured.

    ```
    $> time fn invoke test-app test-fn-01
    Error invoking function. status: 502 message: subnet ocid1.subnet.oc1.iad.aaaaaaaa3zi47ktmvvoqjltnw2kksgbedfcdzqrocvuxeonaz4rs3vped6gq does not exist or Oracle Functions is not authorized to use it

    real	0m1.426s
    user	0m0.065s
    sys	0m0.018s
    ```

    3. PR - Invoke still works when NOT miss-configured..

    ```
    $> time fn invoke test-app test-fn-01
    {"message":"Hello World"}

    real	0m1.121s
    user	0m0.066s
    sys	0m0.017s
    ```

- One line description for the changelog

Prevent long timeout when invoking a function and the user has misconfigured the environment.

