### PR TITLE
fn: slot error retention is suboptimal

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -576,7 +576,7 @@ func (s *hotSlot) SetError(err error) {
 }
 
 func (s *hotSlot) Close() {
-	close(s.done)
+	s.SetError(nil)
 }
 
 func (s *hotSlot) exec(ctx context.Context, call *call) error {

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -368,6 +368,7 @@ func (a *agent) getSlot(ctx context.Context, call *call) (Slot, error) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
+		caller.id = call.ID
 		caller.done = ctx.Done()
 		caller.notify = make(chan error)
 	}
@@ -845,7 +846,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		authToken = call.slots.getAuthToken()
 	}
 
-	container = newHotContainer(ctx, a.evictor, call, &a.cfg, id, authToken, udsWait)
+	container = newHotContainer(ctx, a.evictor, &caller, call, &a.cfg, id, authToken, udsWait)
 	if container == nil {
 		return
 	}
@@ -1181,7 +1182,7 @@ type container struct {
 var _ drivers.ContainerTask = &container{}
 
 // newHotContainer creates a container that can be used for multiple sequential events
-func newHotContainer(ctx context.Context, evictor Evictor, call *call, cfg *Config, id, authToken string, udsWait chan error) *container {
+func newHotContainer(ctx context.Context, evictor Evictor, caller *slotCaller, call *call, cfg *Config, id, authToken string, udsWait chan error) *container {
 
 	var iofs iofs
 	var err error
@@ -1238,10 +1239,19 @@ func newHotContainer(ctx context.Context, evictor Evictor, call *call, cfg *Conf
 		},
 	}
 
+	env := cloneStrMap(call.Config) // clone to avoid data race
+
+	// Debug info exposed to FDK/Container
+	if cfg.EnableFDKDebugInfo {
+		if caller != nil {
+			env["FN_SPAWN_CALL_ID"] = caller.id
+		}
+	}
+
 	return &container{
 		id:             id, // XXX we could just let docker generate ids...
 		image:          call.Image,
-		env:            cloneStrMap(call.Config),     // avoid data race
+		env:            env,
 		extensions:     cloneStrMap(call.extensions), // avoid date race
 		memory:         call.Memory,
 		cpus:           uint64(call.CPUs),

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -538,10 +538,6 @@ func (a *agent) waitHot(ctx context.Context, call *call, caller *slotCaller) (Sl
 			return nil, err
 		case s := <-ch:
 			if call.slots.acquireSlot(s) {
-				if s.slot.Error() != nil {
-					s.slot.Close()
-					return nil, s.slot.Error()
-				}
 				return s.slot, nil
 			}
 			// we failed to take ownership of the token (eg. container idle timeout) => try again
@@ -565,26 +561,21 @@ func (a *agent) waitHot(ctx context.Context, call *call, caller *slotCaller) (Sl
 
 // implements Slot
 type hotSlot struct {
-	done          chan struct{} // signal we are done with slot
-	container     *container    // TODO mask this
+	done          chan error // signal we are done with slot
+	container     *container // TODO mask this
 	cfg           *Config
-	fatalErr      error
 	containerSpan trace.SpanContext
 }
 
-func (s *hotSlot) Close() error {
-	close(s.done)
-	return nil
-}
-
-func (s *hotSlot) Error() error {
-	return s.fatalErr
-}
-
-func (s *hotSlot) trySetError(err error) {
-	if s.fatalErr == nil {
-		s.fatalErr = err
+func (s *hotSlot) SetError(err error) {
+	select {
+	case s.done <- err:
+	default:
 	}
+}
+
+func (s *hotSlot) Close() {
+	close(s.done)
 }
 
 func (s *hotSlot) exec(ctx context.Context, call *call) error {
@@ -668,7 +659,7 @@ func (s *hotSlot) dispatch(ctx context.Context, call *call) error {
 
 	if err != nil {
 		// IMPORTANT: Container contract: If http-uds errors/timeout, container cannot continue
-		s.trySetError(err)
+		s.SetError(err)
 		// first filter out timeouts
 		if ctx.Err() == context.DeadlineExceeded {
 			return context.DeadlineExceeded
@@ -693,7 +684,7 @@ func (s *hotSlot) dispatch(ctx context.Context, call *call) error {
 	case <-ctx.Done():
 		if ctx.Err() == context.DeadlineExceeded {
 			// IMPORTANT: Container contract: If http-uds timeout, container cannot continue
-			s.trySetError(ctx.Err())
+			s.SetError(ctx.Err())
 		}
 		return ctx.Err()
 	}
@@ -719,7 +710,7 @@ func (s *hotSlot) writeResp(ctx context.Context, max uint64, resp *http.Response
 		return context.DeadlineExceeded
 	default:
 		// Any other code. Possible FDK failure. We shutdown the container
-		s.trySetError(fmt.Errorf("FDK Error, invalid status code %d", resp.StatusCode))
+		s.SetError(fmt.Errorf("FDK Error, invalid status code %d", resp.StatusCode))
 		return models.ErrFunctionInvalidResponse
 	}
 
@@ -761,15 +752,14 @@ func newSizerRespWriter(max uint64, rw http.ResponseWriter) http.ResponseWriter 
 
 func (s *sizerRespWriter) Write(b []byte) (int, error) { return s.w.Write(b) }
 
-// Try to queue an error to the error channel if possible.
-func tryQueueErr(err error, ch chan error) error {
-	if err != nil {
-		select {
-		case ch <- err:
-		default:
-		}
+// If a client is waiting/listening for this container to initialize, then transmit the error to client
+func notifyCaller(ctx context.Context, err error, caller slotCaller) {
+	select {
+	case caller.notify <- err:
+		common.Logger(ctx).WithError(err).Info("hot function failure, error sent to client")
+	default:
+		common.Logger(ctx).WithError(err).Info("hot function failure, error suppressed")
 	}
-	return err
 }
 
 func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok ResourceToken, state ContainerState) {
@@ -792,7 +782,6 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 
 	initialized := make(chan struct{}) // when closed, container is ready to handle requests
 	udsWait := make(chan error, 1)     // track UDS state and errors
-	errQueue := make(chan error, 1)    // errors to be reflected back to the slot queue
 
 	statsUtilization(ctx, a.resources.GetUtilization())
 	state.UpdateState(ctx, ContainerStateStart, call)
@@ -802,12 +791,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		select {
 		case <-initialized:
 		default:
-			tryQueueErr(models.ErrContainerInitFail, errQueue)
-		}
-		select {
-		case err := <-errQueue:
-			call.slots.queueSlot(&hotSlot{done: make(chan struct{}), fatalErr: err})
-		default:
+			notifyCaller(ctx, models.ErrContainerInitFail, caller)
 		}
 
 		// shutdown the container and related I/O operations and go routines
@@ -839,7 +823,8 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		for {
 			select {
 			case err := <-udsWait:
-				if tryQueueErr(err, errQueue) != nil {
+				if err != nil {
+					notifyCaller(ctx, err, caller)
 					cancel()
 				} else {
 					close(initialized)
@@ -866,9 +851,11 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	}
 
 	cookie, err = a.driver.CreateCookie(ctx, container)
-	if tryQueueErr(err, errQueue) != nil {
+	if err != nil {
+		notifyCaller(ctx, err, caller)
 		return
 	}
+
 	needsPull, err := cookie.ValidateImage(ctx)
 	atomic.StoreInt64(&call.ctrPrepTime, int64(time.Since(ctrCreatePrepStart)))
 	if needsPull {
@@ -876,10 +863,11 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		pullCtx, pullCancel := context.WithTimeout(ctx, a.cfg.HotPullTimeout)
 		err = cookie.PullImage(pullCtx)
 		pullCancel()
-		if err != nil && pullCtx.Err() == context.DeadlineExceeded {
-			err = models.ErrDockerPullTimeout
-		}
-		if tryQueueErr(err, errQueue) == nil {
+		if err != nil {
+			if pullCtx.Err() == context.DeadlineExceeded {
+				err = models.ErrDockerPullTimeout
+			}
+		} else {
 			needsPull, err = cookie.ValidateImage(ctx) // uses original ctx timeout
 			if needsPull {
 				// Image must have removed by image cleaner, manual intervention, etc.
@@ -888,18 +876,21 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 		}
 		atomic.StoreInt64(&call.imagePullWaitTime, int64(time.Since(waitStart)))
 	}
-	if tryQueueErr(err, errQueue) != nil {
+	if err != nil {
+		notifyCaller(ctx, err, caller)
 		return
 	}
 
 	ctrCreateStart := time.Now()
 	err = cookie.CreateContainer(ctx)
-	if tryQueueErr(err, errQueue) != nil {
+	if err != nil {
+		notifyCaller(ctx, err, caller)
 		return
 	}
 
 	waiter, err := cookie.Run(ctx)
-	if tryQueueErr(err, errQueue) != nil {
+	if err != nil {
+		notifyCaller(ctx, err, caller)
 		return
 	}
 	atomic.StoreInt64(&call.ctrCreateTime, int64(time.Since(ctrCreateStart)))
@@ -939,7 +930,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 			timeoutTime := time.Now()
 			statsContainerUDSInitLatency(ctx, initStart, timeoutTime, "timedout")
 			atomic.StoreInt64(&call.initStartTime, int64(timeoutTime.Sub(initStart)))
-			tryQueueErr(models.ErrContainerInitTimeout, errQueue)
+			notifyCaller(ctx, models.ErrContainerInitTimeout, caller)
 			return
 		}
 
@@ -947,7 +938,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 
 		for ctx.Err() == nil {
 			slot := &hotSlot{
-				done:          make(chan struct{}),
+				done:          make(chan error, 1),
 				container:     container,
 				cfg:           &a.cfg,
 				containerSpan: trace.FromContext(ctx).SpanContext(),
@@ -959,10 +950,8 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 
 			// wait for this call to finish
 			// NOTE do NOT select with shutdown / other channels. slot handles this.
-			<-slot.done
-
-			if slot.fatalErr != nil {
-				logger.WithError(slot.fatalErr).Info("hot function terminating")
+			if err := <-slot.done; err != nil {
+				logger.WithError(err).Info("hot function terminating")
 				return
 			}
 		}
@@ -1122,10 +1111,8 @@ func (a *agent) runHotReq(ctx context.Context, call *call, state ContainerState,
 	// abort/shutdown/timeout/evict, attempt to acquire and terminate,
 	// otherwise continue processing the request
 	if call.slots.acquireSlot(s) {
-		slot.Close()
 		select {
 		case <-evicted:
-			logger.Debugf("Hot function evicted")
 			statsContainerEvicted(ctx, state.GetState())
 		default:
 		}

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	DisableReadOnlyRootFs         bool          `json:"disable_readonly_rootfs"`
 	DisableDebugUserLogs          bool          `json:"disable_debug_user_logs"`
 	IOFSEnableTmpfs               bool          `json:"iofs_enable_tmpfs"`
+	EnableFDKDebugInfo            bool          `json:"enable_fdk_debug_info"`
 	IOFSAgentPath                 string        `json:"iofs_path"`
 	IOFSMountRoot                 string        `json:"iofs_mount_root"`
 	IOFSOpts                      string        `json:"iofs_opts"`

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -44,6 +44,7 @@ type slotToken struct {
 }
 
 type slotCaller struct {
+	id     string
 	notify chan error      // notification to caller
 	done   <-chan struct{} // caller done
 }

--- a/api/agent/slots.go
+++ b/api/agent/slots.go
@@ -20,8 +20,8 @@ import (
 
 type Slot interface {
 	exec(ctx context.Context, call *call) error
-	Close() error
-	Error() error
+	SetError(err error)
+	Close()
 }
 
 // slotQueueMgr manages hot container slotQueues

--- a/api/agent/slots_test.go
+++ b/api/agent/slots_test.go
@@ -22,17 +22,18 @@ func (a *testSlot) exec(ctx context.Context, call *call) error {
 	return nil
 }
 
-func (a *testSlot) Close() error {
+func (a *testSlot) SetError(err error) {
+	a.err = err
+}
+
+func (a *testSlot) Close() {
 	if a.isClosed {
 		panic(fmt.Errorf("id=%d already closed %v", a.id, a))
 	}
 	a.isClosed = true
-	return nil
 }
 
-func (a *testSlot) Error() error {
-	return a.err
-}
+var _ Slot = &testSlot{}
 
 func NewTestSlot(id uint64) Slot {
 	mySlot := &testSlot{

--- a/images/fn-test-utils/fn-test-utils.go
+++ b/images/fn-test-utils/fn-test-utils.go
@@ -335,6 +335,29 @@ func main() {
 		os.Exit(int(exitCode))
 	}
 
+	if spawn_match := os.Getenv("ENABLE_FAIL_IF_FN_SPAWN_CALL_ID_NONMATCH"); spawn_match != "" {
+		if spawn_id := os.Getenv("FN_SPAWN_CALL_ID"); spawn_id != "" {
+
+			// Non-match case, we need to crash/exit
+			if spawn_match != spawn_id {
+
+				sleeper := os.Getenv("ENABLE_FAIL_IF_FN_SPAWN_CALL_ID_NONMATCH_MSEC")
+
+				log.Printf("Container start spawn id non-match our_id(%v) != spawner_id(%v) sleep %v", spawn_id, spawn_match, sleeper)
+
+				// Do we need some sleep?
+				if sleeper != "" {
+					delay, err := strconv.ParseInt(sleeper, 10, 64)
+					if err != nil {
+						log.Fatalf("cannot parse ENABLE_FAIL_IF_FN_SPAWN_CALL_ID_NONMATCH_MSEC %v", err)
+					}
+					time.Sleep(time.Millisecond * time.Duration(delay))
+				}
+				os.Exit(int(-1))
+			}
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	GlobCancel = cancel
 	fdk.HandleContext(ctx, fdk.HandlerFunc(AppHandler)) // XXX(reed): can extract & instrument


### PR DESCRIPTION
   
    Current fn agent (aka runner) tries to communicate
    all container start errors to clients. In order to
    achieve this, the errors are retained and could be
    delivered to clients that did not spawn that container.
    This is OK as it tries to be transparent to callers
    instead of suppressing or hiding errors. However,
    these errors are retained without a time bound which
    is not ideal. An old request could trigger an error
    and this error can be sent to a client much later time.
    
    With this change, the error retention semantics change.
    If an errors occurs during container start and the client
    which triggered the container is no longer present, we
    log and discard the result.
    
    Broadly, any error that occurs when a request is not 1-1
    bound to a container is logged and discarded.
    
    For testing these scenarios, a new debug option EnableFDKDebugInfo 
    allows agent to pass request id that triggered the spawn
    of the container as an environment variable.
