### PR TITLE
Revert client to using the older(v1) Status method.

### DIFF
--- a/api/agent/runner_client.go
+++ b/api/agent/runner_client.go
@@ -24,7 +24,7 @@ import (
 	pool "github.com/fnproject/fn/api/runnerpool"
 	"github.com/fnproject/fn/grpcutil"
 
-	pbst "github.com/golang/protobuf/ptypes/struct"
+	pb_empty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
 )
 
@@ -164,7 +164,7 @@ func (r *gRPCRunner) Status(ctx context.Context) (*pool.RunnerStatus, error) {
 		ctx = metadata.NewOutgoingContext(ctx, mp)
 	}
 
-	status, err := r.client.Status2(ctx, &pbst.Struct{})
+	status, err := r.client.Status(ctx, &pb_empty.Empty{})
 	log.WithError(err).Debugf("Status Call %+v", status)
 	return TranslateGRPCStatusToRunnerStatus(status), err
 }


### PR DESCRIPTION
Revert runner client to use the Status method on gRPC interface.  This is for environments where different OSS versions are vendored into client and server processes and the server may not have upgraded to the newer version. 