### PR TITLE
memory limit parameter for newer docker versions

### DIFF
--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -108,6 +108,7 @@ func (c *cookie) configureMem(log logrus.FieldLogger) {
 	c.opts.Config.Memory = mem
 	c.opts.Config.MemorySwap = mem // disables swap
 	c.opts.Config.KernelMemory = mem
+	c.opts.HostConfig.Memory = mem
 	c.opts.HostConfig.MemorySwap = mem
 	c.opts.HostConfig.KernelMemory = mem
 	var zero int64


### PR DESCRIPTION
- Link to issue this resolves

This error when running a very recent version of docker with fn's default image.

```txt
Error invoking function. status: 500 message: internal server error
```
Log from the `fnproject/fnserver`

```txt
API error (400): You should always set the Memory limit when using Memoryswap limit, see usage
```

- What I did

Added a required config option to `api/agent/drivers/docker/cookie.go - configureMem`


This project needs some love. Until that happens, you can mitigate this by doing the following steps:

```bash
git clone https://github.com/egandro/fn.git
# or use https://github.com/fnproject/fn.git add apply the patch from here to cookie.go
cd fn
docker rmi fnproject/fnserver:latest || true
docker build -t fnproject/fnserver:latest .
fn start
```

