### PR TITLE
Increase maximum page size to 500

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1052,8 +1052,8 @@ func pageParams(c *gin.Context) (cursor string, perPage int) {
 	cursor = c.Query("cursor")
 
 	perPage, _ = strconv.Atoi(c.Query("per_page"))
-	if perPage > 100 {
-		perPage = 100
+	if perPage > 500 {
+		perPage = 500
 	} else if perPage <= 0 {
 		perPage = 30
 	}


### PR DESCRIPTION
One hundred is a sensible limit, but five hundred gives us a lot more head room. The entities are only small after all.