### PR TITLE
request limit exceeded added to user errors

### DIFF
--- a/api/models/error.go
+++ b/api/models/error.go
@@ -217,6 +217,10 @@ var (
 		code:  http.StatusInternalServerError,
 		error: errors.New("Syslog Unavailable"),
 	}
+	ErrRequestLimitExceeded = ferr{
+		code:  http.StatusTooManyRequests,
+		error: errors.New("Request capacity for user exceeded"),
+	}
 )
 
 // APIError any error that implements this interface will return an API response


### PR DESCRIPTION

enables reporting capacity exceeded errors as user errors


