### PR TITLE
Fix permission issue when FDK tried to bind socket (plus other change required to start up FnServer without pain)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           mkdir tmp
           cd tmp
           sudo rm -rf /usr/local/go
-          wget https://storage.googleapis.com/golang/go$GOVERSION.$OS-$ARCH.tar.gz
+          wget https://go.dev/dl/go$GOVERSION.$OS-$ARCH.tar.gz
           sudo tar -C /usr/local -xzf go$GOVERSION.$OS-$ARCH.tar.gz
       - run: go version
       # install latest Docker

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The fastest way to experience Fn is to follow the quickstart below, or you can j
 
 ### Pre-requisites
 
-* Docker 17.10.0-ce or later installed and running
+* Docker 17.10.0-ce or later, Podman 5.7.0 or later installed and running
 * [Docker Hub](https://hub.docker.com/) account (or other Docker-compliant registry) (Not required for local development)
 * Logged into Registry: ie `docker login` (Not required for local development)
 
@@ -62,19 +62,39 @@ This will download a shell script and execute it. If the script asks for a passw
 #### Option 4. Download the bin - Linux, macOS and Windows
 Head over to our [releases](https://github.com/fnproject/cli/releases) and download it.
 
+### Before you start
+
+If you are using Podman or Rancher desktop, it is recommended use a volume. The volume will be used by FnServer
+to create unix socket file to communicate to other Fn containers.
+
+The volume will be created automatically when you use "--iofs-dir" option in "fn start" and specify the volume name (e.g. fniofsvol).
+
+If you want to create volume manually, you could do:
+`docker volume create --opt device=tmpfs --opt type=tmpfs --opt o=size=2M,dev,noexec <volume name>`
+
+The docker command is provided by podman or rancher desktop in this case.
 
 ### Run Fn Server
 
-First, start up an Fn server locally:
+First, start up a Fn server locally:
 
 ```sh
 fn start
 ```
+or if you are on podman/rancher which you need to use a volume
+```sh
+fn start --iofs-dir <volume name, or it could be a directory in the host VM for Docker Desktop>
+```
+
+iofs-dir allows you to specify a volume (which is required for Podman or Rancher case), or any directory in the
+host-vm (for Docker Desktop) if you want to use a specific directory to host the unix socket file. It is usually
+not a concern for Docker users.
 
 This will start Fn in single server mode, using an embedded database and message queue. You can find all the
 configuration options [here](https://github.com/fnproject/docs/blob/master/fn/operate/options.md). If you are on Windows, check [here](https://github.com/fnproject/docs/blob/master/fn/operate/windows.md).
-If you are on a Linux system where the SELinux security policy is set to "Enforcing", such as Oracle Linux 7, check
-[here](https://github.com/fnproject/docs/blob/master/fn/operate/selinux.md).
+
+### SELinux
+Most Linux systems have SELinux enabled and FnServer supports running on SELinux.
 
 ### Your First Function
 

--- a/api/agent/agent.go
+++ b/api/agent/agent.go
@@ -39,10 +39,10 @@ const (
 // Agent exposes an api to create calls from various parameters and then submit
 // those calls, it also exposes a 'safe' shutdown mechanism via its Close method.
 // Agent has a few roles:
-//	* manage the memory pool for a given server
-//	* manage the container lifecycle for calls
-//	* execute calls against containers
-//	* invoke Start and End for each call appropriately
+//   - manage the memory pool for a given server
+//   - manage the container lifecycle for calls
+//   - execute calls against containers
+//   - invoke Start and End for each call appropriately
 //
 // Overview:
 // Upon submission of a call, Agent will start the call's timeout timer
@@ -202,7 +202,6 @@ func NewDockerDriver(cfg *Config) (drivers.Driver, error) {
 	return drivers.New("docker", drivers.Config{
 		DockerNetworks:                cfg.DockerNetworks,
 		DockerLoadFile:                cfg.DockerLoadFile,
-		ServerVersion:                 cfg.MinDockerVersion,
 		PreForkPoolSize:               cfg.PreForkPoolSize,
 		PreForkImage:                  cfg.PreForkImage,
 		PreForkCmd:                    cfg.PreForkCmd,
@@ -970,7 +969,7 @@ func (a *agent) runHot(ctx context.Context, caller slotCaller, call *call, tok R
 	}
 }
 
-//checkSocketDestination verifies that the socket file created by the FDK is valid and permitted - notably verifying that any symlinks are relative to the socket dir
+// checkSocketDestination verifies that the socket file created by the FDK is valid and permitted - notably verifying that any symlinks are relative to the socket dir
 func checkSocketDestination(filename string) error {
 	finfo, err := os.Lstat(filename)
 	if err != nil {
@@ -1253,6 +1252,12 @@ func newHotContainer(ctx context.Context, evictor Evictor, caller *slotCaller, c
 			env["FN_SPAWN_CALL_ID"] = caller.id
 		}
 	}
+	// filepath.Base never return empty path
+	iofsRelPath := filepath.Base(iofs.AgentPath())
+
+	env["FN_LISTENER"] = "unix:" + filepath.Join(iofsDockerMountDest, iofsRelPath, udsFilename)
+	logger.WithField("FN_LISTENER", env["FN_LISTENER"]).
+		Debug("Setting FN_LISTENER in container")
 
 	return &container{
 		id:             id, // XXX we could just let docker generate ids...

--- a/api/agent/call.go
+++ b/api/agent/call.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -251,7 +250,6 @@ func (a *agent) GetCall(opts ...CallOpt) (Call, error) {
 	if c.Call.Config == nil {
 		c.Call.Config = make(models.Config)
 	}
-	c.Call.Config["FN_LISTENER"] = "unix:" + filepath.Join(iofsDockerMountDest, udsFilename)
 	c.Call.Config["FN_FORMAT"] = "http-stream" // TODO: remove this after fdk's forget what it means
 	// TODO we could set type here too, for now, or anything else not based in fn/app/trigger config
 

--- a/api/agent/config.go
+++ b/api/agent/config.go
@@ -11,7 +11,6 @@ import (
 
 // Config specifies various settings for an agent
 type Config struct {
-	MinDockerVersion              string        `json:"min_docker_version"`
 	ContainerLabelTag             string        `json:"container_label_tag"`
 	DockerNetworks                string        `json:"docker_networks"`
 	DockerLoadFile                string        `json:"docker_load_file"`
@@ -155,10 +154,9 @@ const (
 // NewConfig returns a config set from env vars, plus defaults
 func NewConfig() (*Config, error) {
 	cfg := &Config{
-		MinDockerVersion: "17.10.0-ce",
-		MaxLogSize:       1 * 1024 * 1024,
-		PreForkImage:     "busybox",
-		PreForkCmd:       "tail -f /dev/null",
+		MaxLogSize:   1 * 1024 * 1024,
+		PreForkImage: "busybox",
+		PreForkCmd:   "tail -f /dev/null",
 	}
 
 	defaultMaxPIDs := uint64(50)

--- a/api/agent/drivers/docker/cookie.go
+++ b/api/agent/drivers/docker/cookie.go
@@ -111,8 +111,6 @@ func (c *cookie) configureMem(log logrus.FieldLogger) {
 	c.opts.HostConfig.MemorySwap = mem
 	c.opts.HostConfig.KernelMemory = mem
 	c.opts.HostConfig.Memory = mem
-	var zero int64
-	c.opts.HostConfig.MemorySwappiness = &zero // disables host swap
 }
 
 func (c *cookie) configureFsSize(log logrus.FieldLogger) {
@@ -190,13 +188,29 @@ func (c *cookie) configureTmpFs(log logrus.FieldLogger) {
 }
 
 func (c *cookie) configureIOFS(log logrus.FieldLogger) {
-	path := c.task.UDSDockerPath()
-	if path == "" {
+	// Configure the bind mount from host to Fn container to put the unix socket file that used for
+	//   communication between Fn Server to Fn container
+	// User could use either host machine path or container engine named volume for the source part of the bind mount
+	// For host machine path, user could set "FN_IOFS_DOCKER_PATH" to a path (e.g. \mycustomeriofspath). The mapping will be:
+	//   - \mycustomeriofspath:\tmp\iofs
+	//   If host machine path is used, "Z" option need to be set for host machine which has SELinux enabled. (See below)
+	// For container engine named volume, user could set "FN_IOFS_DOCKER_PATH" to a named volume (e.g. mynamedvolume).
+	// The mapping will be:
+	//   - mynamedvolume:\tmp\iofs
+	// In both case, FN_LISTENER will be set to "\tmp\iofs\<temp directory created by fn server>"
+
+	// The reason of allowing user to use named volume since for Rancher/Podman, they do not allow using HOME directory
+	//  to host socket file as the volume mapping from host to host vm is created with "nodev" options.
+	//  See issue: https://github.com/fnproject/fn/issues/1577#issuecomment-1297736260
+	udsDockerPath := c.task.UDSDockerPath()
+	if udsDockerPath == "" {
 		// TODO this should be required soon-ish
 		return
 	}
 
-	bind := fmt.Sprintf("%s:%s", path, c.task.UDSDockerDest())
+	// Z - private unshared SELinux option which is required for host VM that running on SELinux. No effect
+	//     on Linux with SELinux disabled, or docker/podman named volume.
+	bind := fmt.Sprintf("%s:%s:Z", udsDockerPath, c.task.UDSDockerDest())
 	c.opts.HostConfig.Binds = append(c.opts.HostConfig.Binds, bind)
 	log.WithFields(logrus.Fields{"bind": bind, "call_id": c.task.Id()}).Debug("setting bind")
 }

--- a/api/agent/drivers/docker/docker.go
+++ b/api/agent/drivers/docker/docker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fnproject/fn/api/agent/drivers/stats"
 	docker "github.com/fsouza/go-dockerclient"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/fnproject/fn/api/agent/drivers"
 	"github.com/fnproject/fn/api/common"
 	"github.com/fnproject/fn/api/models"
@@ -102,11 +101,6 @@ func NewDocker(conf drivers.Config) *DockerDriver {
 		network:    NewDockerNetworks(conf),
 		instanceId: instanceId,
 		imgCache:   createImageCache(conf),
-	}
-
-	err = checkDockerVersion(ctx, driver)
-	if err != nil {
-		logrus.WithError(err).Fatal("docker version error")
 	}
 
 	// start the cleanup jobs as early as possible
@@ -310,33 +304,6 @@ func runImageCleaner(ctx context.Context, driver *DockerDriver) {
 			}
 		}
 	}
-}
-
-func checkDockerVersion(ctx context.Context, driver *DockerDriver) error {
-	if driver.conf.ServerVersion == "" {
-		return nil
-	}
-
-	info, err := driver.docker.Info(ctx)
-	if err != nil {
-		return err
-	}
-
-	actual, err := semver.NewVersion(info.ServerVersion)
-	if err != nil {
-		return err
-	}
-
-	wanted, err := semver.NewVersion(driver.conf.ServerVersion)
-	if err != nil {
-		return err
-	}
-
-	if actual.Compare(*wanted) < 0 {
-		return fmt.Errorf("docker version is too old. Required: %s Found: %s", driver.conf.ServerVersion, info.ServerVersion)
-	}
-
-	return nil
 }
 
 func loadDockerImages(ctx context.Context, driver *DockerDriver) error {

--- a/api/agent/drivers/docker/docker_test.go
+++ b/api/agent/drivers/docker/docker_test.go
@@ -224,29 +224,6 @@ func TestRunnerDockerNetworks(t *testing.T) {
 	}
 }
 
-func TestRunnerDockerVersion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(6)*time.Second)
-	defer cancel()
-
-	dkr := NewDocker(drivers.Config{})
-	if dkr == nil {
-		t.Fatal("should not be nil")
-	}
-	defer dkr.Close()
-
-	dkr.conf.ServerVersion = "1.0.0"
-	err := checkDockerVersion(ctx, dkr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dkr.conf.ServerVersion = "9999.0.0"
-	err = checkDockerVersion(ctx, dkr)
-	if err == nil {
-		t.Fatal("should have failed")
-	}
-}
-
 func TestRunnerDockerStdout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(30)*time.Second)
 	defer cancel()

--- a/api/agent/drivers/driver.go
+++ b/api/agent/drivers/driver.go
@@ -252,7 +252,6 @@ type Config struct {
 	Docker                        string `json:"docker"`
 	DockerNetworks                string `json:"docker_networks"`
 	DockerLoadFile                string `json:"docker_load_file"`
-	ServerVersion                 string `json:"server_version"`
 	PreForkPoolSize               uint64 `json:"pre_fork_pool_size"`
 	PreForkImage                  string `json:"pre_fork_image"`
 	PreForkCmd                    string `json:"pre_fork_cmd"`

--- a/api/agent/iofs.go
+++ b/api/agent/iofs.go
@@ -3,12 +3,11 @@ package agent
 import (
 	"context"
 	"fmt"
+	"github.com/fnproject/fn/api/common"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"github.com/fnproject/fn/api/common"
 )
 
 type iofs interface {
@@ -63,8 +62,26 @@ func newDirectoryIOFS(ctx context.Context, cfg *Config) (*directoryIOFS, error) 
 		}
 	}
 
+	iofsAgentPath := ""
+	if len(cfg.IOFSAgentPath) > 0 {
+		iofsAgentPath = cfg.IOFSAgentPath
+	} else {
+		// iofsPath: /<host tmp dir>/iofs
+		//   Our system integration test runs Fn Server as plain process (instead of as a docker container)
+		//   and not specify cfg.IOFSAgentPath.
+		//   When Fn Server spawns a Fn container, the iofsPath will be mapped to /tmp/iofs in Fn container
+		//   for Fn container to access the socket
+		iofsPath := filepath.Join(os.TempDir(), "iofs")
+
+		err := os.Mkdir(iofsPath, 0755) // #nosec G301
+		if err != nil && !os.IsExist(err) {
+			return nil, fmt.Errorf("cannot create iofs directory under TempDir: %v", err)
+		}
+		iofsAgentPath = iofsPath
+	}
+
 	// create a tmpdir
-	iofsAgentDir, err := ioutil.TempDir(cfg.IOFSAgentPath, "iofs")
+	iofsAgentDir, err := ioutil.TempDir(iofsAgentPath, "iofs")
 	if err != nil {
 		handleErr(iofsAgentDir)
 		return nil, fmt.Errorf("cannot create tmpdir for iofs: %v", err)
@@ -78,15 +95,13 @@ func newDirectoryIOFS(ctx context.Context, cfg *Config) (*directoryIOFS, error) 
 		}
 	}
 
-	ret := &directoryIOFS{iofsAgentDir, iofsAgentDir}
+	ret := &directoryIOFS{iofsAgentDir, iofsAgentPath}
 
 	if cfg.IOFSMountRoot != "" {
-		iofsRelPath, err := filepath.Rel(cfg.IOFSAgentPath, iofsAgentDir)
-		if err != nil {
-			handleErr(iofsAgentDir)
-			return nil, fmt.Errorf("cannot relativise iofs path: %v", err)
-		}
-		ret.dockerPath = filepath.Join(cfg.IOFSMountRoot, iofsRelPath)
+		// cfg.IOFSMountRoot is the source path on host vm hosting the unix socket file required for FDK/Fn Server
+		// if the value is specified, it will map to /tmp/iofs in the Fn container. It allows user to override with
+		// podman/rancher volume instead of using their $HOME directory
+		ret.dockerPath = cfg.IOFSMountRoot
 	}
 
 	return ret, nil

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -1,9 +1,6 @@
-FROM docker:17.12-dind
+FROM docker:24.0.9-dind
 
 RUN apk add --no-cache ca-certificates
-
-# cleanup warning: https://github.com/docker-library/docker/issues/55
-RUN addgroup -g 2999 docker
 
 COPY preentry.sh /usr/local/bin/
 


### PR DESCRIPTION
Fix permission issue when FDK tried to chmod or bind socket to file and deprecated cgroup v1 mem swappiness api, plus other minor fixes that required for Fn Server to function normally with the latest container engine desktop such as Podman and Rancher.

- Link to issue this resolves
  - https://github.com/fnproject/fn/issues/1577
  - https://github.com/fnproject/fn/issues/1610
  - https://github.com/fnproject/fn/issues/1608
  - https://github.com/fnproject/fn/issues/1595

- What I did
  - Remove MemorySwappiness as it has been deprecated in cgroup v2
    - See: https://github.com/opencontainers/runtime-spec/issues/1005 on why MemorySwappiness is removed.
      - Tejun: "It’s not very clear what swappiness encodes. A lot of it is compared to file-backed IOs, how [un]favorable IOs for anonymous memory are considering their inherently higher randomness. As such, it’s more a function of the underlying hardware than workloads. Also, the implementation wasn’t quite right either – iirc, the behavior would differ depending on who’s reclaiming."
  - Mount the IOFS path from host vm to Fn Container with "Z" options, which is required for host that is on SELinux. "Z" is the option for unshared private access. Private Unshared access is enough since we created a separate iofs path for each instance of FnServer container. The option has no effect on host that has not enabled or do not support SELinux, or if user uses container engine named volume as the iofs path.
  - Allow user to use named volume for Fn Server to create the unix socket file. It resolves the issue that the unix socket file could not be hosted under $HOME/.fn directory (See: https://github.com/fnproject/fn/issues/1577#issuecomment-1297736260) for Podman/Rancher desktop.
  - Change the way the IOFS path mapping (bind mount) from host VM to Fn Container, which is required if we want to allow users to use container engine named volume as iofs path. 
    - bind mount change: 
      - before fix: \<IOFS Path in Host VM>/\<temp directory created by Fn Server>:/tmp/iofs
        - (FN_LISTENER was /tmp/iofs)
      - after fix:      \<IOFS Path in Host VM or named volume>:/tmp/iofs/\<temp directory created by Fn Server>
        - FN_LISTENER is set to /tmp/iofs/\<temp directory created by Fn Server>
  - Disable docker version check since customers could use any container engine desktop other than docker desktop.
  - Update dind to 24.0.9

- How to verify it
  - Verified by running Fn Server with Podman and Rancher Desktop, create and invoke local Functions with Fn CLI

- One line description for the changelog
  - Fix a couple of critical issues about starting up Fn Server on latest container engine desktop
