### PR TITLE
fn: metrics cleanup

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -884,7 +884,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		return
 	}
 	needsPull, err := cookie.ValidateImage(ctx)
-	atomic.StoreInt64(&call.ctrPrepTime, int64(time.Since(ctrCreatePrepStart)/time.Millisecond))
+	atomic.StoreInt64(&call.ctrPrepTime, int64(time.Since(ctrCreatePrepStart)))
 	if needsPull {
 		waitStart := time.Now()
 		pullCtx, pullCancel := context.WithTimeout(ctx, a.cfg.HotPullTimeout)
@@ -900,7 +900,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 				err = models.ErrCallTimeoutServerBusy
 			}
 		}
-		atomic.StoreInt64(&call.imagePullWaitTime, int64(time.Since(waitStart)/time.Millisecond))
+		atomic.StoreInt64(&call.imagePullWaitTime, int64(time.Since(waitStart)))
 	}
 	if tryQueueErr(err, errQueue) != nil {
 		return
@@ -916,7 +916,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	if tryQueueErr(err, errQueue) != nil {
 		return
 	}
-	atomic.StoreInt64(&call.ctrCreateTime, int64(time.Since(ctrCreateStart)/time.Millisecond))
+	atomic.StoreInt64(&call.ctrCreateTime, int64(time.Since(ctrCreateStart)))
 
 	childDone = make(chan struct{})
 
@@ -938,21 +938,21 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		case <-initialized:
 			initTime := time.Now() // Declaring this prior to keep the stats in sync
 			statsContainerUDSInitLatency(ctx, initStart, initTime, "initialized")
-			atomic.StoreInt64(&call.initStartTime, int64(initTime.Sub(initStart)/time.Millisecond))
+			atomic.StoreInt64(&call.initStartTime, int64(initTime.Sub(initStart)))
 		case <-a.shutWg.Closer(): // agent shutdown
 			closerTime := time.Now()
 			statsContainerUDSInitLatency(ctx, initStart, closerTime, "canceled")
-			atomic.StoreInt64(&call.initStartTime, int64(closerTime.Sub(initStart)/time.Millisecond))
+			atomic.StoreInt64(&call.initStartTime, int64(closerTime.Sub(initStart)))
 			return
 		case <-ctx.Done():
 			ctxCancelTime := time.Now()
 			statsContainerUDSInitLatency(ctx, initStart, ctxCancelTime, "canceled")
-			atomic.StoreInt64(&call.initStartTime, int64(ctxCancelTime.Sub(initStart)/time.Millisecond))
+			atomic.StoreInt64(&call.initStartTime, int64(ctxCancelTime.Sub(initStart)))
 			return
 		case <-timer.C:
 			timeoutTime := time.Now()
 			statsContainerUDSInitLatency(ctx, initStart, timeoutTime, "timedout")
-			atomic.StoreInt64(&call.initStartTime, int64(timeoutTime.Sub(initStart)/time.Millisecond))
+			atomic.StoreInt64(&call.initStartTime, int64(timeoutTime.Sub(initStart)))
 			tryQueueErr(models.ErrContainerInitTimeout, errQueue)
 			return
 		}

--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -334,32 +334,11 @@ func recordFinishStats(ctx context.Context, msg *pb.CallFinished, c pool.RunnerC
 	runnerSchedLatency := time.Duration(msg.GetSchedulerDuration())
 	runnerExecLatency := time.Duration(msg.GetExecutionDuration())
 
-	if runnerSchedLatency != 0 || runnerExecLatency != 0 {
-		if runnerSchedLatency != 0 {
-			statsLBAgentRunnerSchedLatency(ctx, runnerSchedLatency)
-		}
-		if runnerExecLatency != 0 {
-			statsLBAgentRunnerExecLatency(ctx, runnerExecLatency)
-			c.AddUserExecutionTime(runnerExecLatency)
-		}
-		return
-	}
-
-	// TODO: Remove this once all Runners are upgraded.
-	// Fallback to older Runner response type, where instead of the above duration, formatted-wall-clock
-	// timestamps are present.
-	creatTs := translateDate(msg.GetCreatedAt())
-	startTs := translateDate(msg.GetStartedAt())
-	complTs := translateDate(msg.GetCompletedAt())
-
-	// Validate this as info *is* coming from runner and its local clock.
-	if !creatTs.IsZero() && !startTs.IsZero() && !complTs.IsZero() && !startTs.Before(creatTs) && !complTs.Before(startTs) {
-		runnerSchedLatency := startTs.Sub(creatTs)
-		runnerExecLatency := complTs.Sub(startTs)
-
+	if runnerSchedLatency != 0 {
 		statsLBAgentRunnerSchedLatency(ctx, runnerSchedLatency)
+	}
+	if runnerExecLatency != 0 {
 		statsLBAgentRunnerExecLatency(ctx, runnerExecLatency)
-
 		c.AddUserExecutionTime(runnerExecLatency)
 	}
 }


### PR DESCRIPTION
Duration units don't need msec conversion for consistency
across, we currently do not do any conversion for execution
duration for example. Newer metrics, ctrPrepTime, imagePullWaitTime,
ctrCreateTime, initStartTime can follow the same.

Remove legacy runner reported duration calculations.
