### PR TITLE
Add Windows CLI install to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ curl -LSs https://raw.githubusercontent.com/fnproject/cli/master/install | sh
 
 This will download a shell script and execute it. If the script asks for a password, that is because it invokes sudo.
 
+#### Option 3. Install the Windows CLI
+[Install and run the Fn Client for Windows](https://github.com/fnproject/docs/blob/master/fn/develop/running-fn-client-windows.md).
 
-#### Option 3. Download the bin - Linux, macOS and Windows
 
+#### Option 4. Download the bin - Linux, macOS and Windows
 Head over to our [releases](https://github.com/fnproject/cli/releases) and download it.
+
 
 ### Run Fn Server
 


### PR DESCRIPTION
- Link to issue this resolves
Docs issue: https://github.com/fnproject/docs/issues/119

- What I did
Added the link.

- How I did it
Added a 3rd install option.

- How to verify it
Previewed it in my editor.

- One line description for the changelog
Add Windows CLI install to Quickstart

- One moving picture involving robots (not mandatory but encouraged)
Roy needs a Windows CLI option.  
![Roy needs a Windows CLI option](https://media.giphy.com/media/90t4OWE4b1XwI/giphy.gif)