### PR TITLE
fn: scheduler latency metric and pull/init duration

### DIFF
--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -415,6 +415,23 @@ func GetCallLatencies(c *call) (time.Duration, time.Duration) {
 				}
 			}
 		}
+
+		// latency out of our control: 1) docker pull wait
+		pullWait := time.Duration(c.imagePullWaitTime) * time.Millisecond
+		if pullWait < schedDuration {
+			schedDuration -= pullWait
+		} else {
+			schedDuration = time.Duration(0)
+		}
+
+		// latency out of our control: 2) UDS & container init wait
+		udsWait := time.Duration(c.initStartTime) * time.Millisecond
+		if udsWait < schedDuration {
+			schedDuration -= udsWait
+		} else {
+			schedDuration = time.Duration(0)
+		}
 	}
+
 	return schedDuration, execDuration
 }

--- a/api/agent/stats.go
+++ b/api/agent/stats.go
@@ -206,7 +206,7 @@ var (
 	containerEvictedMeasure        = common.MakeMeasure(containerEvictedMetricName, "containers evicted", "")
 	containerUDSInitLatencyMeasure = common.MakeMeasure(containerUDSInitLatencyMetricName, "container UDS Init-Wait Latency", "msecs")
 
-	// Reported By LB: How long does a runner scheduler wait for a committed call? eg. wait/launch/pull containers
+	// Reported By LB: How long does a runner scheduler wait for a committed call? eg. wait/launch containers excluding docker-pull and uds wait
 	runnerSchedLatencyMeasure = common.MakeMeasure(runnerSchedLatencyMetricName, "Runner Scheduler Latency Reported By LBAgent", "msecs")
 	// Reported By LB: Function execution time inside a container.
 	runnerExecLatencyMeasure = common.MakeMeasure(runnerExecLatencyMetricName, "Runner Container Execution Latency Reported By LBAgent", "msecs")


### PR DESCRIPTION
Image pull and container uds initialization duration is
out of Fn Service control, therefore should not be included
in scheduler latency which tracks service health.