### PR TITLE
Run gofmt on all files that aren't vendored

### DIFF
--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -39,10 +39,10 @@ const (
 // Agent exposes an api to create calls from various parameters and then submit
 // those calls, it also exposes a 'safe' shutdown mechanism via its Close method.
 // Agent has a few roles:
-//	* manage the memory pool for a given server
-//	* manage the container lifecycle for calls
-//	* execute calls against containers
-//	* invoke Start and End for each call appropriately
+//   - manage the memory pool for a given server
+//   - manage the container lifecycle for calls
+//   - execute calls against containers
+//   - invoke Start and End for each call appropriately
 //
 // Overview:
 // Upon submission of a call, Agent will start the call's timeout timer
@@ -970,7 +970,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	}
 }
 
-//checkSocketDestination verifies that the socket file created by the FDK is valid and permitted - notably verifying that any symlinks are relative to the socket dir
+// checkSocketDestination verifies that the socket file created by the FDK is valid and permitted - notably verifying that any symlinks are relative to the socket dir
 func checkSocketDestination(filename string) error {
 	finfo, err := os.Lstat(filename)
 	if err != nil {

--- a/api/agent/agent_test.go
+++ b/api/agent/agent_test.go
@@ -698,9 +698,7 @@ func TestGetCallReturnsResourceImpossibility(t *testing.T) {
 	}
 }
 
-//
 // Tmp directory should be RW by default.
-//
 func TestTmpFsRW(t *testing.T) {
 
 	app := &models.App{ID: "app_id"}
@@ -908,8 +906,8 @@ func testCall() *models.Call {
 	}
 	headers := map[string][]string{
 		// FromRequest would insert these from original HTTP request
-		"Content-Type":   []string{contentType},
-		"Content-Length": []string{contentLength},
+		"Content-Type":   {contentType},
+		"Content-Length": {contentLength},
 	}
 
 	return &models.Call{

--- a/api/agent/doc.go
+++ b/api/agent/doc.go
@@ -1,20 +1,20 @@
 // Package agent defines the Agent interface and related concepts. An agent is
 // an entity that knows how to execute an Fn function.
 //
-// The Agent Interface
+// # The Agent Interface
 //
 // The Agent interface is the heart of this package. Agent exposes an api to
 // create calls from various parameters and then execute those calls. An Agent
 // has a few roles:
-//	* manage the memory pool for a given server
-//	* manage the container lifecycle for calls
-//	* execute calls against containers
-//	* invoke Start and End for each call appropriately
+//   - manage the memory pool for a given server
+//   - manage the container lifecycle for calls
+//   - execute calls against containers
+//   - invoke Start and End for each call appropriately
 //
 // For more information about how an agent executes a call see the
 // documentation on the Agent interface.
 //
-// Variants
+// # Variants
 //
 // There are two flavors of runner, the local Docker agent and a load-balancing
 // agent. To create an agent that uses Docker containers to execute calls, use

--- a/api/agent/drivers/doc.go
+++ b/api/agent/drivers/doc.go
@@ -3,11 +3,11 @@
 // runtimes (e.g. Docker, Rkt, etc.) and provides utlities and data types that
 // are common across all runtimes.
 //
-// Docker Driver
+// # Docker Driver
 //
 // The docker driver runs functions as Docker containers.
 //
-// Mock Driver
+// # Mock Driver
 //
 // The mock driver pretends to run functions but doesn't actually run them. This
 // is for testing only.

--- a/api/agent/drivers/docker/doc.go
+++ b/api/agent/drivers/docker/doc.go
@@ -1,5 +1,7 @@
 // Package docker provides a Docker driver for Fn. Provides an implementation
 // of
+//
 //	github.com/fnproject/fn/api/agent/drivers.Driver
+//
 // that knows how to run Docker images.
 package docker

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -178,7 +178,7 @@ func killLeakedContainers(ctx context.Context, driver *DockerDriver) {
 		containers, err = driver.docker.ListContainers(docker.ListContainersOptions{
 			All: true, // let's include containers that are not running, but not destroyed
 			Filters: map[string][]string{
-				"label": []string{filter},
+				"label": {filter},
 			},
 			Context: ctx,
 		})

--- a/api/common/ctx.go
+++ b/api/common/ctx.go
@@ -12,7 +12,7 @@ type contextKey string
 // RequestIDContextKey is the name of the key used to store the request ID into the context
 const RequestIDContextKey = "fn_request_id"
 
-//WithRequestID stores a request ID into the context
+// WithRequestID stores a request ID into the context
 func WithRequestID(ctx context.Context, rid string) context.Context {
 	return context.WithValue(ctx, contextKey(RequestIDContextKey), rid)
 }

--- a/api/common/io_utils.go
+++ b/api/common/io_utils.go
@@ -70,7 +70,7 @@ type clampWriter struct {
 // NewClamWriter creates a clamp writer that will limit the number of bytes written to to an underlying stream
 // This allows up to max bytes to be written to the underlying stream , writes that exceed this will return overflowErr
 //
-// Setting a  max of 0 sets no limit
+// # Setting a  max of 0 sets no limit
 //
 // If a write spans the last remaining bytes available the number of bytes up-to the limit will be written and the
 // overflow error will be returned

--- a/api/common/request_id_util.go
+++ b/api/common/request_id_util.go
@@ -14,7 +14,7 @@ func FnRequestID(ridFound string) string {
 	return ridFound
 }
 
-//RequestIDFromContext extract the request id from the context
+// RequestIDFromContext extract the request id from the context
 func RequestIDFromContext(ctx context.Context) string {
 	rid, _ := ctx.Value(contextKey(RequestIDContextKey)).(string)
 	return rid

--- a/api/datastore/datastoretest/test.go
+++ b/api/datastore/datastoretest/test.go
@@ -29,7 +29,7 @@ func setLogBuffer() *bytes.Buffer {
 	return &buf
 }
 
-//ResourceProvider provides an abstraction for supplying data store tests with
+// ResourceProvider provides an abstraction for supplying data store tests with
 // appropriate initial testing objects for running tests
 // Use the resource calls to supply objects with (e.g.) middleware enforced annotations set on them
 // Use DefaultCtx to override custom middleware-supplied context variables
@@ -54,7 +54,7 @@ type BasicResourceProvider struct {
 // DataStoreFunc provides an instance of a data store
 type DataStoreFunc func(*testing.T) models.Datastore
 
-//NewBasicResourceProvider creates a dumb resource provider that generates resources that have valid, random names (and other unique attributes)
+// NewBasicResourceProvider creates a dumb resource provider that generates resources that have valid, random names (and other unique attributes)
 func NewBasicResourceProvider() ResourceProvider {
 	return &BasicResourceProvider{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),

--- a/api/models/annotations.go
+++ b/api/models/annotations.go
@@ -11,7 +11,9 @@ import (
 
 // Annotations encapsulates key-value metadata associated with resource. The structure is immutable via its public API and nil-safe for its contract
 // permissive nilability is here to simplify updates and reduce the need for nil handling in extensions - annotations should be updated by over-writing the original object:
-//  target.Annotations  = target.Annotations.With("fooKey",1)
+//
+//	target.Annotations  = target.Annotations.With("fooKey",1)
+//
 // old MD remains empty
 // Annotations is lenable
 type Annotations map[string]*annotationValue

--- a/api/models/trigger.go
+++ b/api/models/trigger.go
@@ -57,17 +57,17 @@ func (t *Trigger) EqualsWithAnnotationSubset(t2 *Trigger) bool {
 	return eq
 }
 
-//TriggerTypeHTTP represents an HTTP trigger
+// TriggerTypeHTTP represents an HTTP trigger
 const TriggerTypeHTTP = "http"
 
 var triggerTypes = []string{TriggerTypeHTTP}
 
-//ValidTriggerTypes lists the supported trigger types in this service
+// ValidTriggerTypes lists the supported trigger types in this service
 func ValidTriggerTypes() []string {
 	return triggerTypes
 }
 
-//ValidTriggerType checks that a given trigger type is valid on this service
+// ValidTriggerType checks that a given trigger type is valid on this service
 func ValidTriggerType(a string) bool {
 	for _, b := range triggerTypes {
 		if b == a {
@@ -138,7 +138,7 @@ var (
 		error: errors.New("Trigger with the same type and source exists on this app")}
 )
 
-//Validate checks that trigger has valid data for inserting into a store
+// Validate checks that trigger has valid data for inserting into a store
 func (t *Trigger) Validate() error {
 	if t.AppID == "" {
 		return ErrTriggerMissingAppID
@@ -225,7 +225,7 @@ func (t *Trigger) Update(patch *Trigger) {
 	}
 }
 
-//TriggerFilter is a search criteria on triggers
+// TriggerFilter is a search criteria on triggers
 type TriggerFilter struct {
 	//AppID searches for triggers in APP - mandatory
 	AppID string // this is exact match mandatory
@@ -238,7 +238,7 @@ type TriggerFilter struct {
 	PerPage int
 }
 
-//TriggerList is a container of triggers returned by search, optionally indicating the next page cursor
+// TriggerList is a container of triggers returned by search, optionally indicating the next page cursor
 type TriggerList struct {
 	NextCursor string     `json:"next_cursor,omitempty"`
 	Items      []*Trigger `json:"items"`

--- a/api/runnerpool/ch_placer.go
+++ b/api/runnerpool/ch_placer.go
@@ -1,5 +1,7 @@
-/* The consistent hash ring from the original fnlb.
-   The behaviour of this depends on changes to the runner list leaving it relatively stable.
+/*
+The consistent hash ring from the original fnlb.
+
+	The behaviour of this depends on changes to the runner list leaving it relatively stable.
 */
 package runnerpool
 

--- a/api/server/apps_test.go
+++ b/api/server/apps_test.go
@@ -63,7 +63,7 @@ func TestAppCreate(t *testing.T) {
 		{datastore.NewMock(), "/v2/apps", `{ "name": "teste"  }`, http.StatusOK, nil},
 		{datastore.NewMock(), "/v2/apps", `{  "name": "teste" , "annotations": {"k1":"v1", "k2":[]}}`, http.StatusOK, nil},
 		{datastore.NewMock(), "/v2/apps", `{"name": "teste", "syslog_url":"tcp://example.com:443" } `, http.StatusOK, nil},
-		{datastore.NewMockInit([]*models.App{&models.App{ID: "appid", Name: "teste"}}), "/v2/apps", `{ "name": "teste"  }`, http.StatusConflict, models.ErrAppsAlreadyExists},
+		{datastore.NewMockInit([]*models.App{{ID: "appid", Name: "teste"}}), "/v2/apps", `{ "name": "teste"  }`, http.StatusConflict, models.ErrAppsAlreadyExists},
 	} {
 		rnr, cancel := testRunner(t)
 		srv := testServer(test.mock, rnr, ServerTypeFull)

--- a/api/server/fn_annotator.go
+++ b/api/server/fn_annotator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-//FnAnnotator Is used to inject trigger context (such as request URLs) into outbound trigger resources
+// FnAnnotator Is used to inject trigger context (such as request URLs) into outbound trigger resources
 type FnAnnotator interface {
 	// Annotates a trigger on read
 	AnnotateFn(ctx *gin.Context, a *models.App, fn *models.Fn) (*models.Fn, error)
@@ -42,7 +42,7 @@ func (tp *requestBasedFnAnnotator) AnnotateFn(ctx *gin.Context, app *models.App,
 	return annotateFnWithBaseURL(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), app, t)
 }
 
-//NewRequestBasedFnAnnotator creates a FnAnnotator that inspects the incoming request host and port, and uses this to generate fn invoke endpoint URLs based on those
+// NewRequestBasedFnAnnotator creates a FnAnnotator that inspects the incoming request host and port, and uses this to generate fn invoke endpoint URLs based on those
 func NewRequestBasedFnAnnotator() FnAnnotator {
 	return &requestBasedFnAnnotator{}
 }
@@ -51,7 +51,7 @@ type staticURLFnAnnotator struct {
 	baseURL string
 }
 
-//NewStaticURLFnAnnotator annotates triggers bases on a given, specified URL base - e.g. "https://my.domain" --->  "https://my.domain/t/app/source"
+// NewStaticURLFnAnnotator annotates triggers bases on a given, specified URL base - e.g. "https://my.domain" --->  "https://my.domain/t/app/source"
 func NewStaticURLFnAnnotator(baseURL string) FnAnnotator {
 
 	return &staticURLFnAnnotator{baseURL: baseURL}

--- a/api/server/runner_fninvoke_test.go
+++ b/api/server/runner_fninvoke_test.go
@@ -35,7 +35,7 @@ func TestBadRequests(t *testing.T) {
 		{"/invoke/notfn", "", "", http.StatusNotFound, models.ErrFnsNotFound},
 	} {
 		request := createRequest(t, http.MethodPost, test.path, strings.NewReader(test.body))
-		request.Header = map[string][]string{"Content-Type": []string{test.contentType}}
+		request.Header = map[string][]string{"Content-Type": {test.contentType}}
 		_, rec := routerRequest2(t, srv.Router, request)
 
 		if rec.Code != test.expectedCode {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -471,7 +471,7 @@ func WithExtraCtx(extraCtx context.Context) Option {
 	}
 }
 
-//WithTriggerAnnotator adds a trigggerEndpoint provider to the server
+// WithTriggerAnnotator adds a trigggerEndpoint provider to the server
 func WithTriggerAnnotator(provider TriggerAnnotator) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.triggerAnnotator = provider
@@ -479,7 +479,7 @@ func WithTriggerAnnotator(provider TriggerAnnotator) Option {
 	}
 }
 
-//WithFnAnnotator adds a fnEndpoint provider to the server
+// WithFnAnnotator adds a fnEndpoint provider to the server
 func WithFnAnnotator(provider FnAnnotator) Option {
 	return func(ctx context.Context, s *Server) error {
 		s.fnAnnotator = provider
@@ -516,15 +516,15 @@ func New(ctx context.Context, opts ...Option) *Server {
 		Router:      engine,
 		AdminRouter: engine,
 		svcConfigs: map[string]*http.Server{
-			WebServer: &http.Server{
+			WebServer: {
 				MaxHeaderBytes:    getEnvInt(EnvMaxHeaderSize, http.DefaultMaxHeaderBytes),
 				ReadHeaderTimeout: getEnvDuration(EnvReadHeaderTimeout, 0),
 				ReadTimeout:       getEnvDuration(EnvReadTimeout, 0),
 				WriteTimeout:      getEnvDuration(EnvWriteTimeout, 0),
 				IdleTimeout:       getEnvDuration(EnvHTTPIdleTimeout, 0),
 			},
-			AdminServer: &http.Server{},
-			GRPCServer:  &http.Server{},
+			AdminServer: {},
+			GRPCServer:  {},
 		},
 		// MUST initialize these before opts
 		appListeners:     new(appListeners),

--- a/api/server/trigger_annotator.go
+++ b/api/server/trigger_annotator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-//TriggerAnnotator Is used to inject trigger context (such as request URLs) into outbound trigger resources
+// TriggerAnnotator Is used to inject trigger context (such as request URLs) into outbound trigger resources
 type TriggerAnnotator interface {
 	// Annotates a trigger on read
 	AnnotateTrigger(ctx *gin.Context, a *models.App, t *models.Trigger) (*models.Trigger, error)
@@ -44,7 +44,7 @@ func (tp *requestBasedTriggerAnnotator) AnnotateTrigger(ctx *gin.Context, app *m
 	return annotateTriggerWithBaseURL(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), app, t)
 }
 
-//NewRequestBasedTriggerAnnotator creates a TriggerAnnotator that inspects the incoming request host and port, and uses this to generate http trigger endpoint URLs based on those
+// NewRequestBasedTriggerAnnotator creates a TriggerAnnotator that inspects the incoming request host and port, and uses this to generate http trigger endpoint URLs based on those
 func NewRequestBasedTriggerAnnotator() TriggerAnnotator {
 	return &requestBasedTriggerAnnotator{}
 }
@@ -53,7 +53,7 @@ type staticURLTriggerAnnotator struct {
 	baseURL string
 }
 
-//NewStaticURLTriggerAnnotator annotates triggers bases on a given, specified URL base - e.g. "https://my.domain" --->  "https://my.domain/t/app/source"
+// NewStaticURLTriggerAnnotator annotates triggers bases on a given, specified URL base - e.g. "https://my.domain" --->  "https://my.domain/t/app/source"
 func NewStaticURLTriggerAnnotator(baseURL string) TriggerAnnotator {
 
 	return &staticURLTriggerAnnotator{baseURL: baseURL}

--- a/examples/apps/hellos/func.go
+++ b/examples/apps/hellos/func.go
@@ -47,9 +47,9 @@ func main() {
 		Title: "My App",
 		Body:  "This is my app. It may not be the best app, but it's my app. And it's multilingual!",
 		Items: []link{
-			link{"Ruby", fmt.Sprintf("/r/%s/ruby", appName)},
-			link{"Node", fmt.Sprintf("/r/%s/node", appName)},
-			link{"Python", fmt.Sprintf("/r/%s/python", appName)},
+			{"Ruby", fmt.Sprintf("/r/%s/ruby", appName)},
+			{"Node", fmt.Sprintf("/r/%s/node", appName)},
+			{"Python", fmt.Sprintf("/r/%s/python", appName)},
 		},
 	}
 

--- a/go-fmt-all.sh
+++ b/go-fmt-all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# find and output all Go files that are not correctly formatted
+set -euo pipefail
+
+# Find all .go files except those under vendor/ or .git, run gofmt -l on them
+find . ! \( -path ./vendor -prune \) ! \( -path ./.git -prune \) -name '*.go' -exec gofmt -s -w {} +


### PR DESCRIPTION
The build was complaining about a difference between the files in the repo and the expected formatting. This fixes that problem.


- Link to issue this resolves

Fixes #1617

- What I did
Created a script to format all files that aren't in the vendor directory
Ran the script

- How I did it

- How to verify it

- One line description for the changelog
Reformatted source files

- One moving picture involving robots (not mandatory but encouraged)
