### PR TITLE
Decrease log level of failure to find runners message to WARN

### DIFF
--- a/api/runnerpool/placer_tracker.go
+++ b/api/runnerpool/placer_tracker.go
@@ -47,7 +47,7 @@ func (tr *placerTracker) HandleFindRunnersFailure(err error) {
 	if ok {
 		logger = logger.WithField("root_error", w.RootError())
 	}
-	logger.Error("Failed to find runners for call")
+	logger.Warn("Failed to find runners for call")
 	stats.Record(tr.requestCtx, errorPoolCountMeasure.M(0))
 }
 


### PR DESCRIPTION
Having this at ERROR is too noisy, let's decrease it to WARN. In the future we should get the error message into the gin response logging and remove this log line altogether, but I'll leave that for another day.