### PR TITLE
fn: LB runner client header processing fix

### DIFF
--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -386,8 +386,8 @@ DataLoop:
 				span.Annotate([]trace.Attribute{trace.StringAttribute("status", infoMsg)}, "")
 				log.Debugf(infoMsg)
 				for _, header := range meta.Http.Headers {
-					clonedHeaders.Set(header.Key, header.Value)
-					w.Header().Set(header.Key, header.Value)
+					clonedHeaders.Add(header.Key, header.Value)
+					w.Header().Add(header.Key, header.Value)
 				}
 				if meta.Http.StatusCode > 0 {
 					statusCode = meta.Http.StatusCode


### PR DESCRIPTION
When LB is processing http headers from flat array representation
in gRPC, it should use http.Header.Add() to grow http headers to
handle header keys with multiple values.
