### PR TITLE
Use available Ubuntu image in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     working_directory: ~/go/src/github.com/fnproject/fn
     environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
       - GO111MODULE=on


### PR DESCRIPTION
- Link to issue this resolves
Fixes #1615

- What I did
Updated the image in the circle CI configuration 
See https://circleci.com/docs/reference/configuration-reference/#available-linux-machine-images-cloud

- How I did it

- How to verify it
Circle CI build should work

- One line description for the changelog
Fixed CircleCI biuld

- One moving picture involving robots (not mandatory but encouraged)
