### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ fn create app myapp
 Deploy your function: 
 
 ```sh
-fn deploy --app myapp --local
+fn deploy --app myapp --create-app --local
 ```
 
 Note: `--local` flag will skip the push to remote container registry making local development faster


### PR DESCRIPTION
Includes the `--create-app` flag on deploy since omitting it on the first call causes an error:
```
Fn: app myapp not found
```

- Link to issue this resolves

- What I did

- How I did it

- How to verify it

- One line description for the changelog

- One moving picture involving robots (not mandatory but encouraged)
