### PR TITLE
Build with go1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - GO111MODULE=on
       - GOPATH=/home/circleci/go
       - GOFLAGS=-mod=vendor
-      - GOVERSION=1.12.1
+      - GOVERSION=1.13.15
       - OS=linux
       - ARCH=amd64
       - FN_LOG_LEVEL=debug

--- a/api/common/logging.go
+++ b/api/common/logging.go
@@ -3,12 +3,14 @@ package common
 import (
 	"net/url"
 	"os"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
+
+var dbPasswordRegexp = regexp.MustCompile(`(://\w+:)(\w+)(@)`)
 
 func SetLogFormat(format string) {
 	if format != "text" && format != "json" {
@@ -95,12 +97,6 @@ func SetLogDest(to, prefix string) {
 }
 
 // MaskPassword returns a stringified URL without its password visible
-func MaskPassword(u *url.URL) string {
-	if u.User != nil {
-		p, set := u.User.Password()
-		if set {
-			return strings.Replace(u.String(), p+"@", "***@", 1)
-		}
-	}
-	return u.String()
+func MaskPassword(u string) string {
+	return dbPasswordRegexp.ReplaceAllString(u, `${1}***${3}`)
 }

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -2,8 +2,6 @@ package datastore
 
 import (
 	"context"
-	"net/url"
-
 	"fmt"
 
 	"github.com/fnproject/fn/api/common"
@@ -15,18 +13,14 @@ import (
 // New creates a DataStore from the specified URL
 func New(ctx context.Context, dbURL string) (models.Datastore, error) {
 	log := common.Logger(ctx)
-	u, err := url.Parse(dbURL)
-	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{"url": dbURL}).Fatal("bad DB URL")
-	}
-	log.WithFields(logrus.Fields{"db": u.Scheme}).Debug("creating new datastore")
+	log.WithFields(logrus.Fields{"db": dbURL}).Debug("creating new datastore")
 
 	for _, provider := range providers {
-		if provider.Supports(u) {
-			return provider.New(ctx, u)
+		if provider.Supports(dbURL) {
+			return provider.New(ctx, dbURL)
 		}
 	}
-	return nil, fmt.Errorf("no data store provider found for storage url %s", u)
+	return nil, fmt.Errorf("no data store provider found for storage url %s", dbURL)
 }
 
 func Wrap(ds models.Datastore) models.Datastore {
@@ -37,9 +31,9 @@ func Wrap(ds models.Datastore) models.Datastore {
 type Provider interface {
 	fmt.Stringer
 	// Supports indicates if this provider can handle a given data store.
-	Supports(url *url.URL) bool
+	Supports(url string) bool
 	// New creates a new data store from the specified URL
-	New(ctx context.Context, url *url.URL) (models.Datastore, error)
+	New(ctx context.Context, url string) (models.Datastore, error)
 }
 
 var providers []Provider

--- a/api/datastore/sql/dbhelper/dbhelper.go
+++ b/api/datastore/sql/dbhelper/dbhelper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/jmoiron/sqlx"
 	"github.com/sirupsen/logrus"
-	"net/url"
 )
 
 var sqlHelpers []Helper
@@ -21,7 +20,7 @@ type Helper interface {
 	// Supports indicates if this helper supports this driver name
 	Supports(driverName string) bool
 	// PreConnect calculates the connect URL for the db from a canonical URL used in Fn config
-	PreConnect(url *url.URL) (string, error)
+	PreConnect(url string) (string, error)
 	// PostCreate  Apply any configuration to the DB prior to use
 	PostCreate(db *sqlx.DB) (*sqlx.DB, error)
 	// CheckTableExists checks if a table exists in the DB

--- a/api/datastore/sql/mysql/mysql.go
+++ b/api/datastore/sql/mysql/mysql.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/fnproject/fn/api/datastore/sql/dbhelper"
@@ -16,8 +15,8 @@ func (mysqlHelper) Supports(scheme string) bool {
 	return scheme == "mysql"
 }
 
-func (mysqlHelper) PreConnect(url *url.URL) (string, error) {
-	return strings.TrimPrefix(url.String(), url.Scheme+"://"), nil
+func (mysqlHelper) PreConnect(url string) (string, error) {
+	return strings.TrimPrefix(url, "mysql://"), nil
 }
 
 func (mysqlHelper) PostCreate(db *sqlx.DB) (*sqlx.DB, error) {

--- a/api/datastore/sql/postgres/postgres.go
+++ b/api/datastore/sql/postgres/postgres.go
@@ -5,7 +5,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	"net/url"
 )
 
 type postgresHelper int
@@ -18,8 +17,8 @@ func (postgresHelper) Supports(scheme string) bool {
 	return false
 }
 
-func (postgresHelper) PreConnect(url *url.URL) (string, error) {
-	return url.String(), nil
+func (postgresHelper) PreConnect(url string) (string, error) {
+	return url, nil
 }
 
 func (postgresHelper) PostCreate(db *sqlx.DB) (*sqlx.DB, error) {

--- a/api/datastore/sql/sql.go
+++ b/api/datastore/sql/sql.go
@@ -6,9 +6,9 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
-	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fnproject/fn/api/common"
@@ -102,16 +102,17 @@ type sqlDsProvider int
 
 // New will open the db specified by url, create any tables necessary
 // and return a models.Datastore safe for concurrent usage.
-func New(ctx context.Context, u *url.URL) (*SQLStore, error) {
+func New(ctx context.Context, u string) (*SQLStore, error) {
 	return newDS(ctx, u)
 }
 
-func (sqlDsProvider) Supports(u *url.URL) bool {
-	_, ok := dbhelper.GetHelper(u.Scheme)
+func (sqlDsProvider) Supports(u string) bool {
+	driver := strings.SplitN(u, ":", 2)[0]
+	_, ok := dbhelper.GetHelper(driver)
 	return ok
 }
 
-func (sqlDsProvider) New(ctx context.Context, u *url.URL) (models.Datastore, error) {
+func (sqlDsProvider) New(ctx context.Context, u string) (models.Datastore, error) {
 	return newDS(ctx, u)
 }
 
@@ -120,8 +121,8 @@ func (sqlDsProvider) String() string {
 }
 
 // for test methods, return concrete type, but don't expose
-func newDS(ctx context.Context, url *url.URL) (*SQLStore, error) {
-	driver := url.Scheme
+func newDS(ctx context.Context, url string) (*SQLStore, error) {
+	driver := strings.SplitN(url, ":", 2)[0]
 
 	log := common.Logger(ctx).WithFields(logrus.Fields{"url": common.MaskPassword(url)})
 	helper, ok := dbhelper.GetHelper(driver)

--- a/api/datastore/sql/sqlite/sqlite.go
+++ b/api/datastore/sql/sqlite/sqlite.go
@@ -1,14 +1,13 @@
 package sqlite
 
 import (
+	"github.com/fnproject/fn/api/datastore/sql/dbhelper"
+	"github.com/jmoiron/sqlx"
+	"github.com/mattn/go-sqlite3"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/fnproject/fn/api/datastore/sql/dbhelper"
-	"github.com/jmoiron/sqlx"
-	"github.com/mattn/go-sqlite3"
 )
 
 type sqliteHelper int
@@ -21,15 +20,19 @@ func (sqliteHelper) Supports(scheme string) bool {
 	return false
 }
 
-func (sqliteHelper) PreConnect(url *url.URL) (string, error) {
+func (sqliteHelper) PreConnect(u string) (string, error) {
 	// make all the dirs so we can make the file..
-	dir := filepath.Dir(url.Path)
-	err := os.MkdirAll(dir, 0750)
+	sqliteUrl, err := url.Parse(u)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(sqliteUrl.Path)
+	err = os.MkdirAll(dir, 0750)
 	if err != nil {
 		return "", err
 	}
 
-	return strings.TrimPrefix(url.String(), url.Scheme+"://"), nil
+	return strings.TrimPrefix(u, "sqlite3://"), nil
 }
 
 func (sqliteHelper) PostCreate(db *sqlx.DB) (*sqlx.DB, error) {


### PR DESCRIPTION
- What I did
Updated the code to build successfully with go1.13. We parsed DB connection strings with url.Parse, but that no longer works with go1.13. I've changed the code to pass the connection strings around as strings. 

- One line description for the changelog
Buid with go1.13

- One moving picture involving robots (not mandatory but encouraged)
